### PR TITLE
feat: configRepoRevision / clientGitopsRepoRevision (v0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## [0.13.0] - 2026-04-22
+
+### Added — `configRepoRevision` and `clientGitopsRepoRevision` values
+
+Part of ADR 0020 (GitOps-native continuous reconciliation). Lets
+consumers track a branch (e.g. `main`, `release/prod`) instead of
+pinning a specific tag for **own-content repos** (config overrides
++ client gitops). Tag pinning for **external dependencies** (upstream
+Estabilis versions, container images, external helm charts) is
+unchanged.
+
+Changes:
+
+- `bootstrap/platform-root/values.yaml`: add `configRepoRevision`
+  and `clientGitopsRepoRevision`. Legacy `configRepoVersion` and
+  `clientGitopsRepoVersion` are **retained for backcompat** — when
+  both are set, the `*Revision` wins.
+- `bootstrap/platform-root/templates/_helpers.tpl`: new helpers
+  `configRepoRef`, `configRepoRefRequired`, `clientGitopsRef`,
+  `clientGitopsRefRequired`. Existing helpers `overrideEnabled` /
+  `overrideSource` / `overrideValueFile` / `ignoreMissingValueFiles`
+  / `gitopsSource` refactored to consume the new resolvers.
+- `bootstrap/platform-root/templates/custom-apps.yaml`: Application
+  `targetRevision` uses `configRepoRef`.
+- `bootstrap/platform-root/templates/client-kyverno-exceptions.yaml`:
+  Application `targetRevision` uses `clientGitopsRef`.
+- `bootstrap/platform-root/templates/hub-client-apps.yaml`:
+  ApplicationSet `generators.git.revision` and generated Application
+  `targetRevision` use `clientGitopsRefRequired` (fail-loud when
+  URL is set but ref missing).
+
+### Migration path
+
+- **No action required**: continue setting the legacy `*Version`
+  values via Terraform / tfvars. Chart renders identically to v0.12.4.
+- **Adopt branch tracking**: set `*Revision` in overrides to a branch
+  name (`main`, `release/prod`), leave `*Version` empty. Enables
+  continuous reconciliation per ADR 0020.
+
+### Compatibility
+
+100% backward-compatible. Verified via `helm template` in legacy
+and revision modes — external chart pins unchanged, only own-content
+targetRevision transitions between tag and branch based on values
+provided.
+
+### Companion bump
+
+`estabilis-platform-gitops` v0.31.0 introduces matching values at
+the workload-bootstrap chart level. Use both together when adopting
+continuous reconciliation.
+
 ## [0.12.4] - 2026-04-22
 
 ### Added — `valueFiles` block on `acr-image-updater-credentials` Application

--- a/bootstrap/platform-root/templates/_helpers.tpl
+++ b/bootstrap/platform-root/templates/_helpers.tpl
@@ -92,26 +92,74 @@ Usage in Application templates:
       ref: values
     {{- include "platform-root.overrideSource" . | nindent 4 }}
 */}}
+{{/*
+Ref resolver helpers — resolve the effective git ref for each repo,
+preferring the new *Revision values over the legacy *Version values.
+Adopted in v0.13.0 per ADR 0020 (GitOps-native continuous
+reconciliation) to allow consumers to track branches for own-content
+repos (config overrides, client gitops). Tag pinning remains the
+pattern for external dependencies (upstream Estabilis tags, charts,
+container images).
+
+Both legacy (configRepoVersion / clientGitopsRepoVersion) and new
+(configRepoRevision / clientGitopsRepoRevision) values are accepted.
+When both are set, the *Revision wins. When both are empty but the
+corresponding URL is configured, `overrideEnabled` returns false
+(backcompat: missing refs silently disabled the helpers already).
+*/}}
+
+{{- define "platform-root.configRepoRef" -}}
+{{- if .Values.configRepoRevision -}}
+{{- .Values.configRepoRevision -}}
+{{- else if .Values.configRepoVersion -}}
+{{- .Values.configRepoVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "platform-root.clientGitopsRef" -}}
+{{- if .Values.clientGitopsRepoRevision -}}
+{{- .Values.clientGitopsRepoRevision -}}
+{{- else if .Values.clientGitopsRepoVersion -}}
+{{- .Values.clientGitopsRepoVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "platform-root.clientGitopsRefRequired" -}}
+{{- $ref := include "platform-root.clientGitopsRef" . -}}
+{{- if not $ref -}}
+{{- fail "clientGitopsRepoRevision (or legacy clientGitopsRepoVersion) is required when clientGitopsRepoUrl is set" -}}
+{{- end -}}
+{{- $ref -}}
+{{- end -}}
+
+{{- define "platform-root.configRepoRefRequired" -}}
+{{- $ref := include "platform-root.configRepoRef" . -}}
+{{- if not $ref -}}
+{{- fail "configRepoRevision (or legacy configRepoVersion) is required when configRepoUrl is set" -}}
+{{- end -}}
+{{- $ref -}}
+{{- end -}}
+
 {{- define "platform-root.overrideEnabled" -}}
