### PR TITLE
feat(aws): configurable Karpenter discovery tag-key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Changelog
 
+## [0.15.0] - 2026-04-23
+
+### Added — configurable Karpenter discovery tag-key
+
+New variable `karpenter_discovery_tag_key` in `providers/aws/` (default
+`"karpenter.sh/discovery"` — unchanged behavior for existing deployments).
+
+### Motivation
+
+AWS allows a single value per tag-key per resource. When two
+Karpenter-managed clusters share a VPC, both tagging subnets with the
+community-convention key `karpenter.sh/discovery` would silently
+overwrite each other — one cluster's Karpenter would stop finding
+its subnets. Before this change, the upstream hardcoded that key in
+five places (subnet create-mode tags, `aws_ec2_tag` for existing-mode,
+EKS module top-level `tags`, `node_security_group_tags`, and Karpenter
+module `tags`), so the only safe option was `autoscaler =
+"cluster_autoscaler"` or `"none"` when sharing a VPC.
+
+### How it works
+
+Every place that previously hardcoded the key now uses
+`var.karpenter_discovery_tag_key`. The default is the community
+convention, so single-cluster VPCs keep their tag untouched. When two
+clusters share a VPC, each sets a unique key:
+
+- Cluster A (existing): `karpenter.sh/discovery = cluster-a`
+- Cluster B (new):      `estabilis.io/discovery = cluster-b`
+
+Both keys coexist on the same subnets. Each cluster's EC2NodeClass
+(installed via ArgoCD in Phase 2) configures `subnetSelectorTerms` to
+match its own key.
+
+### Platform outputs
+
+`platform-outputs.tf` now emits `global.karpenterDiscoveryTagKey` in
+the `platform-infrastructure` ConfigMap so the Phase 2 Karpenter Helm
+chart can render its EC2NodeClass with the correct subnet/SG selector.
+
+### Backward compatibility
+
+The default matches the hardcoded value from v0.14.0. No Azure
+deployment is affected (the variable is AWS-only). Existing AWS
+deployments that do not override the variable produce an
+identical Terraform plan.
+
+### Changes
+
+- `providers/aws/variables.tf`: new `karpenter_discovery_tag_key`
+  variable with validation (non-empty).
+- `providers/aws/eks.tf`: `module.eks.tags`,
+  `node_security_group_tags`, and
+  `aws_ec2_tag.existing_private_karpenter_discovery` all use the var.
+- `providers/aws/vpc.tf`: private subnet tag (create mode) uses the var.
+- `providers/aws/karpenter.tf`: module tag uses the var.
+- `providers/aws/platform-outputs.tf`: new `global.karpenterDiscoveryTagKey`
+  ConfigMap entry.
+
 ## [0.14.0] - 2026-04-23
 
 ### Added — AWS provider (Phase 1 — landing zone)

--- a/providers/aws/eks.tf
+++ b/providers/aws/eks.tf
@@ -190,15 +190,16 @@ module "eks" {
 
   # --- Node SG tags for Karpenter discovery -------------------------------
   node_security_group_tags = var.autoscaler == "karpenter" ? {
-    "karpenter.sh/discovery" = local.cluster_name
+    (var.karpenter_discovery_tag_key) = local.cluster_name
   } : {}
 
-  tags = merge(
-    {
-      # Karpenter uses this to find the cluster when provisioning new nodes
-      "karpenter.sh/discovery" = local.cluster_name
-    },
-  )
+  tags = {
+    # Karpenter uses this to find the cluster when provisioning new nodes.
+    # Tag-key is configurable via var.karpenter_discovery_tag_key so multiple
+    # Karpenter-managed clusters can share a VPC without overwriting each
+    # other's subnet tags.
+    (var.karpenter_discovery_tag_key) = local.cluster_name
+  }
 }
 
 # ---------------------------------------------------------------------------
@@ -211,7 +212,7 @@ resource "aws_ec2_tag" "existing_private_karpenter_discovery" {
   for_each = var.vpc_mode == "existing" && var.autoscaler == "karpenter" ? toset(var.private_subnet_ids) : []
 
   resource_id = each.value
-  key         = "karpenter.sh/discovery"
+  key         = var.karpenter_discovery_tag_key
   value       = local.cluster_name
 }
 

--- a/providers/aws/karpenter.tf
+++ b/providers/aws/karpenter.tf
@@ -39,7 +39,7 @@ module "karpenter" {
   service_account = "karpenter"
 
   tags = {
-    "karpenter.sh/discovery" = local.cluster_name
+    (var.karpenter_discovery_tag_key) = local.cluster_name
   }
 }
 

