### PR TITLE
fix(cost-export): terraform validate failure on plantimestamp arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.12.1] - 2026-04-21
+
+### Fixed — `terraform validate` rejects `cost-export.tf`
+
+`recurrence_period_end_date` used `formatdate("YYYY", plantimestamp()) + 10`.
+During `terraform validate` (ahead of any plan), `plantimestamp()`
+evaluates to `0001-01-01T00:00:00Z`; `formatdate("YYYY", ...)` returns
+the string `"1"`, which arithmetic-added to `10` yields `11`, and the
+final string becomes `"11-01-01T00:00:00Z"` — year `11`, rejected by
+the `azurerm` provider as invalid RFC3339.
+
+Replace with `formatdate("YYYY-MM-DD", timeadd(plantimestamp(),
+"87600h"))` which always produces a zero-padded 4-digit year and
+stays well-formed under both `validate` (zero-epoch → year 0011)
+and real plan (current-time + 10y).
+
+Unblocks PR validation pipelines on every downstream repo that
+references this module (transfero-platform-azure-eastus2-hml, etc.).
+
 ## [0.12.0] - 2026-04-19
 
 ### Added

--- a/providers/azure/cost-export.tf
+++ b/providers/azure/cost-export.tf
@@ -114,7 +114,12 @@ resource "azurerm_subscription_cost_management_export" "daily" {
   subscription_id              = data.azurerm_subscription.current.id
   recurrence_type              = "Daily"
   recurrence_period_start_date = "${formatdate("YYYY-MM-DD", plantimestamp())}T00:00:00Z"
-  recurrence_period_end_date   = "${formatdate("YYYY", plantimestamp()) + 10}-${formatdate("MM-DD", plantimestamp())}T00:00:00Z"
+  # 87600h = 10 years. `timeadd` produces a zero-padded ISO-8601
+  # timestamp; `formatdate` then reshapes it as RFC3339. Avoids the
+  # "year + 10" string-arithmetic pattern which at `terraform validate`
+  # time evaluates `plantimestamp()` to `0001-01-01T00:00:00Z` and
+  # produces "11-01-01T00:00:00Z" (year `11`, rejected by provider).
+  recurrence_period_end_date = "${formatdate("YYYY-MM-DD", timeadd(plantimestamp(), "87600h"))}T00:00:00Z"
 
   export_data_storage_location {
     container_id     = azurerm_storage_container.cost_exports[0].id


### PR DESCRIPTION
NU1605-equivalent for Terraform. See CHANGELOG v0.12.1. Unblocks PR validation on transfero-platform-azure-eastus2-hml.