### PR TITLE
docs(aws): update deployment_id example to AWS-official region format

### DIFF
--- a/providers/aws/variables.tf
+++ b/providers/aws/variables.tf
@@ -31,12 +31,12 @@ variable "environment" {
 }
 
 variable "deployment_id" {
-  description = "Deployment identifier used as key in the client GitOps repo (e.g., platform-aws-useast1-hml). Maps to platforms/{deployment_id}/ in the gitops repo."
+  description = "Deployment identifier used as key in the client GitOps repo (e.g., platform-aws-us-east-1-hml). Maps to platforms/{deployment_id}/ in the gitops repo."
   type        = string
 
   validation {
     condition     = length(var.deployment_id) > 0
-    error_message = "deployment_id is required (e.g., platform-aws-useast1-hml)."
+    error_message = "deployment_id is required (e.g., platform-aws-us-east-1-hml)."
   }
 }
 


### PR DESCRIPTION
Follow-up to v0.15.2 region format change — the `deployment_id` variable description and validation error message still showed the old `platform-aws-useast1-hml` example. Updated to `platform-aws-us-east-1-hml`.

Doc-only change. No behavior impact; no semver bump needed. Can merge at any time.