### PR TITLE
fix(aws): MNG default IAM role name_prefix overflow (v0.17.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [0.17.1] - 2026-04-24
+
+### Fixed — MNG default IAM role name_prefix overflow
+
+The new `autoscaler = "hybrid"` / `autoscaler = "cluster_autoscaler"`
+path (introduced in v0.17.0) uses the terraform-aws-modules EKS
+managed-node-group submodule, which defaults to
+`iam_role_use_name_prefix = true`. The submodule then builds the IAM
+role as `"${cluster_name}-${node_group_name}-eks-node-group-"` before
+AWS appends its 26-char random suffix. The AWS `name_prefix`
+limit is 38 chars.
+
+Our CAF-style cluster names (`eks-{prefix}-platform-{env}-{region}`)
+routinely exceed that budget once combined with the submodule's
+suffix. First `terraform apply` on AWS with `hybrid` mode fails:
+
+```
+Error: expected length of name_prefix to be in the range (1 - 38),
+got eks-cortex-platform-prd-us-east-1-default-eks-node-group-
+```
+
+Same fix pattern as `module.eks` (v0.15.0) and `module.karpenter`
+(v0.15.2): set `iam_role_use_name_prefix = false` to switch to name
+mode (64-char budget), and pin `iam_role_name` explicitly so future
+additional MNGs get distinct role names without fighting the default.
+
+- `providers/aws/eks.tf`: the `default` MNG now sets
+  `iam_role_use_name_prefix = false` and `iam_role_name = "${local.cluster_name}-default-node"`.
+
+### Migration
+
+Operators on v0.17.0 who hit the error during `terraform apply`: bump
+the module `ref` from `v0.17.0` to `v0.17.1` and re-run
+`terraform plan`/`apply`. No other change required.
+
+Operators already on v0.17.0 who succeeded (unlikely — the MNG can't
+exist yet on v0.17.0 without hitting this error unless their cluster
+name is very short): the next apply will recreate the IAM role with
+a stable name instead of the generated prefix. Acceptable in a fresh
+deployment.
+
 ## [0.17.0] - 2026-04-24
 
 ### Added — `autoscaler = "hybrid"` mode (AWS provider)

--- a/providers/aws/eks.tf
+++ b/providers/aws/eks.tf
@@ -195,6 +195,16 @@ module "eks" {
       disk_size      = var.mng_disk_size_gb
       ami_type       = var.mng_ami_type
       subnet_ids     = local.private_subnet_ids
+
+      # Same IAM role naming constraint as module.eks and module.karpenter:
+      # the CAF-style cluster name ({prefix}-platform-{env}-{region}) plus
+      # the submodule's `-default-eks-node-group` suffix exceeds the 38-char
+      # AWS name_prefix cap. Using false switches to name mode (64-char
+      # budget), and we supply an explicit role name to avoid colliding
+      # with other MNGs if more are added later.
+      iam_role_use_name_prefix = false
+      iam_role_name            = "${local.cluster_name}-default-node"
+
       labels = {
         "estabilis.io/workload-type" = "platform"
         "estabilis.io/pool-type"     = "regular"


### PR DESCRIPTION
## Summary

Patch for the `hybrid` / `cluster_autoscaler` path introduced in v0.17.0. First `terraform apply` on a CAF-style cluster name fails:

```
Error: expected length of name_prefix to be in the range (1 - 38),
got eks-cortex-platform-prd-us-east-1-default-eks-node-group-
```

Observed on the cortex test deployment (first AWS consumer of v0.17.0).

## Root cause

The `terraform-aws-modules/eks/aws//modules/eks-managed-node-group` submodule defaults to `iam_role_use_name_prefix = true` and constructs `${cluster_name}-${node_group_name}-eks-node-group-` before AWS appends its 26-char random suffix. The AWS IAM `name_prefix` limit is 38 characters. Our cluster names (`eks-{prefix}-platform-{env}-{region}`) blow through that budget on anything longer than `eks-x-platform-hml-us-east-1`.

Same class of issue fixed for `module.eks` (v0.15.0) and `module.karpenter` (v0.15.2).

## Fix

In `providers/aws/eks.tf`, the `default` MNG:

```hcl
iam_role_use_name_prefix = false
iam_role_name            = "${local.cluster_name}-default-node"
```

Switches to name mode (64-char budget). Explicit role name ensures future additional MNGs get distinct names without colliding on a generated prefix.

For the cortex case: `eks-cortex-platform-prd-us-east-1-default-node` = 47 chars, well within 64.

## Migration

Operators hitting the error on v0.17.0 `terraform apply`: bump the module `ref` from `v0.17.0` to `v0.17.1` and re-run `terraform plan`/`apply`. No other change needed.

## Test plan

- [x] `terraform validate` passes
- [x] pre-commit hooks pass (fmt, validate, tflint, hygiene, gitleaks)
- [ ] CI green
- [ ] cortex re-apply with `ref=v0.17.1` produces a plan showing MNG creation with the explicit role name (no `name_prefix` error)

## Release path

Squash-merge → manual tag `v0.17.1` (auto-tag regex bug `Estabilis/estabilis-platform-tools#188` still open).

## Related

- Estabilis/estabilis-platform#76 — v0.17.0 that introduced the `hybrid` mode (merged; this is the follow-up patch)
- Cortex-Innovation/cortex-platform-aws-us-east-1-prd#5 — cortex bump PR that surfaced this error