--- a/providers/aws/platform-outputs.tf
+++ b/providers/aws/platform-outputs.tf
@@ -97,10 +97,11 @@ resource "kubernetes_config_map" "platform_infrastructure" {
     "global.hubbleUiExposures" = jsonencode({ for k, v in local.hubble_ui_exposures_resolved : k => v if v.enabled })
 
     # Autoscaler + Karpenter wiring
-    "global.autoscaler"              = var.autoscaler
-    "global.karpenterQueueName"      = var.autoscaler == "karpenter" ? module.karpenter[0].queue_name : ""
-    "global.karpenterNodeRoleName"   = var.autoscaler == "karpenter" ? module.karpenter[0].node_iam_role_name : ""
-    "global.karpenterControllerRole" = var.autoscaler == "karpenter" ? module.karpenter[0].iam_role_arn : ""
+    "global.autoscaler"               = var.autoscaler
+    "global.karpenterQueueName"       = var.autoscaler == "karpenter" ? module.karpenter[0].queue_name : ""
+    "global.karpenterNodeRoleName"    = var.autoscaler == "karpenter" ? module.karpenter[0].node_iam_role_name : ""
+    "global.karpenterControllerRole"  = var.autoscaler == "karpenter" ? module.karpenter[0].iam_role_arn : ""
+    "global.karpenterDiscoveryTagKey" = var.karpenter_discovery_tag_key
 
     # ECR
     "global.ecrRegistry" = length(var.ecr_repositories) > 0 && var.ecr_enabled ? "${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.region}.amazonaws.com" : ""

--- a/providers/aws/variables.tf
+++ b/providers/aws/variables.tf
@@ -294,6 +294,17 @@ variable "karpenter_node_iam_role_additional_policies" {
   default     = {}
 }
 
+variable "karpenter_discovery_tag_key" {
+  description = "Tag key used by Karpenter's EC2NodeClass subnetSelectorTerms + securityGroupSelectorTerms to discover AWS resources. Defaults to the community convention 'karpenter.sh/discovery'. Override only when the VPC already hosts another Karpenter-managed cluster using that key — AWS allows a single value per tag-key per resource, so sharing the key would make the clusters overwrite each other's subnet tags. Recommended override when sharing: 'estabilis.io/discovery'."
+  type        = string
+  default     = "karpenter.sh/discovery"
+
+  validation {
+    condition     = length(var.karpenter_discovery_tag_key) > 0
+    error_message = "karpenter_discovery_tag_key cannot be empty."
+  }
+}
+
 # ---------------------------------------------------------------------------
 # EKS — Addons
 # ---------------------------------------------------------------------------

--- a/providers/aws/vpc.tf
+++ b/providers/aws/vpc.tf
@@ -55,7 +55,7 @@ resource "aws_subnet" "private" {
     Name                                          = "snet-${local.base_name}-private-${local.azs_selected[count.index]}"
     "kubernetes.io/role/internal-elb"             = "1"
     "kubernetes.io/cluster/${local.cluster_name}" = "shared"
-    "karpenter.sh/discovery"                      = local.cluster_name
+    (var.karpenter_discovery_tag_key)             = local.cluster_name
   }
 }
 


### PR DESCRIPTION
## Summary

Adds `var.karpenter_discovery_tag_key` in `providers/aws/` so two Karpenter-managed clusters can share a VPC without overwriting each other's subnet tags.

**Default preserves current behavior** — single-cluster AWS deployments and all Azure deployments produce an identical plan as v0.14.0.

## Motivation

AWS enforces a single value per tag-key per resource. The previous hardcoded `karpenter.sh/discovery` key meant that deploying a second Karpenter cluster in a VPC already managed by another cluster would silently reassign the subnet tag, breaking subnet discovery on the first cluster. Until now the only safe option when sharing a VPC was `autoscaler = "cluster_autoscaler"` or `"none"`.

**Use case:** bringing up a test Estabilis AWS deployment inside an AWS account + VPC that already hosts a production Karpenter cluster, without touching the production one.

## How to use

Default keeps the community convention. Override only when sharing a VPC with another Karpenter-managed cluster:

```hcl
# Cluster A (existing, untouched):
# karpenter.sh/discovery = cluster-a

# Cluster B (new deployment pinning this PR):
karpenter_discovery_tag_key = "estabilis.io/discovery"
```

Both keys coexist on the same subnets. Each cluster's EC2NodeClass — installed via ArgoCD in Phase 2 — configures `subnetSelectorTerms` / `securityGroupSelectorTerms` to match its own key. The `platform-outputs.tf` ConfigMap gains `global.karpenterDiscoveryTagKey` so the Phase 2 chart reads it directly.

## Call sites updated (5)

| File | Change |
|---|---|
| `providers/aws/variables.tf` | new `karpenter_discovery_tag_key` variable with non-empty validation |
| `providers/aws/eks.tf` | `module.eks.tags`, `node_security_group_tags`, and `aws_ec2_tag.existing_private_karpenter_discovery` |
| `providers/aws/vpc.tf` | private subnet tag (create mode) |
| `providers/aws/karpenter.tf` | karpenter module tag |
| `providers/aws/platform-outputs.tf` | new `global.karpenterDiscoveryTagKey` ConfigMap entry |

## Backward compatibility

- Default (`karpenter.sh/discovery`) matches the hardcoded value shipped in v0.14.0.
- Variable is AWS-only — Azure provider is untouched.
- No migration needed for existing AWS deployments that don't override the var.

## Test plan

- [x] `terraform fmt -check` passes
- [x] `terraform validate` passes
- [x] `terraform_tflint` (recommended ruleset) passes
- [x] Full pre-commit suite (12 hooks) passes
- [ ] End-to-end — deferred; the first cortex test deployment under `estabilis-cortex-platform-aws-useast1-prd` will exercise the override path against a real shared VPC.

## Rollout

After merge, tag `v0.15.0` upstream, then bump downstream template `estabilis-platform-downstream` to `v1.6.0` pointing at `v0.15.0` and unblock the cortex test repo.