### PR TITLE
feat(platform-root): add AWS provider branches to core templates (v0.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,85 @@
 # Changelog
 
+## [0.16.0] - 2026-04-24
+
+### Added — AWS provider branches in core `platform-root` templates
+
+Five core hub templates previously had `{{- if eq .Values.global.provider "azure" }}`
+blocks without a matching AWS branch. When rendered on an AWS hub, the
+resulting Applications showed `Synced` in ArgoCD but the underlying
+controllers were missing the wiring that makes them functional (IRSA
+annotations, provider-agnostic platform-secrets rendering, etc.).
+
+This release closes the gaps so an AWS hub produces a functionally
+correct render. The AWS-equivalent of Azure Workload Identity is
+wired via IRSA — each ServiceAccount receives
+`eks.amazonaws.com/role-arn` instead of
+`azure.workload.identity/client-id`. IRSA role ARNs are already
+exported by `providers/aws/platform-outputs.tf` as `identity.<component>.roleArn`.
+
+#### `values.yaml` — per-cloud identity fields
+
+`identity.<component>` now carries both `clientId` (Azure WI) and
+`roleArn` (AWS IRSA). Templates select the right field via
+`.Values.global.provider`. Empty defaults are safe: fields not relevant
+to the active cloud are not rendered into parameters.
+
+#### Template changes
+
+- **`cert-manager.yaml`** — AWS branch adds
+  `serviceAccount.annotations.eks.amazonaws.com/role-arn` parameter
+  from `identity.certManager.roleArn`. Paired with
+  `values/platform/cert-manager-aws.yaml` overlay (new in
+  estabilis-platform-gitops v0.33.0).
+
+- **`external-secrets.yaml`** — AWS branch adds the same IRSA
+  annotation wiring using `identity.externalSecrets.roleArn`. Paired
+  with the `external-secrets-aws.yaml` overlay in gitops v0.33.0.
+
+- **`platform-secrets.yaml`** — outer `{{- if azure }}` wrapper
+  relaxed to `{{- if or (eq provider azure) (eq provider aws) }}` so
+  the chart renders on both clouds. Chart itself is provider-agnostic
+  (uses the `ClusterSecretStore` already AWS-aware in
+  `cluster-secret-store.yaml`). The Azure-only `acrLoginServer`
+  parameter is now gated to Azure explicitly until a provider-neutral
+  registry variable lands (Estabilis/estabilis-platform-tools#182).
+
+- **`cnpg.yaml`** — `cnpg-operator` Application already rendered on
+  both clouds. `cnpg-cluster` Application is now explicitly gated to
+  Azure only on this release because its backup wiring targets Azure
+  Blob via managed identity; the AWS equivalent (Barman Cloud against
+  S3 via IRSA) is not implemented. Deferred to a follow-up issue under
+  Estabilis/estabilis-platform-tools#186.
+
+- **`opencost.yaml`** — no template change this release. The existing
+  Azure-specific cost-export env vars are already gated to Azure; on
+  AWS the chart renders opencost without cost-export integration
+  (cluster-level cost tracking still works). AWS Athena/CUR integration
+  is deferred to a dedicated follow-up.
+
+### Changed — default `platformGitopsVersion`
+
+`bootstrap/platform-root/values.yaml` default bumped from `v0.1.0`
+(stale placeholder) to `v0.33.0` so standalone renders without
+terraform injection pick up the AWS overlays added in
+estabilis-platform-gitops v0.33.0.
+
+### Breaking / compatibility
+
+No breaking changes for Azure deployments — existing renders produce
+identical manifests. AWS hubs that previously saw `Synced` but
+dysfunctional Applications will, on the next ArgoCD refresh, receive
+the corrected IRSA wiring and start authenticating against AWS APIs.
+
+### Related
+
+- Tracker: Estabilis/estabilis-platform-tools#186 — AWS provider
+  branches in core templates (this release closes the main slice)
+- Pair: Estabilis/estabilis-platform-gitops v0.33.0 — overlay files
+- Follow-ups deferred: CNPG AWS backup (S3 + Barman Cloud), opencost
+  AWS cost-export (Athena/CUR), `acrLoginServer` rename
+  (Estabilis/estabilis-platform-tools#182)
+
 ## [0.15.2] - 2026-04-23
 
 ### Changed — region_code in resource names uses AWS-official format

--- a/bootstrap/platform-root/templates/cert-manager.yaml
+++ b/bootstrap/platform-root/templates/cert-manager.yaml
@@ -41,6 +41,17 @@ spec:
           - name: serviceAccount.annotations.azure\.workload\.identity/client-id
             value: "{{ .Values.identity.certManager.clientId }}"
             forceString: true
+          {{- else if eq .Values.global.provider "aws" }}
+          {{- /* AWS IRSA role ARN for the cert-manager controller pod —
+                dynamic per-cluster, injected here. Paired with the
+                provider overlay file loaded above (cert-manager-aws.yaml)
+                and with `module.cert_manager_irsa` in
+                providers/aws/iam.tf (gated on dns_provider = "route53").
+                The controller assumes this role to solve Route53 DNS-01
+                challenges for the `letsencrypt-production` ClusterIssuer. */}}
+          - name: serviceAccount.annotations.eks\.amazonaws\.com/role-arn
+            value: "{{ .Values.identity.certManager.roleArn }}"
+            forceString: true
           {{- end }}
     - repoURL: {{ .Values.platformGitopsRepoUrl }}
       targetRevision: {{ .Values.platformGitopsVersion }}

--- a/bootstrap/platform-root/templates/cnpg.yaml
+++ b/bootstrap/platform-root/templates/cnpg.yaml
@@ -44,6 +44,16 @@ spec:
       - CreateNamespace=true
       - ServerSideApply=true
 ---
+{{- /* cnpg-cluster — AZURE-ONLY on Phase 1. The chart wires backup
+      storage against Azure Blob via managed identity; the AWS backup
+      path (Barman Cloud against S3 with IRSA) is not implemented yet.
+      When the AWS backup story lands, replace this gate with a
+      provider-aware rendering (follow-up issue below).
+
+      Tracker: Estabilis/estabilis-platform-tools#186 — this is the
+      "cnpg backup on AWS" slice explicitly deferred. Open a dedicated
+      issue before shipping AWS CNPG backups. */ -}}
+{{- if eq .Values.global.provider "azure" }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -86,3 +96,4 @@ spec:
         maxDuration: 3m
     syncOptions:
       - CreateNamespace=true
+{{- end }}

--- a/bootstrap/platform-root/templates/external-secrets.yaml
+++ b/bootstrap/platform-root/templates/external-secrets.yaml
@@ -32,6 +32,15 @@ spec:
           {{- if eq .Values.global.provider "azure" }}
           - name: serviceAccount.annotations.azure\.workload\.identity/client-id
             value: "{{ .Values.identity.externalSecrets.clientId }}"
+          {{- else if eq .Values.global.provider "aws" }}
+          {{- /* AWS IRSA role ARN for the external-secrets controller pod.
+                Paired with external-secrets-aws.yaml overlay and
+                `module.external_secrets_irsa` in providers/aws/iam.tf.
+                The controller assumes this role to read from AWS Secrets
+                Manager via the ClusterSecretStore configured in
+                cluster-secret-store.yaml. */}}
+          - name: serviceAccount.annotations.eks\.amazonaws\.com/role-arn
+            value: "{{ .Values.identity.externalSecrets.roleArn }}"
           {{- end }}
           {{- include "platform-root.provenanceParameters" $ | nindent 10 }}
     - repoURL: {{ .Values.platformGitopsRepoUrl }}

--- a/bootstrap/platform-root/templates/platform-secrets.yaml
+++ b/bootstrap/platform-root/templates/platform-secrets.yaml
@@ -1,5 +1,10 @@
-{{- /* core: consolidated secrets — all ExternalSecrets in a single Application */ -}}
-{{- if eq .Values.global.provider "azure" }}
+{{- /* core: consolidated secrets — all ExternalSecrets in a single Application.
+
+The chart itself (core/components/platform-secrets) is provider-agnostic:
+it emits ExternalSecrets that reference `platform-secret-store`, a
+ClusterSecretStore already wired per provider in cluster-secret-store.yaml.
+Only Azure-specific parameters are gated below. */ -}}
+{{- if or (eq .Values.global.provider "azure") (eq .Values.global.provider "aws") }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -24,7 +29,11 @@ spec:
         - name: clientGitopsRepoUrl
           value: {{ .Values.clientGitopsRepoUrl | quote }}
         {{- end }}
-        {{- if .Values.global.acrLoginServer }}
+        {{- if and (eq .Values.global.provider "azure") .Values.global.acrLoginServer }}
+        {{- /* ACR OCI repo-creds ExternalSecret — Azure-only until a
+              provider-neutral registry variable lands
+              (Estabilis/estabilis-platform-tools#182). On AWS the chart
+              emits no ACR secret because `acrLoginServer` stays empty. */}}
         - name: acrLoginServer
           value: {{ .Values.global.acrLoginServer | quote }}
         {{- end }}

--- a/bootstrap/platform-root/values.yaml
+++ b/bootstrap/platform-root/values.yaml
@@ -38,7 +38,7 @@ configRepoVersion: ""       # DEPRECATED: use configRepoRevision
 # See ADR 0001 (estabilis-platform-tools/docs/adr/0001-workload-bootstrap-strategy.md).
 # Default values below; downstream can override via overrides/platform-root/values.yaml.
 platformGitopsRepoUrl: "https://github.com/Estabilis/estabilis-platform-gitops.git"
-platformGitopsVersion: "v0.1.0"
+platformGitopsVersion: "v0.33.0"
 
 global:
   # Provenance — injected at runtime by the CLI (see block above).
@@ -82,22 +82,36 @@ global:
   acrLoginServer: ""
   sharedAcrLoginServer: "" # injected by terraform — shared ACR for workload images (Image Updater)
 
-# Workload Identity client IDs — injected by terraform
+# Per-cloud workload identity references — injected by terraform.
+#
+# Each entry exposes both:
+#   - clientId: Azure Workload Identity client ID (MSI object ID)
+#   - roleArn:  AWS IAM role ARN for IRSA
+#
+# Templates select the right field based on `.Values.global.provider`.
+# Fields not relevant to the active cloud stay empty and are not rendered.
 identity:
   externalDns:
     clientId: ""
+    roleArn: ""
   externalSecrets:
     clientId: ""
+    roleArn: ""
   loki:
     clientId: ""
+    roleArn: ""
   mimir:
     clientId: ""
+    roleArn: ""
   cnpg:
     clientId: ""
+    roleArn: ""
   certManager:
     clientId: ""
+    roleArn: ""
   velero:
     clientId: ""
+    roleArn: ""
 
 # ---------------------------------------------------------------------------
 # Component Toggles


### PR DESCRIPTION
## Summary

Closes the core slice of Estabilis/estabilis-platform-tools#186 — five hub templates had Azure-only provider blocks without matching AWS branches, producing `Synced` but dysfunctional Applications on EKS hubs (SAs missing IRSA annotations, platform-secrets rendering nothing, etc.). This PR ships the AWS branches so an AWS hub renders a functionally correct `platform-root`.

Pairs with `estabilis-platform-gitops` **v0.33.0** (merged + tagged 2026-04-24), which ships the overlay files the templates reference (`cert-manager-aws.yaml`, `external-secrets-aws.yaml`).

## Files

| File | Change |
|---|---|
| `bootstrap/platform-root/values.yaml` | `identity.<component>` now carries both `clientId` (Azure WI) and `roleArn` (AWS IRSA). `platformGitopsVersion` default bumped `v0.1.0 → v0.33.0`. |
| `bootstrap/platform-root/templates/cert-manager.yaml` | `else if aws` branch adds `serviceAccount.annotations.eks.amazonaws.com/role-arn` parameter from `identity.certManager.roleArn`. |
| `bootstrap/platform-root/templates/external-secrets.yaml` | Same IRSA wiring pattern using `identity.externalSecrets.roleArn`. |
| `bootstrap/platform-root/templates/platform-secrets.yaml` | Outer `{{- if azure }}` relaxed to `{{- if or azure aws }}`; `acrLoginServer` parameter gated to Azure explicitly until #182 lands. |
| `bootstrap/platform-root/templates/cnpg.yaml` | `cnpg-cluster` Application gated to Azure only (AWS backup via S3/Barman Cloud deferred — follow-up). `cnpg-operator` renders both clouds unchanged. |
| `bootstrap/platform-root/templates/opencost.yaml` | No change — template already provider-safe; Azure cost-export block is pre-existing and skips cleanly on AWS. AWS cost-export (Athena/CUR) deferred to a dedicated follow-up. |
| `CHANGELOG.md` | v0.16.0 entry. |

## Validation

Verified locally:

**AWS render (`--set global.provider=aws`):**
- `cert-manager` Application emits `serviceAccount.annotations.eks.amazonaws.com/role-arn` with the injected ARN
- `external-secrets` Application emits the same
- `cnpg-operator` renders; `cnpg-cluster` skipped (deferral gate)
- `platform-secrets` renders (outer gate passes)
- Zero `azure.workload.identity/client-id` parameters in the output

**Azure render (`--set global.provider=azure`) — regression-free:**
- 5 Azure WI SA annotations still emit (cert-manager, external-secrets, and three others via other templates — count preserved from before)
- Zero `eks.amazonaws.com/role-arn` parameters
- `cnpg-cluster` still renders

Pre-commit: all hooks pass (`terraform_fmt`, `terraform_validate`, `tflint`, hygiene, `detect-aws-credentials`, `gitleaks`).

## Known deferrals (not in this PR)

These were identified during implementation and intentionally scoped out. Each has or will get a dedicated issue:

- **CNPG AWS backup (S3 + Barman Cloud + IRSA)** — `cnpg-cluster` is Azure-only today. Needed before CNPG databases on EKS can take backups.
- **OpenCost AWS cost-export (Athena/CUR integration)** — opencost runs on AWS but without cloud-cost ingestion.
- **`acrLoginServer` → provider-neutral registry variable** — tracked in Estabilis/estabilis-platform-tools#182.

## Release path

Release workflow regex bug (Estabilis/estabilis-platform-tools#188) is still open, so after squash-merge the tag `v0.16.0` will have to be created manually (like gitops v0.33.0 yesterday). Will tag + release right after merge, unless the regex fix (#188) lands first.

## Related

- Tracker: Estabilis/estabilis-platform-tools#186 — AWS provider branches in core templates (this PR closes the main slice; deferrals open follow-ups)
- Pair: `estabilis-platform-gitops` v0.33.0 (shipped) — overlay files
- Bug: Estabilis/estabilis-platform-tools#188 — release regex rejects `(#N)` suffix