### PR TITLE
fix(aws): destroyable tfstate + per-cluster Karpenter role names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,78 @@
 # Changelog
 
+## [0.15.2] - 2026-04-23
+
+### Fixed — tfstate resources are destroyable; Karpenter roles are per-cluster
+
+Two blockers discovered after the first successful `terraform apply`:
+
+#### Fix 1 — `prevent_destroy = true` blocked `terraform destroy` even on
+empty buckets and lock tables
+
+`aws_s3_bucket.tfstate` and `aws_dynamodb_table.tfstate_lock` shipped
+with `lifecycle { prevent_destroy = true }`, which cannot be disabled
+via a variable (Terraform does not support variable-driven
+`prevent_destroy`). Operators rebuilding an HML/test deployment hit:
+
+```
+Error: Instance cannot be destroyed
+  Resource ... has lifecycle.prevent_destroy set, but the plan calls
+  for this resource to be destroyed.
+```
+
+The only workarounds were editing the module cache by hand or running
+a targeted destroy excluding those two resources — both bad UX.
+
+Removed the `lifecycle.prevent_destroy` block from both resources.
+The safety net that still applies:
+
+- `s3_force_destroy = false` (default) — Terraform refuses to delete
+  a bucket that has objects (including the real tfstate file).
+- `s3_tfstate_protect_critical = true` (opt-in, default false) —
+  enables Object Lock (governance mode) on the tfstate bucket for
+  production deployments that need WORM semantics.
+
+DynamoDB lock table holds only active terraform lock records
+(ephemeral) so no equivalent guard is needed.
+
+- `providers/aws/tfstate.tf`: remove `lifecycle { prevent_destroy }`
+  from `aws_s3_bucket.tfstate` and `aws_dynamodb_table.tfstate_lock`,
+  document the remaining safety guards in comments.
+
+#### Fix 2 — Karpenter IAM role names are per-cluster
+
+The `terraform-aws-modules/eks/aws//modules/karpenter` submodule
+defaults `iam_role_name` to the hardcoded string `"KarpenterController"`
+(not a function of the cluster name). The node role default does
+include `Karpenter-<cluster>`, but the controller role did not. With
+`iam_role_use_name_prefix = false` (required by v0.15.1 to avoid the
+38-char name_prefix cap), the controller role lands in IAM as the
+literal `"KarpenterController"`.
+
+Consequence: two Estabilis deployments in the same AWS account would
+both try to create `KarpenterController` → collision on the second
+apply.
+
+Pinned both role names explicitly to include the cluster name:
+
+```
+iam_role_name      = "Karpenter-${module.eks.cluster_name}"
+node_iam_role_name = "KarpenterNode-${module.eks.cluster_name}"
+```
+
+Node role default already included the cluster name; we set it
+explicitly too for consistency with the controller naming scheme.
+
+- `providers/aws/karpenter.tf`: explicit `iam_role_name` and
+  `node_iam_role_name` inputs to the module.
+
+### Backward compatibility
+
+v0.15.1 was only deployed once (cortex test, currently being torn
+down for a rebuild with `name_prefix = "cortex"`). Next apply of the
+cortex test pins v0.15.2 so the new Karpenter role names and the
+destroyable tfstate land together. No other deployments exist.
+
 ## [0.15.1] - 2026-04-23
 
 ### Fixed — `terraform plan` regressions in the AWS provider

--- a/providers/aws/karpenter.tf
+++ b/providers/aws/karpenter.tf
@@ -44,6 +44,15 @@ module "karpenter" {
   iam_role_use_name_prefix      = false
   node_iam_role_use_name_prefix = false
 
+  # Explicit per-cluster names. Without this override, the upstream module
+  # defaults the controller role to the generic `KarpenterController`
+  # (hardcoded string) and the node role to `Karpenter-<cluster>`. Two
+  # Estabilis deployments in the same AWS account would collide on
+  # `KarpenterController`. Pinning both to include the cluster name gives
+  # unambiguous ownership per deployment.
+  iam_role_name      = "Karpenter-${module.eks.cluster_name}"
+  node_iam_role_name = "KarpenterNode-${module.eks.cluster_name}"
+
   tags = {
     (var.karpenter_discovery_tag_key) = local.cluster_name
   }

--- a/providers/aws/tfstate.tf
+++ b/providers/aws/tfstate.tf
@@ -18,11 +18,18 @@ resource "aws_s3_bucket" "tfstate" {
   # bucket creation (cannot be enabled after).
   object_lock_enabled = var.s3_tfstate_protect_critical
 
+  # Primary safety guard against accidental destroy is force_destroy. With
+  # force_destroy = false (default) Terraform refuses to delete a bucket that
+  # still has objects — the real tfstate file(s) in the bucket. Flip to true
+  # only during controlled teardown (e.g., HML rebuild).
+  #
+  # lifecycle.prevent_destroy is intentionally NOT set here: Terraform does
+  # not support variable-driven prevent_destroy, which would force operators
+  # to patch the module cache every time they want to teardown a test
+  # deployment. Object Lock + force_destroy=false + (optionally)
+  # s3_tfstate_protect_critical=true provide equivalent protection for
+  # production use cases.
   force_destroy = var.s3_force_destroy
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "aws_s3_bucket_versioning" "tfstate" {
@@ -204,7 +211,8 @@ resource "aws_dynamodb_table" "tfstate_lock" {
     enabled = true
   }
 
-  lifecycle {
-    prevent_destroy = true
-  }
+  # Lock table is ephemeral (holds only active terraform lock records).
+  # Recreating it is instant. No prevent_destroy so test deployments can
+  # tear down cleanly. For production extra safety, rely on the S3 bucket's
+  # force_destroy=false and/or Object Lock via s3_tfstate_protect_critical.
 }


### PR DESCRIPTION
Two bugs discovered during the first cortex AWS test rebuild.

## Bug 1 — `prevent_destroy` blocked `terraform destroy`

`aws_s3_bucket.tfstate` and `aws_dynamodb_table.tfstate_lock` had `lifecycle { prevent_destroy = true }`, which cannot be disabled via a variable. HML/test rebuilds hit:

```
Error: Instance cannot be destroyed
  Resource ... has lifecycle.prevent_destroy set, but the plan calls for this resource to be destroyed.
```

Removed the lifecycle block from both. Remaining safety:
- `s3_force_destroy = false` (default) blocks delete of non-empty buckets — protects the real tfstate file at rest.
- `s3_tfstate_protect_critical = true` (opt-in) enables Object Lock for prod WORM requirements.
- DynamoDB lock table is ephemeral (only holds active lock records) so no equivalent guard is needed.

## Bug 2 — Karpenter controller role was account-global

Upstream submodule defaulted `iam_role_name` to the hardcoded `"KarpenterController"`. With `iam_role_use_name_prefix = false` (required by v0.15.1), the role landed as the literal `KarpenterController` — a second Estabilis deployment in the same account would collide.

Pinned both:
```
iam_role_name      = "Karpenter-${module.eks.cluster_name}"
node_iam_role_name = "KarpenterNode-${module.eks.cluster_name}"
```

## Backward compat

v0.15.1 was only deployed once (cortex test, currently being torn down for a rebuild with `name_prefix = "cortex"`). No other deployments. Next cortex apply pins v0.15.2.

## Validation

- `terraform fmt`, `validate`, `tflint` all green
- Full pre-commit suite (12 hooks) passes
- Manual verification: cortex test destroy unblocks once v0.15.2 ref is pinned + `terraform init -upgrade`