### PR TITLE
fix(argocd-image-updater): pin chart to 0.14.0 (track v0.x, annotation-based)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [0.12.2] - 2026-04-21
+
+### Fixed — `argocd-image-updater` chart pinned to track v0.x (annotation-based)
+
+`bootstrap/platform-root/templates/argocd-image-updater.yaml` pinned the
+upstream chart to `1.1.5` (app v1.1.1). The v1.0.0 release
+(2025-11-11) is a rewrite to CRD-only — the controller no longer
+reads `argocd-image-updater.argoproj.io/*` annotations on ArgoCD
+Applications. Our write-back design (ADR 0016 D3) stores the
+image-list / update-strategy / write-back-target as Application
+annotations, so the v1.x controller silently ignored them — 0
+`ImageUpdater` CRs on cluster, 0 write-backs performed.
+
+Downgrade to chart `0.14.0` (app v0.17.0) — the latest chart on the
+annotation-based `master-annotation-based` upstream branch. Restores
+the contract documented in ADR 0016. Do NOT bump past `0.14.x` without
+migrating every consumer Application to the `ImageUpdater` CRD first.
+
+See `docs/adr/0019-argocd-image-updater-v0x-correction.md` (estabilis-
+platform-tools) for the full postmortem.
+
+Post-upgrade cleanup on the cluster: the v1.x chart's Deployment
+(`argocd-image-updater-controller`) has a different name than the
+v0.x chart's (`argocd-image-updater`) and will be orphaned by the
+Helm upgrade. Delete it after sync:
+
+```
+kubectl -n argocd delete deploy argocd-image-updater-controller
+```
+
 ## [0.12.1] - 2026-04-21
 
 ### Fixed — `terraform validate` rejects `cost-export.tf`

--- a/bootstrap/platform-root/templates/argocd-image-updater.yaml
+++ b/bootstrap/platform-root/templates/argocd-image-updater.yaml
@@ -45,9 +45,17 @@ metadata:
 spec:
   project: platform
   sources:
+    # Chart pinned to the track v0.x (annotation-based).
+    # Upstream v1.0.0 (2025-11-11) is a rewrite to CRD-only — it no longer
+    # reads `argocd-image-updater.argoproj.io/*` annotations on ArgoCD
+    # Applications. Our write-back design (ADR 0016 D3) depends on those
+    # annotations. Chart 0.14.0 → app v0.17.0 is the latest annotation-
+    # based release. Do NOT bump to 1.x without also migrating every
+    # consumer App to the ImageUpdater CRD.
+    # See: https://github.com/argoproj-labs/argocd-image-updater/pull/1190
     - repoURL: https://argoproj.github.io/argo-helm
       chart: argocd-image-updater
-      targetRevision: "1.1.5"
+      targetRevision: "0.14.0"
       helm:
         valueFiles:
           - $values/values/platform/argocd-image-updater.yaml


### PR DESCRIPTION
## Problem

Commit [`68a1601`](https://github.com/Estabilis/estabilis-platform/commit/68a1601) (v0.10.2, 2026-04-17) installed `argocd-image-updater` chart `1.1.5` (app v1.1.1) as an opt-in platform-root component. The write-back design (ADR 0016 D3, this repo) stores the image-list / update-strategy / write-back-target as annotations on each ArgoCD Application.

**Upstream v1.0.0 (2025-11-11) is a rewrite to CRD-only** — the controller no longer reads `argocd-image-updater.argoproj.io/*` annotations. Evidence from the [v1.0.0 release notes](https://github.com/argoproj-labs/argocd-image-updater/releases/tag/v1.0.0):

- PR #1190: *Refactor argocd and registry-scanner modules to use CRD Spec instead of Annotations*
- PR #1209: *replace the remaining annotations with CRD fields*
- PR #1221: *deprecate ArgoCD client*
- PR #1300: *add `master-annotation-based` branch and remove crd branch from workflow*

Live evidence on the Transfero HML hub cluster: controller running `v1.1.1`, log shows `No ImageUpdater CRs to process`. `kubectl get imageupdaters -A` → zero CRs. Meanwhile `partner-service-hml` on the workload cluster has placeholder `tag: v0.0.0` + zeroed digest in its overlay `values.yaml`, despite 3 real images published to the shared ACR.

## Fix

Pin chart to `0.14.0` (app `v0.17.0`), the latest release on the annotation-based `master-annotation-based` upstream branch. Restores the contract in ADR 0016 without redesigning the consumer side. Full postmortem: **estabilis-platform-tools ADR 0019** (this PR authors that ADR separately).

## Post-merge checklist

1. Tag `v0.12.2` after merge
2. Bump `estabilis-platform-downstream` template (`main.tf` ref + `tfvars.example` `platform_version`)
3. Bump client downstream `transfero-platform-azure-eastus2-hml` (`main.tf` ref + `tfvars` `platform_version` + self-ref `config_repo_version` + tag `v1.X.Y`)
4. User runs `terraform init -upgrade && terraform apply` → pulls new chart
5. **One-time cluster cleanup** (orphan from v1.x → v0.x name change):
   ```
   kubectl -n argocd delete deploy argocd-image-updater-controller
   ```
6. `estabilis promote transfero -d hml --force-refresh` — propagates chart change
7. Validate: controller logs should show app-level reconciliation (not "No ImageUpdater CRs"). `partner-service-hml` `values.yaml` should get a write-back PR with real image tag/digest.