### PR TITLE
fix(aws): use AWS-official region format in resource names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [0.15.2] - 2026-04-23
 
+### Changed — region_code in resource names uses AWS-official format
+
+Resource names derived from `base_name` previously stripped dashes
+from the AWS region (`us-east-1` → `useast1`) for visual parity with
+the Azure provider's `eastus2` format. Every AWS CLI, tag, and AWS
+doc refers to the region with dashes, so the compact form created
+cognitive overhead without benefit.
+
+Now the region is inserted verbatim:
+
+```
+cluster_name: eks-cortex-platform-prd-us-east-1   (was: eks-cortex-platform-prd-useast1)
+```
+
+All derivatives (S3 buckets, IAM roles, KMS aliases, DynamoDB) follow.
+Dashes inside the region are safe in every AWS resource name we create.
+
+**Breaking**: existing AWS deployments on v0.15.1 produce different
+resource names on v0.15.2. Since v0.15.1 had only one deployment
+(cortex test, being destroyed) and no production use, no migration is
+needed beyond re-applying the test.
+
+- `providers/aws/main.tf`: `locals.region_code = var.region` (dropped
+  the `replace()` call).
+
 ### Fixed — tfstate resources are destroyable; Karpenter roles are per-cluster
 
 Two blockers discovered after the first successful `terraform apply`:

--- a/providers/aws/main.tf
+++ b/providers/aws/main.tf
@@ -65,9 +65,12 @@ locals {
     prod = "prd"
   }[var.environment]
 
-  # Compact region code for resource names: us-east-1 -> useast1.
-  # Keeps names short and avoids dash-on-dash segments (estabilis-platform-prd-useast1).
-  region_code = replace(var.region, "-", "")
+  # Region code used in resource names. Uses the AWS-official region string
+  # (with dashes) so names match every AWS CLI, tag, and documentation.
+  # Example: us-east-1 -> eks-{prefix}-platform-{env}-us-east-1. Dashes
+  # inside region_code are harmless — every AWS resource name that we
+  # derive (EKS cluster, IAM roles, S3 buckets, KMS aliases) allows them.
+  region_code = var.region
 
   base_name = "${var.name_prefix}-platform-${local.env_code}-${local.region_code}"
 


### PR DESCRIPTION
Drops the `replace(var.region, "-", "")` transformation on the AWS region code. Resource names now use the canonical `us-east-1` format instead of the compact `useast1` used for visual parity with Azure.

```
Before: eks-cortex-platform-prd-useast1
After:  eks-cortex-platform-prd-us-east-1
```

Benefits:
- Matches AWS CLI, AWS console, AWS docs, existing tags in the account
- Searchable — grep for `us-east-1` hits both our resources and unrelated AWS resources uniformly
- No need to translate mentally between `useast1` and `us-east-1` when running AWS CLI commands

Dashes inside a region code are safe in every AWS resource we derive (EKS cluster name, IAM role name, S3 bucket name, KMS alias, DynamoDB table).

**Breaking for v0.15.1 deployments** — resource names change, Terraform would plan destroy/recreate of everything derived from `base_name`. Only one v0.15.1 deployment exists (cortex test, being torn down right now), so this lands transparently in the same tag window as the naming cycle.

CHANGELOG entry added under `[0.15.2]` alongside the prevent_destroy + Karpenter naming fixes from #70.