### PR TITLE
feat: external_secrets_principal_id output (v0.12.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.12.3] - 2026-04-22
+
+### Added — `external_secrets_principal_id` output
+
+New `providers/azure/outputs.tf` output exposing the principal ID
+(object ID) of the `external-secrets` managed identity. The existing
+`external_secrets_client_id` output only carries the client ID (used
+by workload-identity federation), but cross-module RBAC wiring
+(`azurerm_role_assignment`) requires the principal ID.
+
+Motivation: enables downstream Terraform repos (e.g. shared-infra
+wrappers that own their own Key Vault) to grant `Key Vault Secrets
+User` to the same MI that ESO uses on the cluster, without
+duplicating the identity. Before this output, a shared-infra repo
+had to either (a) write its secrets to the platform-owned KV (the
+only one the MI could read), creating cross-module ownership
+coupling, or (b) provision its own duplicate MI.
+
+Additive, backward-compatible. Existing consumers unaffected.
+
 ## [0.12.2] - 2026-04-21
 
 ### Fixed — `argocd-image-updater` chart pinned to track v0.x (annotation-based)

--- a/providers/azure/outputs.tf
+++ b/providers/azure/outputs.tf
@@ -78,6 +78,11 @@ output "external_secrets_client_id" {
   value       = azurerm_user_assigned_identity.external_secrets.client_id
 }
 
+output "external_secrets_principal_id" {
+  description = "Principal ID (object ID) of the external-secrets managed identity. Exported so downstream modules that provision additional Key Vaults can grant `Key Vault Secrets User` to this MI via `azurerm_role_assignment`, instead of the MI being limited to the platform KV. Consumed by shared-infra Terraform repos that write secrets to a dedicated KV which the cluster's external-secrets controller must read."
+  value       = azurerm_user_assigned_identity.external_secrets.principal_id
+}
+
 output "loki_client_id" {
   description = "Client ID of the Loki managed identity."
   value       = azurerm_user_assigned_identity.loki.client_id


### PR DESCRIPTION
## Summary

Adds a new `external_secrets_principal_id` output to `providers/azure/outputs.tf`, exposing the principal ID (object ID) of the `external-secrets` managed identity.

## Why

The existing `external_secrets_client_id` output carries the client ID — the right shape for workload-identity federation (OIDC subject). Cross-module RBAC wiring via `azurerm_role_assignment.principal_id`, however, requires the **principal ID** (object ID).

Today, the external-secrets MI is granted `Key Vault Secrets User` only on the platform KV (via `workload-identity.tf`). Any cross-cluster code that writes secrets to a separate KV must either:

1. Write to the platform KV (ownership coupling — observed in `transfero-acr-shared-hml` today, where `acr-shared-*` and `image-updater-git-pat` live in `kv-transfero-hml-lmj060` despite being owned by a different module), or
2. Duplicate the MI (needless IAM surface)

With this output, a shared-infra Terraform repo can:

```hcl
data "terraform_remote_state" "platform" { ... }

resource "azurerm_role_assignment" "eso_reader_shared" {
  scope                = azurerm_key_vault.shared.id
  role_definition_name = "Key Vault Secrets User"
  principal_id         = data.terraform_remote_state.platform.outputs.external_secrets_principal_id
}
```

…and write its secrets to its own KV, fully owned by the shared-infra module. The cluster's ESO reads from both.

## Compatibility

- **Additive only.** No existing output removed or renamed.
- **Backward-compatible.** Existing downstream consumers (`transfero-platform-azure-eastus2-hml`, etc.) continue to work unchanged.
- **Bump:** patch `v0.12.2 → v0.12.3` per `CLAUDE.md` §Cross-repo versioning rules (every functional change to `providers/` is a patch).

## Companion PRs

- [ ] `estabilis-platform-gitops`: multi-store ClusterSecretStore + `secretStoreName` parameter in `acr-image-updater-credentials` (targets `v0.30.0`)

Together these unlock tenant-level KV separation: a client's shared-infra repo owns its own KV; the cluster's ESO reads from multiple stores; no more foreign writes to the platform KV.

## Test plan

- [x] `terraform validate` in `providers/azure/` passes
- [x] `terraform fmt` clean
- [x] Pre-commit hooks passed
- [ ] After merge + tag `v0.12.3`, consuming repo (`transfero-infra-shared-hml`) exercises the output end-to-end