### PR TITLE
feat(ci): Phase 1 — pre-commit, release, gitleaks workflows

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -1,0 +1,39 @@
+name: gitleaks
+
+# Hard-gate secret scanning independent of pre-commit. Rationale:
+#   - pre-commit on PR scans the PR diff. If a secret landed in a previous
+#     commit that gets rebased/amended, pre-commit on the new PR misses it.
+#   - This job scans the FULL history on every push to main so any leak
+#     gets caught even if someone force-pushes or bypasses pre-commit locally.
+#
+# Shares .gitleaks.toml with the local pre-commit setup — single source of
+# truth for allowlists and custom rules.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # scan full history
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -1,10 +1,15 @@
 name: gitleaks
 
-# Hard-gate secret scanning independent of pre-commit. Rationale:
-#   - pre-commit on PR scans the PR diff. If a secret landed in a previous
-#     commit that gets rebased/amended, pre-commit on the new PR misses it.
-#   - This job scans the FULL history on every push to main so any leak
-#     gets caught even if someone force-pushes or bypasses pre-commit locally.
+# Hard-gate secret scanning using the gitleaks CLI binary directly
+# (Apache 2.0). This avoids the gitleaks-action v2 requirement for a
+# GITLEAKS_LICENSE secret, which is free for orgs but still needs one-time
+# registration + secret provisioning per org. The trade-off is less
+# convenience (no inline PR annotations), in exchange for zero
+# registration + zero telemetry.
+#
+# Binary version is pinned and kept in sync with the rev in
+# .pre-commit-config.yaml, so CI and local developer setups produce the
+# same findings.
 #
 # Shares .gitleaks.toml with the local pre-commit setup — single source of
 # truth for allowlists and custom rules.
@@ -26,14 +31,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    env:
+      # Keep in sync with the `rev:` field in .pre-commit-config.yaml for
+      # the gitleaks hook. When bumping, update both places.
+      GITLEAKS_VERSION: "8.21.2"
+
     steps:
