### PR TITLE
fix(argocd): ignore AKS admissionsenforcer namespaceSelector drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.13.1] - 2026-04-22
+
+### Fixed — AKS `admissionsenforcer` namespaceSelector drift on webhooks
+
+AKS clusters have a managed field manager named `admissionsenforcer`
+that injects `namespaceSelector.matchExpressions` on every
+`ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` to
+exclude managed-plane namespaces (`kubernetes.azure.com/managedby=aks`,
+`control-plane=true`). Any webhook declaring `namespaceSelector: {}`
+in git shows perpetual cosmetic OutOfSync — the field is owned by the
+AKS admission controller, not by git.
+
+Adds `resource.customizations.ignoreDifferences` entries in `argocd-cm`
+scoped to `admissionregistration.k8s.io/{Validating,Mutating}WebhookConfiguration`.
+
+- `core/components/argocd/values.yaml`: two new customizations ignoring
+  `.webhooks[]?.namespaceSelector`.
+
+Safe on non-AKS clusters: the jqPathExpressions match no webhooks when
+`admissionsenforcer` doesn't exist, so the rule is a no-op elsewhere.
+
+First observed on keda-admission; affects any webhook deployed on AKS.
+
 ## [0.13.0] - 2026-04-22
 
 ### Added — `configRepoRevision` and `clientGitopsRepoRevision` values

--- a/core/components/argocd/values.yaml
+++ b/core/components/argocd/values.yaml
@@ -41,6 +41,26 @@ configs:
         - .metadata.annotations."estabilis.io/build-id"
         - .metadata.annotations."estabilis.io/git-revision"
         - .metadata.annotations."estabilis.io/git-source"
+    # AKS `admissionsenforcer` field manager injects
+    # `namespaceSelector.matchExpressions` on every Validating/Mutating
+    # WebhookConfiguration to exclude managed-plane namespaces
+    # (kubernetes.azure.com/managedby=aks, control-plane=true). The
+    # field is owned by the AKS admission controller — git sources
+    # declaring `namespaceSelector: {}` will show perpetual drift on
+    # live clusters. Ignoring eliminates cosmetic OutOfSync without
+    # affecting behavior (the matchExpressions are beneficial and
+    # non-deterministically ordered, so declaring them in git would
+    # just move the drift around).
+    #
+    # Safe on non-AKS clusters: jqPathExpressions match no webhooks
+    # when admissionsenforcer doesn't exist, so the rule is a no-op
+    # elsewhere.
+    resource.customizations.ignoreDifferences.admissionregistration.k8s.io_ValidatingWebhookConfiguration: |
+      jqPathExpressions:
+        - .webhooks[]?.namespaceSelector
+    resource.customizations.ignoreDifferences.admissionregistration.k8s.io_MutatingWebhookConfiguration: |
+      jqPathExpressions:
+        - .webhooks[]?.namespaceSelector
     resource.customizations.health.postgresql.cnpg.io_Cluster: |
       hs = {}
       if obj.status == nil or obj.status.phase == nil then


### PR DESCRIPTION
## Summary

AKS has a managed field manager named `admissionsenforcer` that injects `namespaceSelector.matchExpressions` on every `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` to exclude managed-plane namespaces (`kubernetes.azure.com/managedby=aks`, `control-plane=true`). Any webhook declaring `namespaceSelector: {}` in git shows perpetual cosmetic OutOfSync in ArgoCD — the field is owned by the AKS admission controller, not by git.

This adds `resource.customizations.ignoreDifferences` in `argocd-cm` scoped to `admissionregistration.k8s.io/{Validating,Mutating}WebhookConfiguration`, ignoring `.webhooks[]?.namespaceSelector`.

## Diagnosis evidence

```console
$ kubectl get validatingwebhookconfiguration keda-admission \
    --show-managed-fields -o json | jq '.metadata.managedFields[] | {manager, operation}'
{ "manager": "argocd-controller",  "operation": "Apply"  }
{ "manager": "keda",               "operation": "Update" }  # owns caBundle only
{ "manager": "admissionsenforcer", "operation": "Update" }  # owns namespaceSelector
```

## Non-AKS safety

Safe on non-AKS clusters: `jqPathExpressions` match no webhooks when `admissionsenforcer` doesn't exist, so the rule is a no-op elsewhere.

## Why this over declaring the selectors in git

AKS reorders the injected `matchExpressions` non-deterministically (observed across the 6 keda webhooks: some had `control-plane` first, some had `managedby` first). Declaring them in git just moves the drift around.

## Version bump

v0.13.0 → v0.13.1 (patch — AKS-universal platform fix, no API changes).

## Test plan

- [x] Validated on `platform-azure-eastus2-hml` via client override (`overrides/argocd/values.yaml`) before promoting upstream — keda Application went Synced/Healthy after argocd-cm update + per-Application hard-refresh.
- [ ] After merge + tag `v0.13.1`, propagate to downstream template + clients; remove the client-level override that shipped as a stopgap.