### PR TITLE
feat(argocd-project): extension point for client hub-app cluster resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [0.12.0] - 2026-04-19
+
+### Added
+
+- **`clientHubAppExtraClusterResources` extension point on the
+  `platform-client-infra` AppProject** (ADR 0017). The project's
+  `clusterResourceWhitelist` now appends a client-declared list of
+  additional `(group, kind)` pairs sourced from wrapper overrides.
+  This lets the client authorize cluster-scoped resource kinds their
+  own hub-apps need — for example KEDA's `APIService`
+  (`apiregistration.k8s.io`) for the external-metrics adapter, or an
+  Istio/Linkerd install's mesh-specific kinds — without opening a
+  platform PR for every case.
+
+  Default is an empty list. Upstream defines the governance classes
+  permitted (Namespace, ClusterRole, ClusterRoleBinding, CRD,
+  admissionregistration.k8s.io/*, networking.k8s.io/*,
+  kyverno.io/PolicyException) and this value extends them. Matches
+  the spirit of ADR 0017's "upstream proposes, client disposes".
+
+  Files:
+
+  - `bootstrap/platform-root/values.yaml` — adds
+    `clientHubAppExtraClusterResources: []` default next to
+    `clientHubAppNamespaces`.
+  - `bootstrap/platform-root/templates/argocd-project.yaml` — range
+    over that list appended to the `platform-client-infra`
+    `clusterResourceWhitelist`.
+
 ## [0.11.0] - 2026-04-18
 
 ### Added

--- a/bootstrap/platform-root/templates/argocd-project.yaml
+++ b/bootstrap/platform-root/templates/argocd-project.yaml
@@ -280,6 +280,15 @@ spec:
       kind: PolicyException
     - group: networking.k8s.io
       kind: "*"
+    {{- /* ADR 0017 extension — client-declared additional cluster-scoped
+           kinds their hub-apps need. Appended via wrapper override at
+           overrides/platform-root/values.yaml.clientHubAppExtraClusterResources.
+           Upstream defines governance classes; client declares specific
+           kinds their own hub-apps require. */}}
+    {{- range .Values.clientHubAppExtraClusterResources }}
+    - group: {{ .group | quote }}
+      kind: {{ .kind | quote }}
+    {{- end }}
   namespaceResourceWhitelist:
     - group: "*"
       kind: "*"

--- a/bootstrap/platform-root/values.yaml
+++ b/bootstrap/platform-root/values.yaml
@@ -182,6 +182,30 @@ deploymentId: ""
 # client's platform downstream — NOT client-mutable.
 clientHubAppNamespaces: []
 
+# Additional cluster-scoped resource kinds authorized for the
+# `platform-client-infra` AppProject. Appended to the project's
+# `clusterResourceWhitelist` baseline (which already includes
+# Namespace, ClusterRole, ClusterRoleBinding, CRD,
+# admissionregistration.k8s.io/*, networking.k8s.io/*, and
+# kyverno.io/PolicyException).
+#
+# Why this exists: legitimate hub-apps sometimes ship resources the
+# baseline doesn't cover (e.g. KEDA registers an APIService in
+# apiregistration.k8s.io for its external-metrics adapter; Istio and
+# other service meshes register networking.istio.io types). Upstream
+# defines the GOVERNANCE CLASSES permitted; the client declares the
+# specific kinds their own hub-apps need. This follows ADR 0017's
+# "upstream proposes, client disposes" principle and avoids forcing
+# a platform PR for every new hub-app kind.
+#
+# Client sets this in overrides/platform-root/values.yaml:
+#   clientHubAppExtraClusterResources:
+#     - group: apiregistration.k8s.io
+#       kind: APIService
+#
+# Default empty — no extras beyond the baseline.
+clientHubAppExtraClusterResources: []
+
 # Scheduling policy per component (ADR 0012 — tracked in
 # Estabilis/estabilis-platform-tools#97). Empty by default — each
 # Application template uses its opinionated mode ("auto" for most,


### PR DESCRIPTION
## Summary

Adds `clientHubAppExtraClusterResources` as a values-driven extension on the `platform-client-infra` AppProject (ADR 0017). The project's `clusterResourceWhitelist` now appends a client-declared list of additional `(group, kind)` pairs, sourced from wrapper overrides.

## Why

Legitimate hub-apps sometimes register cluster-scoped resource kinds the baseline whitelist doesn't cover:

- **KEDA** registers an `APIService` (`apiregistration.k8s.io`) for its external-metrics adapter (concrete motivation — see Estabilis/estabilis-platform-tools#141).
- A future Istio install would bring `networking.istio.io` kinds.
- Flagger, Knative, etc. — each ships their own cluster-scoped resources.

Upstream today defines GOVERNANCE CLASSES (Namespace, ClusterRole, ClusterRoleBinding, CRD, `admissionregistration.k8s.io/*`, `networking.k8s.io/*`, `kyverno.io/PolicyException`). Every time a client needs an additional class, they need a platform PR. That's fine for the first case; painful past that.

This hook moves the declaration to the client's own wrapper, without loosening governance: upstream still defines the classes permitted (baseline list stays), the client extends within that envelope. Matches ADR 0017's "upstream proposes, client disposes".

## How

One extension point in the template, one default in values:

- `bootstrap/platform-root/values.yaml` — new `clientHubAppExtraClusterResources: []` default next to `clientHubAppNamespaces`, with documentation explaining the pattern.
- `bootstrap/platform-root/templates/argocd-project.yaml` — `range .Values.clientHubAppExtraClusterResources` appended to the `platform-client-infra` `clusterResourceWhitelist`.

## Client usage

In the client wrapper's `overrides/platform-root/values.yaml`:

```yaml
clientHubAppExtraClusterResources:
  - group: apiregistration.k8s.io
    kind: APIService
```

## Backwards compatibility

Default is empty list. No behavioural change for existing deployments. Minor version bump (v0.12.0).

## Test

```bash
helm template test bootstrap/platform-root/ \
  --set clientGitopsRepoUrl=https://example.com/gitops.git \
  --set clientGitopsRepoVersion=v1.0.0 \
  --set deploymentId=test \
  --set 'clientHubAppExtraClusterResources[0].group=apiregistration.k8s.io' \
  --set 'clientHubAppExtraClusterResources[0].kind=APIService'
```

Rendered `platform-client-infra.clusterResourceWhitelist` includes the APIService entry only when the value is set. No rendering when list is empty.

Linked: Estabilis/estabilis-platform-tools#141.