### PR TITLE
feat(platform-root): hub-targeted client applications — ADR 0017 (v0.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## [0.11.0] - 2026-04-18
+
+### Added
+
+- **ADR 0017 — Hub-targeted client applications.** New structural tier
+  for client-authored infrastructure Applications that must run on the
+  platform hub (not on workload clusters). Two new pieces:
+
+  - `bootstrap/platform-root/templates/hub-client-apps.yaml` — new
+    ApplicationSet that discovers `platforms/{deploymentId}/hub-apps/*`
+    in the client gitops repo and creates one Application per
+    subdirectory on the hub. The ApplicationSet renders the Application
+    spec directly from the path plus wrapper parameters — clients do
+    NOT write an inner `application.yaml`. This eliminates the
+    self-referential `targetRevision` drift that plagues the workload
+    `apps/` path (issue #100).
+
+  - `bootstrap/platform-root/templates/argocd-project.yaml` — new
+    `platform-client-infra` AppProject authorizing client hub-apps
+    against an **explicit** namespace allowlist (no wildcards). The
+    allowlist is driven by the new `clientHubAppNamespaces` value,
+    operator-managed in the client's wrapper
+    `overrides/platform-root/values.yaml`.
+
+  `ClusterRole` / `ClusterRoleBinding` / `CustomResourceDefinition` /
+  `ValidatingWebhookConfiguration` / `MutatingWebhookConfiguration`
+  are **intentionally** allowed in the project's resource whitelist,
+  because legitimate hub-apps (admission webhooks, operators with
+  cluster-wide reach, CRD providers) need them. Risk is audited by the
+  upstream Kyverno catalog, not blocked by the project — per ADR 0017
+  "upstream proposes, client disposes".
+
+### Added (values)
+
+- `clientHubAppNamespaces` (defaults to `[]`) in
+  `bootstrap/platform-root/values.yaml`. Empty list = no hub-apps
+  authorized (safe default).
+
+### Documentation
+
+- ADR 0017 (Draft) in estabilis-platform-tools/docs/adr/.
+- Tracking issue Estabilis/estabilis-platform-tools#118.
+
+### Notes
+
+- Version metadata jumps from 0.8.2 → 0.11.0. Tags v0.9.0, v0.9.1,
+  v0.9.2, v0.9.3, v0.10.0, v0.10.1, v0.10.2 were cut without
+  CHANGELOG entries. Fix-forward: 0.11.0 is the first release with
+  a documented changelog entry since 0.8.2. Backfill tracked
+  separately if needed.
+
 ## [0.8.2] - 2026-04-16
 
 ### Fixed

--- a/bootstrap/platform-root/templates/argocd-project.yaml
+++ b/bootstrap/platform-root/templates/argocd-project.yaml
@@ -230,6 +230,60 @@ spec:
   namespaceResourceWhitelist:
     - group: "*"
       kind: "*"
+{{- if .Values.clientGitopsRepoUrl }}
+---
+# ADR 0017 — platform-client-infra project
+# For client-authored infrastructure Applications deployed to the HUB
+# cluster (not workload clusters). Discovered from the client gitops
+# repo at platforms/{deploymentId}/hub-apps/* by the hub-client-apps
+# ApplicationSet. Destinations are driven by clientHubAppNamespaces
+# (explicit allowlist declared in the wrapper) — no wildcards.
+#
+# ClusterRole / ClusterRoleBinding / CRD are intentionally allowed
+# because legitimate hub-apps (webhook admission controllers,
+# operators with cluster-wide reach, CRD providers) need them. Risk is
+# audited by the Kyverno catalog, not blocked by the project —
+# ADR 0017 "upstream proposes, client disposes".
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: platform-client-infra
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  description: Client-authored infrastructure Applications on the platform hub (ADR 0017)
+  sourceRepos:
+    - {{ .Values.clientGitopsRepoUrl | quote }}
+    {{- if .Values.global.sharedAcrLoginServer }}
+    - {{ printf "%s/charts" .Values.global.sharedAcrLoginServer | quote }}
+    {{- end }}
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: argocd
+    {{- range .Values.clientHubAppNamespaces }}
+    - server: https://kubernetes.default.svc
+      namespace: {{ . | quote }}
+    {{- end }}
+  clusterResourceWhitelist:
+    - group: "*"
+      kind: Namespace
+    - group: "*"
+      kind: ClusterRole
+    - group: "*"
+      kind: ClusterRoleBinding
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+    - group: admissionregistration.k8s.io
+      kind: "*"
+    - group: kyverno.io
+      kind: PolicyException
+    - group: networking.k8s.io
+      kind: "*"
+  namespaceResourceWhitelist:
+    - group: "*"
+      kind: "*"
+{{- end }}
 {{- if and .Values.configRepoUrl .Values.configRepoVersion }}
 ---
 # Applications project — for client custom apps in app-* namespaces

--- a/bootstrap/platform-root/templates/hub-client-apps.yaml
+++ b/bootstrap/platform-root/templates/hub-client-apps.yaml
@@ -1,0 +1,85 @@
+{{- /*
+  ADR 0017 — Hub-targeted client applications.
+
+  ApplicationSet that discovers client-authored infrastructure under
+  the client gitops repo at `platforms/{deploymentId}/hub-apps/*` and
+  creates one ArgoCD Application per subdirectory on the hub. The
+  Application spec is rendered by THIS AppSet from path + wrapper
+  parameters — clients do NOT write an inner `application.yaml`. This
+  eliminates the self-ref targetRevision drift that plagues the
+  workload-cluster `apps/` path (issue #100).
+
+  Each `hub-apps/{name}/` is a directory whose `manifests/` subtree is
+  applied by ArgoCD as raw K8s YAML. The client declares the namespace
+  in `manifests/namespace.yaml`. Kyverno mutates PSS labels on the
+  namespace automatically (same mechanism as app-* namespaces). If the
+  app requires enforce=privileged, the wrapper appends the namespace
+  to `policies.inject_pss_labels.extraPrivilegedNamespaces`
+  (estabilis-platform-gitops v0.26.0+).
+
+  Authorized namespaces are listed in `clientHubAppNamespaces` at the
+  platform-root level (operator-managed via the wrapper). Every
+  namespace referenced in a hub-apps manifest MUST appear in that
+  list; otherwise ArgoCD rejects the Application for violating the
+  platform-client-infra AppProject destinations.
+
+  Only active when clientGitopsRepoUrl and deploymentId are set (same
+  gate as the `$gitops` override sources).
+
+  See ADR 0017 for the full design + client responsibilities
+  checklist.
+*/ -}}
+{{- if and .Values.clientGitopsRepoUrl .Values.deploymentId }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: hub-client-apps
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - git:
+        repoURL: {{ .Values.clientGitopsRepoUrl | quote }}
+        revision: {{ required "clientGitopsRepoVersion is required when clientGitopsRepoUrl is set" .Values.clientGitopsRepoVersion | quote }}
+        directories:
+          - path: "platforms/{{ .Values.deploymentId }}/hub-apps/*"
+  template:
+    metadata:
+      name: "{{ `{{ .path.basename }}` }}-{{ .Values.deploymentId }}"
+      annotations:
+        argocd.argoproj.io/sync-wave: "10"
+      labels:
+        estabilis.io/managed-by: client-gitops
+        estabilis.io/tier: hub-client-infra
+        estabilis.io/component: "{{ `{{ .path.basename }}` }}"
+    spec:
+      project: platform-client-infra
+      source:
+        repoURL: {{ .Values.clientGitopsRepoUrl | quote }}
+        targetRevision: {{ .Values.clientGitopsRepoVersion | quote }}
+        path: "{{ `{{ .path.path }}` }}/manifests"
+        directory:
+          recurse: true
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: "{{ `{{ .path.basename }}` }}"
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        retry:
+          limit: 10
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m
+        syncOptions:
+          # Client owns the namespace manifest in manifests/namespace.yaml.
+          # Platform does not pre-create — the namespace is part of the
+          # Application's desired state, declared by the client, mutated
+          # by Kyverno.
+          - CreateNamespace=false
+          - ServerSideApply=true
+{{- end }}

--- a/bootstrap/platform-root/values.yaml
+++ b/bootstrap/platform-root/values.yaml
@@ -164,6 +164,24 @@ clientGitopsRepoUrl: ""
 clientGitopsRepoVersion: ""
 deploymentId: ""
 
+# ---------------------------------------------------------------------------
+# Hub-targeted client applications (ADR 0017)
+# ---------------------------------------------------------------------------
+# Namespaces on the hub that `platform-client-infra` AppProject is
+# authorized to deploy into. Each entry adds a `server=kubernetes.default.svc,
+# namespace=<ns>` to the project's destinations list and allows the
+# hub-client-apps ApplicationSet to create Applications whose manifests
+# target that namespace.
+#
+# Empty list = no hub-apps authorized (safe default). Every namespace
+# declared in a `hub-apps/{name}/manifests/namespace.yaml` MUST appear
+# in this list, otherwise ArgoCD rejects the Application for violating
+# its project.
+#
+# Operator-managed via overrides/platform-root/values.yaml in the
+# client's platform downstream — NOT client-mutable.
+clientHubAppNamespaces: []
+
 # Scheduling policy per component (ADR 0012 — tracked in
 # Estabilis/estabilis-platform-tools#97). Empty by default — each
 # Application template uses its opinionated mode ("auto" for most,


### PR DESCRIPTION
Implements ADR 0017 Phase 1.

Tracks [Estabilis/estabilis-platform-tools#118](https://github.com/Estabilis/estabilis-platform-tools/issues/118).
See [Estabilis/estabilis-platform-tools#121](https://github.com/Estabilis/estabilis-platform-tools/pull/121) (ADR 0017 rev 2).

## What's new in `platform-root`

### 1. `templates/hub-client-apps.yaml` — new ApplicationSet

Discovers `platforms/{deploymentId}/hub-apps/*` in the client gitops repo and creates one Application per subdirectory on the hub. The ApplicationSet renders the Application spec directly from path + wrapper parameters — clients do **not** write an inner `application.yaml`. Eliminates the self-referential `targetRevision` drift that plagues the workload `apps/` path (#100).

Each discovered directory becomes:
- `Application.metadata.name = {basename}-{deploymentId}`
- `destination.namespace = {basename}` (convention; overridable via `clientHubAppNamespaces`)
- Source: `{clientGitopsRepoUrl}@{clientGitopsRepoVersion}` path `hub-apps/{basename}/manifests` (directory type, raw YAML)
- Sync: automated + selfHeal + retry; `CreateNamespace=false` (client owns `namespace.yaml` in manifests)

### 2. `templates/argocd-project.yaml` — new `platform-client-infra` AppProject

Authorizes client hub-apps with an **explicit** destination allowlist (no wildcards):

```yaml
destinations:
  - server: https://kubernetes.default.svc
    namespace: argocd
  {{- range .Values.clientHubAppNamespaces }}
  - server: https://kubernetes.default.svc
    namespace: {{ . | quote }}
  {{- end }}
```

`ClusterRole` / `ClusterRoleBinding` / `CustomResourceDefinition` / `admissionregistration.k8s.io/*` are intentionally allowed — webhook admission controllers, cluster-wide operators, and CRD providers legitimately need them. Risk is audited by the upstream Kyverno catalog, not blocked by the project, per ADR 0017 "upstream proposes, client disposes".

### 3. `values.yaml` — `clientHubAppNamespaces: []`

Operator-managed via the client's wrapper `overrides/platform-root/values.yaml`. Empty list = no hub-apps authorized (safe default). Every namespace declared in a `hub-apps/{name}/manifests/namespace.yaml` MUST appear here, otherwise ArgoCD rejects the Application for violating its project destinations.

## Backward compatibility

- **Deployments without `clientGitopsRepoUrl`**: zero changes — both the ApplicationSet and the AppProject are gated behind `if .Values.clientGitopsRepoUrl`.
- **Existing deployments with `clientGitopsRepoUrl` but no `hub-apps/` directory in their gitops repo**: the ApplicationSet's git-directory generator matches nothing, produces zero Applications. No-op.

## Test plan

- [x] `helm template` renders both the ApplicationSet and the AppProject with realistic values
- [x] `helm template` WITHOUT `clientGitopsRepoUrl` renders **neither** (correctly gated)
- [x] `helm lint` passes
- [x] AppProject destinations include `argocd` + every entry in `clientHubAppNamespaces`
- [ ] End-to-end validation happens in Phase 2 (transfero-gitops hub-apps/ migration + wrapper bump + promote + verify ado-build-agent pod Running)

## Version

- Git tag: `v0.11.0` (MINOR — new feature, backwards compatible)
- `CHANGELOG.md` entry added. Note: changelog jumped from 0.8.2 → 0.11.0; tags v0.9.x and v0.10.x were cut without changelog entries (pre-existing drift; backfill tracked separately).