### PR TITLE
feat: valueFiles on acr-image-updater-credentials Application (v0.12.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [0.12.4] - 2026-04-22
+
+### Added — `valueFiles` block on `acr-image-updater-credentials` Application
+
+The platform-root Application template for `acr-image-updater-credentials`
+previously supported overrides only via `helm.parameters`. Per-cluster
+overrides of component values (e.g. `secretStoreName` added by
+estabilis-platform-gitops v0.30.0 for multi-KV tenant separation) could
+not be set from the downstream config repo or client-gitops repo.
+
+Adds a `valueFiles:` block mirroring the pattern used by
+`cluster-secret-store`:
+
+```yaml
+valueFiles:
+  - $values/components/acr-image-updater-credentials/values.yaml
+  - $values/values/platform/acr-image-updater-credentials.yaml
+  {{- include "platform-root.overrideValueFile" ... }}
+  {{- include "platform-root.gitopsValueFile" ... }}
+```
+
+Also adds a second source declaring the platform-gitops `ref: values`
+so the `$values/...` paths resolve (the Application previously had no
+explicit values ref).
+
+### Impact
+
+- Any consumer of `acr-image-updater-credentials` can now override its
+  values via a standard override file, e.g.
+  `<config-repo>/overrides/acr-image-updater-credentials/values.yaml`.
+- Enables the planned Transfero shared-infra cutover
+  (`secretStoreName: shared-infra-secret-store`) without per-cluster
+  upstream bumps.
+- Backcompat: `ignoreMissingValueFiles: true` included via helper, so
+  deployments without override files continue to work unchanged.
+
 ## [0.12.3] - 2026-04-22
 
 ### Added — `external_secrets_principal_id` output

--- a/bootstrap/platform-root/templates/argocd-image-updater.yaml
+++ b/bootstrap/platform-root/templates/argocd-image-updater.yaml
@@ -16,10 +16,28 @@ spec:
       targetRevision: {{ .Values.platformGitopsVersion }}
       path: components/acr-image-updater-credentials
       helm:
+        # ValueFiles pulled from config-repo (`overrides/`) and client-
+        # gitops (`overrides/` under `platforms/<deploymentId>/`). Match
+        # the pattern used by cluster-secret-store so tenant-level KV
+        # separation (e.g. `secretStoreName: shared-infra-secret-store`)
+        # can be declared via a simple override file — no upstream bump
+        # needed per deployment. Added in estabilis-platform v0.12.4.
+        valueFiles:
+          - $values/components/acr-image-updater-credentials/values.yaml
+          - $values/values/platform/acr-image-updater-credentials.yaml
+          {{- include "platform-root.overrideValueFile" (dict "component" "acr-image-updater-credentials" "root" $) | nindent 10 }}
+          {{- include "platform-root.gitopsValueFile" (dict "component" "acr-image-updater-credentials" "root" $) | nindent 10 }}
+        {{- include "platform-root.ignoreMissingValueFiles" $ | nindent 8 }}
         parameters:
           - name: acrLoginServer
             value: "{{ .Values.global.sharedAcrLoginServer }}"
           {{- include "platform-root.provenanceParameters" $ | nindent 10 }}
+    # Platform-gitops $values ref — needed by the `$values/...` paths
+    # above. Declared explicitly here because this Application is single-
+    # source otherwise; cluster-secret-store declares the same ref.
+    - repoURL: {{ .Values.platformGitopsRepoUrl }}
+      targetRevision: {{ .Values.platformGitopsVersion }}
+      ref: values
     {{- include "platform-root.overrideSource" . | nindent 4 }}
     {{- include "platform-root.gitopsSource" . | nindent 4 }}
   destination:


### PR DESCRIPTION
## Summary

Adds `valueFiles` block to the `acr-image-updater-credentials` Application in the platform-root chart, mirroring the pattern used by `cluster-secret-store`. Enables downstream per-cluster overrides without upstream changes.

## Motivation

estabilis-platform-gitops v0.30.0 added `secretStoreName` parameter to `acr-image-updater-credentials` for multi-KV tenant separation. But the platform-root Application template only supported `helm.parameters` overrides — there was no path to set arbitrary chart values (like `secretStoreName`) from the downstream config repo or client gitops repo.

Observed blocking `transfero-infra-shared-hml` cutover: we created a dedicated KV in a separate RG, granted the ESO MI access, but couldn't point `acr-image-updater-credentials.secretStoreName` at a second `ClusterSecretStore` without editing upstream.

## Change

In `bootstrap/platform-root/templates/argocd-image-updater.yaml`:

- Add `valueFiles:` list with 4 paths (component defaults, platform overlay, config-repo override, client-gitops override).
- Add explicit `- repoURL: platformGitopsRepoUrl / ref: values` source so the `$values/...` paths resolve.
- `ignoreMissingValueFiles: true` via helper — backcompat-preserving.

## Compatibility

- 100% backcompat. Deployments without override files render identical Applications to v0.12.3.
- No helm parameter renamed or removed.
- `provenanceParameters` path preserved.

## Companion

- [ ] `estabilis-platform-gitops` v0.30.1 — adds empty `values/platform/acr-image-updater-credentials.yaml` so the new valueFile path resolves.

## Test plan

- [x] `helm template` on the platform-root chart with and without `configRepoUrl` set renders the Application correctly.
- [ ] After merge + tag + bump, the `transfero-infra-shared-hml` cutover PR creates `overrides/acr-image-updater-credentials/values.yaml` with `secretStoreName: shared-infra-secret-store` and it's picked up.