-{{- and .Values.configRepoUrl .Values.configRepoVersion -}}
+{{- and .Values.configRepoUrl (include "platform-root.configRepoRef" .) -}}
 {{- end -}}
 
 {{- define "platform-root.overrideSource" -}}
-{{- if and .Values.configRepoUrl .Values.configRepoVersion }}
+{{- if include "platform-root.overrideEnabled" . }}
 - repoURL: {{ .Values.configRepoUrl }}
-  targetRevision: {{ .Values.configRepoVersion }}
+  targetRevision: {{ include "platform-root.configRepoRef" . }}
   ref: overrides
 {{- end }}
 {{- end -}}
 
 {{- define "platform-root.overrideValueFile" -}}
-{{- if and .root.Values.configRepoUrl .root.Values.configRepoVersion }}
+{{- if include "platform-root.overrideEnabled" .root }}
 - $overrides/overrides/{{ .component }}/values.yaml
 {{- end }}
 {{- end -}}
 
 {{- define "platform-root.ignoreMissingValueFiles" -}}
-{{- if and .Values.configRepoUrl .Values.configRepoVersion }}
+{{- if include "platform-root.overrideEnabled" . }}
 ignoreMissingValueFiles: true
 {{- end }}
 {{- end -}}
@@ -207,7 +255,7 @@ per-platform override paths scoped by deploymentId.
 {{- define "platform-root.gitopsSource" -}}
 {{- if and .Values.clientGitopsRepoUrl .Values.deploymentId }}
 - repoURL: {{ .Values.clientGitopsRepoUrl }}
-  targetRevision: {{ .Values.clientGitopsRepoVersion | default "HEAD" }}
+  targetRevision: {{ include "platform-root.clientGitopsRef" . | default "HEAD" }}
   ref: gitops
 {{- end }}
 {{- end -}}

--- a/bootstrap/platform-root/templates/client-kyverno-exceptions.yaml
+++ b/bootstrap/platform-root/templates/client-kyverno-exceptions.yaml
@@ -23,7 +23,7 @@ spec:
   project: platform
   source:
     repoURL: {{ .Values.clientGitopsRepoUrl }}
-    targetRevision: {{ .Values.clientGitopsRepoVersion | default "HEAD" }}
+    targetRevision: {{ include "platform-root.clientGitopsRef" . | default "HEAD" }}
     path: platforms/{{ .Values.deploymentId }}/policies/exceptions
     directory:
       recurse: true

--- a/bootstrap/platform-root/templates/custom-apps.yaml
+++ b/bootstrap/platform-root/templates/custom-apps.yaml
@@ -1,5 +1,5 @@
 {{- /* conditional: downstream custom apps — enabled when configRepoUrl is set */ -}}
-{{- if and .Values.configRepoUrl .Values.configRepoVersion }}
+{{- if include "platform-root.overrideEnabled" . }}
 {{- range $name, $app := .Values.customApps }}
 ---
 apiVersion: argoproj.io/v1alpha1
@@ -16,7 +16,7 @@ spec:
   project: applications
   source:
     repoURL: {{ $.Values.configRepoUrl }}
-    targetRevision: {{ $.Values.configRepoVersion }}
+    targetRevision: {{ include "platform-root.configRepoRef" $ }}
     path: {{ $app.path }}
   destination:
     server: https://kubernetes.default.svc

--- a/bootstrap/platform-root/templates/hub-client-apps.yaml
+++ b/bootstrap/platform-root/templates/hub-client-apps.yaml
@@ -42,7 +42,7 @@ spec:
   generators:
     - git:
         repoURL: {{ .Values.clientGitopsRepoUrl | quote }}
-        revision: {{ required "clientGitopsRepoVersion is required when clientGitopsRepoUrl is set" .Values.clientGitopsRepoVersion | quote }}
+        revision: {{ include "platform-root.clientGitopsRefRequired" . | quote }}
         directories:
           - path: "platforms/{{ .Values.deploymentId }}/hub-apps/*"
   template:
