### PR TITLE
fix(aws): terraform plan regressions — encryption ternary + IAM name_prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## [0.15.1] - 2026-04-23
+
+### Fixed — `terraform plan` regressions in the AWS provider
+
+Two bugs surfaced when running `terraform plan` for real (both slipped
+through `terraform validate` because the type/length checks are only
+exercised at plan-time once module resource attributes resolve).
+
+#### Fix 1 — `cluster_encryption_config` ternary type mismatch
+
+```
+Error: Inconsistent conditional result types
+  The 'true' value includes object attribute "provider_key_arn",
+  which is absent in the 'false' value.
+```
+
+Terraform 1.7+ enforces matching types on both ternary branches. The
+`true` branch returned `{resources, provider_key_arn}`, the `false`
+branch returned `{}`. Swapped the false branch to `null`, which
+disables encryption cleanly without forcing the shape duplication.
+
+- `providers/aws/eks.tf` — `cluster_encryption_config` now returns
+  `null` when `cluster_secrets_encryption_enabled = false`.
+
+#### Fix 2 — IAM role `name_prefix` overflow
+
+```
+Error: expected length of name_prefix to be in the range (1 - 38),
+got eks-estabilis-cortex-platform-prd-useast1-cluster-
+```
+
+The EKS module defaults `iam_role_use_name_prefix = true`, which caps
+role names at 38 chars (AWS IAM `name_prefix` limit — the module
+leaves room for the 26-char Terraform-generated suffix inside the
+64-char total IAM role name budget). Our CAF-style cluster names
+(`eks-{prefix}-platform-{env}-{region}`) already consume 30–41 chars
+before the module appends `-cluster-`, so any `name_prefix > 5 chars`
+would overflow.
+
+Flipped to `iam_role_use_name_prefix = false` on both `module.eks`
+(cascades to Fargate profile IAM roles) and `module.karpenter`
+(covers the controller IRSA + node IAM roles). The resulting role
+names fit in the 64-char `name` budget without truncating any CAF
+tag segment.
+
+- `providers/aws/eks.tf` — `iam_role_use_name_prefix = false` on
+  the EKS module call.
+- `providers/aws/karpenter.tf` — `iam_role_use_name_prefix = false`
+  + `node_iam_role_use_name_prefix = false` on the Karpenter module.
+
+### Backward compatibility
+
+Since v0.14.0 was the first AWS release and no deployment reached
+`terraform apply` before this fix (both bugs blocked plan), flipping
+`iam_role_use_name_prefix` has **no migration impact** — there are
+no existing IAM roles with `name_prefix` random suffixes to rename.
+
 ## [0.15.0] - 2026-04-23
 
 ### Added — configurable Karpenter discovery tag-key

--- a/providers/aws/eks.tf
+++ b/providers/aws/eks.tf
@@ -145,15 +145,28 @@ module "eks" {
   cloudwatch_log_group_retention_in_days = var.cluster_log_retention_days
 
   # --- Secrets encryption (envelope) --------------------------------------
+  # Ternary must return matching types on both branches (Terraform 1.7+
+  # strict type check). `null` disables encryption cleanly without forcing
+  # the "false" branch to echo the full object shape.
   cluster_encryption_config = var.cluster_secrets_encryption_enabled ? {
     resources        = ["secrets"]
     provider_key_arn = aws_kms_key.cluster_secrets.arn
-  } : {}
+  } : null
 
   # --- Authentication (Access Entries, AWS best practice) -----------------
   authentication_mode                      = var.authentication_mode
   enable_cluster_creator_admin_permissions = var.enable_cluster_creator_admin_permissions
   access_entries                           = local.eks_access_entries_map
+
+  # --- IAM role naming ----------------------------------------------------
+  # The EKS module defaults to `iam_role_use_name_prefix = true`, which
+  # caps role names at 38 chars (AWS IAM name_prefix limit — the module
+  # leaves room for the 26-char Terraform-generated suffix inside the
+  # 64-char total budget). Our CAF-style cluster names
+  # (`eks-{prefix}-platform-{env}-{region}`) plus the module's `-cluster`
+  # suffix routinely exceed 38 chars. Using `false` switches to
+  # name-mode, which allows the full 64-char budget.
+  iam_role_use_name_prefix = false
 
   # --- Addons --------------------------------------------------------------
   cluster_addons = local.effective_addons

--- a/providers/aws/karpenter.tf
+++ b/providers/aws/karpenter.tf
@@ -38,6 +38,12 @@ module "karpenter" {
   namespace       = "karpenter"
   service_account = "karpenter"
 
+  # Same IAM role naming constraint as module.eks — our cluster names
+  # exceed the 38-char name_prefix budget. Use full names (64-char
+  # budget) so `Karpenter-${cluster_name}` fits.
+  iam_role_use_name_prefix      = false
+  node_iam_role_use_name_prefix = false
+
   tags = {
     (var.karpenter_discovery_tag_key) = local.cluster_name
   }


### PR DESCRIPTION
## Summary

Two bugs in the AWS provider surfaced when the first operator ran `terraform plan` against a real account. Both slipped through `terraform validate` because they only trigger at plan-time when module resource attributes resolve.

## Bug 1 — `cluster_encryption_config` ternary type mismatch

```
Error: Inconsistent conditional result types
  The 'true' value includes object attribute "provider_key_arn",
  which is absent in the 'false' value.
```

Terraform 1.7+ enforces matching types on both ternary branches. The `true` branch returned `{resources, provider_key_arn}`; the `false` branch returned `{}`. Fixed by returning `null` from the false branch instead (module skips encryption).

## Bug 2 — IAM role `name_prefix` overflow (38-char limit)

```
Error: expected length of name_prefix to be in the range (1 - 38), got
eks-estabilis-cortex-platform-prd-useast1-cluster-
```

The EKS module defaults `iam_role_use_name_prefix = true`, capping IAM role names at 38 chars. Our CAF cluster names (`eks-{prefix}-platform-{env}-{region}`) already consume 30–41 chars before the module appends `-cluster-`, so any `name_prefix > 5 chars` overflows.

Flipped `iam_role_use_name_prefix = false` on:
- `module.eks` (cascades to Fargate profile IAM roles)
- `module.karpenter` (cluster role + node role)

Switches from `name_prefix` mode (38-char limit) to `name` mode (64-char limit). Our 41–51 char role names fit comfortably.

## Backward compatibility

v0.14.0 was the first AWS release and both bugs blocked `terraform plan`, so **no deployment reached apply before this fix**. No existing IAM roles with random hex suffixes to recreate.

## Test plan

- [x] `terraform fmt -check` passes
- [x] `terraform validate` passes
- [x] `terraform_tflint` (recommended ruleset) passes
- [x] Full pre-commit suite (12 hooks) passes
- [ ] End-to-end — the cortex test deployment (`cortex-platform-aws-useast1-prd`) is the first consumer; once this tag lands it will retry `terraform plan` and we'll verify both errors disappear.