### PR TITLE
feat(aws): add autoscaler hybrid mode (MNG + Karpenter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog
 
+## [0.17.0] - 2026-04-24
+
+### Added — `autoscaler = "hybrid"` mode (AWS provider)
+
+Resolves a chicken-and-egg that blocks the ArgoCD seed on an AWS hub:
+with `autoscaler = "karpenter"` (the previous default), the cluster
+has only Fargate Profiles for `kube-system` + `karpenter` namespaces,
+and Karpenter itself only provisions EC2 when its NodePool CR exists.
+The NodePool is installed BY ArgoCD as part of platform-root. But
+ArgoCD needs a node to run — so it can't start, which means Karpenter
+can't be deployed, which means there are no nodes. Deadlock.
+
+The new `hybrid` mode fixes this by provisioning a small always-on
+Managed Node Group (MNG) alongside the Karpenter infrastructure:
+
+- **MNG**: 2 permanent EC2 nodes (defaults: `t3a.medium`/`t3.medium`,
+  `min_size=2`, `max_size=4`) — hosts platform control-plane
+  (ArgoCD, cert-manager, external-secrets, kyverno, ...). Analogous
+  to the AKS `platformrg` user pool.
+- **Karpenter infra** (IRSA role + SQS queue + Fargate Profile for
+  the karpenter namespace): ready to be wired up by platform-root,
+  and provisions workload EC2 once NodePool lands.
+- **Fargate Profile `kube-system`**: unchanged — still hosts coredns,
+  ebs-csi-controller, pod-identity-agent, etc. Analogous to the AKS
+  system pool.
+
+The resulting topology mirrors AKS: system-level addons on one pool
+(Fargate), platform control-plane on another (MNG), workloads
+elastic via Karpenter.
+
+**Default changed** from `autoscaler = "karpenter"` to
+`autoscaler = "hybrid"`. Existing Azure clients are unaffected
+(variable is AWS-only). The only AWS deployment today (cortex test)
+is still in seed and was not moved to production; it will be
+re-applied with `hybrid` to unblock the seed.
+
+### Changed — file-level touches
+
+- `variables.tf`: `autoscaler` now accepts `"hybrid"` in addition to
+  `"karpenter"`, `"cluster_autoscaler"`, `"none"`. Description
+  expanded with the full contract of each mode. Default flipped to
+  `"hybrid"`.
+- `eks.tf`: the MNG block fires on both `"cluster_autoscaler"` and
+  `"hybrid"`; the Karpenter Fargate Profile + node SG Karpenter
+  discovery tags fire on both `"karpenter"` and `"hybrid"`. VPC
+  subnet Karpenter-discovery tags in existing-VPC mode follow the
+  same rule.
+- `karpenter.tf`: `module.karpenter` and the IAM `-instance-profile-gc`
+  policy fire on both `"karpenter"` and `"hybrid"`.
+- `platform-outputs.tf`: `global.karpenterQueueName` / `karpenterNodeRoleName`
+  / `karpenterControllerRole` populated on both `"karpenter"` and
+  `"hybrid"`.
+
+### Migration guide
+
+Operators on `autoscaler = "karpenter"` who want to adopt `hybrid`:
+
+1. Update `terraform.tfvars`: `autoscaler = "hybrid"`.
+2. `terraform plan` — expected: MNG `<cluster>-default` created with
+   `min_size=2` nodes; no destroy of existing Karpenter IAM/SQS
+   (both modes share those resources).
+3. `terraform apply`.
+4. No change required on the gitops or CLI side. ArgoCD + platform-root
+   seed runs as if it were a fresh install.
+
+Operators on `autoscaler = "karpenter"` who want to stay there: no
+change required. Behaviour identical to before.
+
 ## [0.16.0] - 2026-04-24
 
 ### Added — AWS provider branches in core `platform-root` templates

--- a/providers/aws/eks.tf
+++ b/providers/aws/eks.tf
@@ -7,7 +7,10 @@
 #   - Cluster encryption for Kubernetes Secrets via aws_kms_key.cluster_secrets
 #   - Authentication in API-only mode + Access Entries (eks_access_entries)
 #   - Fargate profiles for kube-system + karpenter namespaces (when
-#     autoscaler = "karpenter"), plus any extras in fargate_profile_namespaces
+#     autoscaler is "karpenter" or "hybrid"), plus any extras in
+#     fargate_profile_namespaces
+#   - Managed Node Group for control-plane workloads (when autoscaler is
+#     "cluster_autoscaler" or "hybrid")
 #   - The additional SG from security-groups.tf for operator ingress/extras
 #   - karpenter.sh/discovery tag on cluster + node SG (so Karpenter can find
 #     them for nodeClass lookups)
@@ -48,7 +51,8 @@ locals {
   effective_addons = length(keys(var.cluster_addons)) > 0 ? var.cluster_addons : local.default_addons
 
   # Fargate profiles — kube-system is always included (addons land here),
-  # karpenter when autoscaler = "karpenter". Extras appended from var.
+  # karpenter namespace when autoscaler uses Karpenter ("karpenter" or
+  # "hybrid"). Extras appended from var.
   fargate_profiles_default = merge(
     {
       kube_system = {
@@ -59,7 +63,7 @@ locals {
         subnet_ids = local.private_subnet_ids
       }
     },
-    var.autoscaler == "karpenter" ? {
+    contains(["karpenter", "hybrid"], var.autoscaler) ? {
       karpenter = {
         name = "karpenter"
         selectors = [
@@ -174,9 +178,13 @@ module "eks" {
   # --- Fargate profiles ---------------------------------------------------
   fargate_profiles = local.fargate_profiles_default
 
-  # --- Managed node groups (only when cluster_autoscaler is selected;
-  # karpenter mode uses Fargate + Karpenter-provisioned EC2) --------------
-  eks_managed_node_groups = var.autoscaler == "cluster_autoscaler" ? {
+  # --- Managed node groups -------------------------------------------------
+  # Created when autoscaler provisions a persistent EC2 fleet:
+  #   - 'cluster_autoscaler': MNG is the only compute (no Karpenter)
+  #   - 'hybrid': MNG hosts platform control-plane; Karpenter layers on
+  #     top for workloads
+  # Skipped for 'karpenter' (Karpenter-only) and 'none' (BYO).
+  eks_managed_node_groups = contains(["cluster_autoscaler", "hybrid"], var.autoscaler) ? {
     default = {
       name           = "${local.cluster_name}-default"
       instance_types = var.mng_instance_types
@@ -202,7 +210,8 @@ module "eks" {
   node_security_group_additional_rules = {}
 
   # --- Node SG tags for Karpenter discovery -------------------------------
-  node_security_group_tags = var.autoscaler == "karpenter" ? {
+  # Applied whenever Karpenter is present (both 'karpenter' and 'hybrid').
+  node_security_group_tags = contains(["karpenter", "hybrid"], var.autoscaler) ? {
     (var.karpenter_discovery_tag_key) = local.cluster_name
   } : {}
 
@@ -222,7 +231,7 @@ module "eks" {
 # ---------------------------------------------------------------------------
 
 resource "aws_ec2_tag" "existing_private_karpenter_discovery" {
-  for_each = var.vpc_mode == "existing" && var.autoscaler == "karpenter" ? toset(var.private_subnet_ids) : []
+  for_each = var.vpc_mode == "existing" && contains(["karpenter", "hybrid"], var.autoscaler) ? toset(var.private_subnet_ids) : []
 
   resource_id = each.value
   key         = var.karpenter_discovery_tag_key

--- a/providers/aws/karpenter.tf
+++ b/providers/aws/karpenter.tf
@@ -14,11 +14,11 @@
 # The EC2NodeClass + NodePool custom resources are Kubernetes manifests and
 # live in core/components/karpenter/ (Phase 2).
 #
-# Only rendered when var.autoscaler = "karpenter".
+# Rendered when var.autoscaler includes Karpenter ("karpenter" or "hybrid").
 # ---------------------------------------------------------------------------
 
 module "karpenter" {
-  count = var.autoscaler == "karpenter" ? 1 : 0
+  count = contains(["karpenter", "hybrid"], var.autoscaler) ? 1 : 0
 
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
   version = "~> 20.37"
@@ -60,7 +60,7 @@ module "karpenter" {
 
 # Allow Karpenter controller to garbage-collect orphaned instance profiles.
 resource "aws_iam_role_policy" "karpenter_instance_profile_gc" {
-  count = var.autoscaler == "karpenter" ? 1 : 0
+  count = contains(["karpenter", "hybrid"], var.autoscaler) ? 1 : 0
 
   name = "${local.cluster_name}-karpenter-instance-profile-gc"
   role = module.karpenter[0].iam_role_name

--- a/providers/aws/platform-outputs.tf
+++ b/providers/aws/platform-outputs.tf
@@ -98,9 +98,9 @@ resource "kubernetes_config_map" "platform_infrastructure" {
 
     # Autoscaler + Karpenter wiring
     "global.autoscaler"               = var.autoscaler
-    "global.karpenterQueueName"       = var.autoscaler == "karpenter" ? module.karpenter[0].queue_name : ""
-    "global.karpenterNodeRoleName"    = var.autoscaler == "karpenter" ? module.karpenter[0].node_iam_role_name : ""
-    "global.karpenterControllerRole"  = var.autoscaler == "karpenter" ? module.karpenter[0].iam_role_arn : ""
+    "global.karpenterQueueName"       = contains(["karpenter", "hybrid"], var.autoscaler) ? module.karpenter[0].queue_name : ""
+    "global.karpenterNodeRoleName"    = contains(["karpenter", "hybrid"], var.autoscaler) ? module.karpenter[0].node_iam_role_name : ""
+    "global.karpenterControllerRole"  = contains(["karpenter", "hybrid"], var.autoscaler) ? module.karpenter[0].iam_role_arn : ""
     "global.karpenterDiscoveryTagKey" = var.karpenter_discovery_tag_key
 
     # ECR

--- a/providers/aws/variables.tf
+++ b/providers/aws/variables.tf
@@ -227,13 +227,36 @@ variable "fargate_profile_namespaces" {
 }
 
 variable "autoscaler" {
-  description = "Node autoscaling strategy. 'karpenter' (recommended): Fargate for system + Karpenter provisions EC2 on demand. 'cluster_autoscaler': managed node groups with ASG-based autoscaling. 'none': bring-your-own node groups via ArgoCD/manual."
+  description = <<-EOT
+    Node autoscaling strategy. Four modes:
+
+    - 'hybrid' (recommended): managed node group (MNG) with a small
+      always-on EC2 fleet for platform control-plane (ArgoCD,
+      cert-manager, external-secrets, kyverno, ...) + Karpenter
+      infrastructure ready to provision EC2 nodes on demand for
+      workloads. Mirrors the AKS `system pool + user pool` model and
+      eliminates the chicken-and-egg where ArgoCD needs nodes to run
+      but Karpenter's NodePool is created BY ArgoCD.
+
+    - 'karpenter': Fargate for system + karpenter namespaces;
+      Karpenter provisions EC2 for everything else. Requires Karpenter
+      NodePool to be installed via a pre-seed path (not via ArgoCD) or
+      the MNG-less variant of this mode has a chicken-and-egg on
+      ArgoCD bootstrap. Kept for parity with earlier deployments.
+
+    - 'cluster_autoscaler': MNG only, with ASG-based autoscaling.
+      No Karpenter. Simplest model but less flexibility on instance
+      types for workloads.
+
+    - 'none': bring-your-own node groups via ArgoCD or manual
+      Terraform resources in the downstream repo.
+  EOT
   type        = string
-  default     = "karpenter"
+  default     = "hybrid"
 
   validation {
-    condition     = contains(["karpenter", "cluster_autoscaler", "none"], var.autoscaler)
-    error_message = "autoscaler must be one of: karpenter, cluster_autoscaler, none."
+    condition     = contains(["hybrid", "karpenter", "cluster_autoscaler", "none"], var.autoscaler)
+    error_message = "autoscaler must be one of: hybrid, karpenter, cluster_autoscaler, none."
   }
 }
 


### PR DESCRIPTION
## Summary

Adds a new `autoscaler = "hybrid"` mode to the AWS provider that provisions a small always-on Managed Node Group **alongside** Karpenter infrastructure. The resulting topology mirrors AKS:

| Layer | AKS | AWS (new `hybrid` mode) |
|---|---|---|
| Kubernetes system addons | system pool (`CriticalAddonsOnly` taint) | Fargate Profile `kube-system` |
| Platform control-plane (ArgoCD, cert-manager, ESO, kyverno) | `platformrg` user pool | Managed Node Group (2 EC2 nodes default) |
| Elastic workloads | N/A on hml; prod uses autoscaling user pool | Karpenter-provisioned EC2 |

## Why

The `autoscaler = "karpenter"` mode has a chicken-and-egg that blocks the ArgoCD seed on a fresh hub: Karpenter only provisions EC2 when its `NodePool` CR exists, but that `NodePool` is installed **by ArgoCD** via platform-root. ArgoCD needs a node to start → no node → deadlock.

The `cluster_autoscaler` mode avoids the deadlock but turns Karpenter off entirely, losing the elastic capacity model for workloads.

`hybrid` takes the best of both: MNG for the predictable control-plane footprint, Karpenter for everything else. Same pattern the cortex legacy used (TF-installed Karpenter + EC2 nodes) but cleaner because the module owns the full wiring.

## Default flipped

`var.autoscaler` default changes from `"karpenter"` to `"hybrid"`. Rationale:
- No production AWS deployment today (cortex is the first, still in seed).
- Any new AWS client gets a working seed out of the box.
- Existing Azure clients unaffected (variable is AWS-only).

## Files

| File | Change |
|---|---|
| `variables.tf` | `autoscaler` accepts `"hybrid"`; description expanded with full contract per mode; default flipped to `"hybrid"` |
| `eks.tf` | MNG block fires on `cluster_autoscaler` OR `hybrid`; Karpenter Fargate Profile + node SG Karpenter-discovery tags + existing-VPC subnet tags fire on `karpenter` OR `hybrid` |
| `karpenter.tf` | `module.karpenter` + `aws_iam_role_policy.karpenter_instance_profile_gc` fire on `karpenter` OR `hybrid` |
| `platform-outputs.tf` | `global.karpenterQueueName`, `karpenterNodeRoleName`, `karpenterControllerRole` populated on `karpenter` OR `hybrid` |
| `CHANGELOG.md` | v0.17.0 entry with migration guide |

## Migration — existing clients

**Staying on `karpenter`:** no change.
**Moving to `hybrid`:** set `autoscaler = "hybrid"` in `terraform.tfvars`, `terraform plan`, apply. The plan shows an **MNG created** (2 EC2 nodes) — no destroy of the Karpenter IAM/SQS (both modes share them).

## Test plan

- [x] `terraform validate` on `providers/aws/` — passes
- [x] `terraform fmt -check -recursive` — passes
- [x] pre-commit all hooks — pass
- [ ] CI (terraform + pre-commit + gitleaks workflows)
- [ ] Functional: cortex re-apply with `autoscaler = "hybrid"` → MNG created, ArgoCD seed proceeds

## Release path

Squash-merge → manual tag `v0.17.0` (auto-tag regex bug Estabilis/estabilis-platform-tools#188 still open for this repo, so manual tag as recovery like `v0.16.0` yesterday).

## Related

- Estabilis/estabilis-platform-tools#186 — AWS provider branches (v0.16.0 shipped Phase 2 core)
- Estabilis/estabilis-platform-tools#188 — release regex bug (affects this repo's auto-tag)