@@ -58,7 +58,7 @@ spec:
       project: platform-client-infra
       source:
         repoURL: {{ .Values.clientGitopsRepoUrl | quote }}
-        targetRevision: {{ .Values.clientGitopsRepoVersion | quote }}
+        targetRevision: {{ include "platform-root.clientGitopsRefRequired" . | quote }}
         path: "{{ `{{ .path.path }}` }}/manifests"
         directory:
           recurse: true

--- a/bootstrap/platform-root/values.yaml
+++ b/bootstrap/platform-root/values.yaml
@@ -5,10 +5,17 @@
 # All other values are defaults that can be overridden by the client
 # via the multi-source mechanism.
 
-platformRepoUrl: ""       # injected by terraform
-platformVersion: ""       # injected by terraform
-configRepoUrl: ""         # injected by terraform
-configRepoVersion: ""     # injected by terraform
+platformRepoUrl: ""         # injected by terraform
+platformVersion: ""         # injected by terraform
+configRepoUrl: ""           # injected by terraform
+
+# Git ref for the config repo. Prefer `configRepoRevision` (added
+# v0.13.0 per ADR 0020) which accepts branches (main / release/<env>)
+# for continuous reconciliation OR tags for pinned releases.
+# `configRepoVersion` is retained for backcompat — when both are set,
+# `configRepoRevision` wins.
+configRepoRevision: ""      # injected by terraform (new)
+configRepoVersion: ""       # DEPRECATED: use configRepoRevision
 
 # ---------------------------------------------------------------------------
 # Supply-chain provenance — ADR 0005 Phase 2
@@ -161,7 +168,15 @@ customApps: {}
 #
 # Set by the CLI at render time (same mechanism as global.provenance.*).
 clientGitopsRepoUrl: ""
-clientGitopsRepoVersion: ""
+
+# Git ref for the client gitops repo. Prefer `clientGitopsRepoRevision`
+# (added v0.13.0 per ADR 0020) which accepts branches (main /
+# release/<env>) for continuous reconciliation OR tags for pinned
+# releases. `clientGitopsRepoVersion` is retained for backcompat —
+# when both are set, `clientGitopsRepoRevision` wins.
+clientGitopsRepoRevision: ""
+clientGitopsRepoVersion: ""  # DEPRECATED: use clientGitopsRepoRevision
+
 deploymentId: ""
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 2 of ADR 0020 (GitOps-native continuous reconciliation). Adds new `*Revision` values to the `platform-root` chart that accept branch names (`main`, `release/prod`) in addition to tags, enabling continuous reconciliation for own-content repos without forcing the bump cascade.

External dependencies (upstream Estabilis versions, container images, external helm charts) remain pinned — no change to supply chain.

## Changes

- `bootstrap/platform-root/values.yaml`: add `configRepoRevision` + `clientGitopsRepoRevision`. Legacy `*Version` retained.
- `bootstrap/platform-root/templates/_helpers.tpl`: new resolvers `configRepoRef[Required]` + `clientGitopsRef[Required]`; existing helpers consume them.
- `custom-apps.yaml`: `targetRevision` uses `configRepoRef`.
- `client-kyverno-exceptions.yaml`: `targetRevision` uses `clientGitopsRef`.
- `hub-client-apps.yaml`: uses `clientGitopsRefRequired` (fail-loud).

## Compatibility

**100% backward-compatible.** Verified via `helm template`:
- Legacy mode (`configRepoVersion=v1.0.87`, `clientGitopsRepoVersion=v1.11.34`) → renders identical to v0.12.4
- Revision mode (`configRepoRevision=main`, `clientGitopsRepoRevision=main`) → renders branches
- External chart pins (cert-manager, grafana, etc.) unchanged in both modes

## Companion

`estabilis-platform-gitops` v0.31.0 (PR #19) adds matching values at the workload-bootstrap chart. They ship together.

## Migration path

- No action: continue with `*Version` (via Terraform helm.parameters as today)
- Adopt continuous reconciliation: set `*Revision` to branch, leave `*Version` empty

## Version bump

`v0.12.4 → v0.13.0` (minor: new capability, backcompat preserved).

## Test plan

- [x] `helm template` legacy mode — identical to v0.12.4
- [x] `helm template` revision mode — renders branch name
- [x] External chart targetRevisions unchanged
- [ ] After merge + tag, Transfero HML adopts both upstream bumps
- [ ] Cluster validates continuous reconciliation end-to-end

## Relates

ADR 0020 (PR #164 in estabilis-platform-tools) — reference design.
Companion: estabilis-platform-gitops PR #19 (v0.31.0).