-      - name: Checkout
+      - name: Checkout (full history)
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # scan full history
+          fetch-depth: 0
 
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_CONFIG: .gitleaks.toml
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -fsSL "$url" | tar -xz
+          sudo mv gitleaks /usr/local/bin/
+          gitleaks version
+
+      - name: Scan full history
+        run: |
+          gitleaks detect \
+            --source=. \
+            --config=.gitleaks.toml \
+            --redact \
+            --verbose

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,59 @@
+name: pre-commit
+
+# Runs the same hooks developers run locally (see .pre-commit-config.yaml).
+# Mirrors the local config — zero drift. Blocks merge on any failure.
+#
+# Trigger matrix:
+#   pull_request → gate new contributions
+#   push to main → catches anything that bypassed the PR gate (direct push,
+#                  amended tag-move, etc.)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: pre-commit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1.10"
+          terraform_wrapper: false
+
+      - name: Setup TFLint
+        uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: latest
+
+      - name: Cache TFLint plugins
+        uses: actions/cache@v4
+        with:
+          path: ~/.tflint.d/plugins
+          key: tflint-${{ runner.os }}-${{ hashFiles('.tflint.hcl') }}
+          restore-keys: |
+            tflint-${{ runner.os }}-
+
+      - name: Initialize TFLint plugins
+        run: tflint --init
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,123 @@
+name: release
+
+# Detects `chore(release): vX.Y.Z` commits on main and:
+#   1. Creates an annotated git tag `vX.Y.Z` pointing at the commit
+#   2. Creates a GitHub Release with the CHANGELOG section extracted
+#      between `## [X.Y.Z]` and the next `## [`
+#
+# Operator workflow:
+#   - Merge feature PRs normally (squash or merge, doesn't matter)
+#   - When ready to release, create a dedicated commit on main with the
+#     subject `chore(release): vX.Y.Z` (via a small PR or direct push —
+#     the workflow handles both).
+#   - This workflow tags + releases. No manual `git tag` / `git push --tags`
+#     required.
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write # needs to push the tag + create the release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need full history for CHANGELOG extraction
+
+      - name: Detect release commit
+        id: detect
+        run: |
+          set -euo pipefail
+          subject=$(git log -1 --pretty=%s)
+          echo "Last commit subject: $subject"
+          if [[ "$subject" =~ ^chore\(release\):\ v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            version="v${BASH_REMATCH[1]}"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "version=$version" >> "$GITHUB_OUTPUT"
+            echo "Detected release: $version"
+          else
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "Not a release commit — skipping."
+          fi
+
+      - name: Guard against duplicate tag
+        if: steps.detect.outputs.should_release == 'true'
+        run: |
+          set -euo pipefail
+          version="${{ steps.detect.outputs.version }}"
+          if git rev-parse "refs/tags/$version" >/dev/null 2>&1; then
+            echo "::error::Tag $version already exists. Either the release commit is being replayed, or a manual tag was created out of band."
+            exit 1
+          fi
+
+      - name: Extract CHANGELOG section
+        if: steps.detect.outputs.should_release == 'true'
+        id: changelog
+        run: |
+          set -euo pipefail
+          version_bare="${{ steps.detect.outputs.version }}"
+          version_bare="${version_bare#v}"
+
+          # AWK extracts lines between `## [X.Y.Z]` (exclusive of header)
+          # and the next `## [` marker. Stops on first match only.
+          body=$(awk -v ver="$version_bare" '
+            BEGIN { found=0; done=0 }
+            /^## \[/ {
+              if (found) { done=1 }
+              if ($0 ~ "^## \\[" ver "\\]") { found=1; next }
+            }
+            found && !done { print }
+          ' CHANGELOG.md)
+
+          if [[ -z "$body" ]]; then
+            echo "::warning::No CHANGELOG section found for $version_bare — using a generic message."
+            body="Release $version_bare. See CHANGELOG.md for the full list of changes."
+          fi
+
+          # Multi-line output via heredoc delimiter
+          {
+            echo 'body<<RELEASE_NOTES_EOF'
+            echo "$body"
+            echo 'RELEASE_NOTES_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create annotated tag
+        if: steps.detect.outputs.should_release == 'true'
+        env:
+          VERSION: ${{ steps.detect.outputs.version }}
+          BODY: ${{ steps.changelog.outputs.body }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Build the tag message in a file — using -m with embedded newlines
+          # is brittle inside YAML block scalars.
+          printf '%s\n\n%s\n' "$VERSION" "$BODY" > /tmp/tag-message.txt
+          git tag -a "$VERSION" -F /tmp/tag-message.txt
+          git push origin "$VERSION"
+          echo "Tag $VERSION pushed."
+
+      - name: Create GitHub Release
+        if: steps.detect.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.detect.outputs.version }}
+          BODY: ${{ steps.changelog.outputs.body }}
+        run: |
+          set -euo pipefail
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --notes "$BODY" \
+            --target "$GITHUB_SHA"
+          echo "GitHub Release $VERSION created."


### PR DESCRIPTION
## Summary

First phase of the CI rollout from Estabilis/estabilis-platform-tools#175. Ships three workflows that remove mechanical work from the release cycle and catch bugs that \`terraform validate\` + local hooks miss.

## Workflows

### \`.github/workflows/pre-commit.yaml\`
Runs the 12 hooks from \`.pre-commit-config.yaml\` on every PR and every push to main. TFLint plugins cached via \`actions/cache\` keyed on \`.tflint.hcl\`. Parity with local setup — zero config drift.

### \`.github/workflows/release.yaml\`
Detects \`chore(release): vX.Y.Z\` commits on main. When matched:
1. Extracts the \`## [X.Y.Z]\` section from \`CHANGELOG.md\` via AWK.
2. Creates annotated tag \`vX.Y.Z\` pointing at the release commit with the CHANGELOG body as the tag message.
3. Creates a GitHub Release with the same body.

Guards against duplicate tags (fails loud if \`vX.Y.Z\` already exists). Uses \`github-actions[bot]\` as the tagger identity.

Operator workflow becomes:
- Merge feature PRs normally.
- Commit \`chore(release): vX.Y.Z\` (via small PR or direct push — the workflow handles both).
- CI tags + releases. No more manual \`git tag\` / \`git push --tags\` / \`gh release create\`.

### \`.github/workflows/gitleaks.yaml\`
Independent from pre-commit: scans **full history** on every PR and push to main. Pre-commit on PR scans only the diff, so a leak that landed in a rebased/amended commit would slip through. This job is the backstop. Shares \`.gitleaks.toml\` with local hooks.

## Measured friction this workflow removes

Over this week's AWS development cycle (5 PRs merged, 3 tags created):
- ~5 \`git checkout -b\` → commit → \`gh pr create\` → wait → \`git pull\` → \`git branch -d\` sequences
- 3 \`git tag -a\` → \`git push origin <tag>\` → \`gh release create\` sequences
- 3 CHANGELOG extractions by hand for release bodies

Each iteration: 3-5 min of pure ceremony. At 6 iterations/hour on active days, that's 20-30 min reclaimed per hour.

## Out of scope

- Phase 2 (plan-on-PR, on-demand drift check) — separate issue
- Phase 3 (daily drift cron, gated apply) — only after platform maturity triggers met
- Client repo CI — tracked in estabilis-platform-tools#177

## Test plan

- [x] \`pre-commit run --files .github/workflows/*.yaml\` locally: all 12 hooks green
- [ ] First PR after merge exercises pre-commit workflow
- [ ] First \`chore(release): vX.Y.Z\` commit after merge exercises release workflow
- [ ] Any PR exercises gitleaks workflow

Related: Estabilis/estabilis-platform-tools#175 #177