### PR TITLE
fix(aws): MNG name prefix + karpenter outputs under hybrid (v0.17.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## [0.17.2] - 2026-04-24
+
+### Fixed — MNG `node_group_name_prefix` overflow + Karpenter outputs under `hybrid` mode
+
+Two additional issues surfaced when `terraform apply` was retried on
+v0.17.1 against a CAF-style cluster name:
+
+#### 1. `node_group_name_prefix` overflow
+
+The EKS managed-node-group submodule has a second IAM-like name
+construction beyond the role name — `aws_eks_node_group.this.node_group_name_prefix`
+uses `"${var.name}-"` when `var.use_name_prefix = true` (default). Our
+`var.name` for the default MNG is `"${cluster_name}-default"` → prefix
+becomes `"${cluster_name}-default-"` (42 chars) → AWS caps at 37:
+
+```
+Error: expected length of node_group_name_prefix to be in the range
+(0 - 37), got eks-cortex-platform-prd-us-east-1-default-
+```
+
+Fix: set `use_name_prefix = false` on the default MNG so the submodule
+uses our explicit `name` directly. Complements the `iam_role_use_name_prefix`
+fix from v0.17.1.
+
+#### 2. Karpenter outputs go empty under `hybrid`
+
+`outputs.tf` still gated three Karpenter outputs on the strict
+`var.autoscaler == "karpenter"` check missed by the v0.17.0 rollout:
+
+- `karpenter_queue_name`
+- `karpenter_node_iam_role_name`
+- `karpenter_controller_role_arn`
+
+Consequence on a `hybrid` apply: `terraform plan` shows these outputs
+flipping to `""` even though the Karpenter module is still provisioned.
+Downstream consumers reading them see a false "Karpenter disabled"
+signal.
+
+Fix: switch all three to `contains(["karpenter", "hybrid"], var.autoscaler)`.
+Matches the pattern already applied to `platform-outputs.tf` in v0.17.0.
+
+### Migration
+
+Operators hitting either error on v0.17.1 `terraform apply`: bump the
+module `ref` from `v0.17.1` to `v0.17.2` and re-run `terraform plan`/`apply`.
+No other change required.
+
 ## [0.17.1] - 2026-04-24
 
 ### Fixed — MNG default IAM role name_prefix overflow

--- a/providers/aws/eks.tf
+++ b/providers/aws/eks.tf
@@ -196,12 +196,22 @@ module "eks" {
       ami_type       = var.mng_ami_type
       subnet_ids     = local.private_subnet_ids
 
-      # Same IAM role naming constraint as module.eks and module.karpenter:
-      # the CAF-style cluster name ({prefix}-platform-{env}-{region}) plus
-      # the submodule's `-default-eks-node-group` suffix exceeds the 38-char
-      # AWS name_prefix cap. Using false switches to name mode (64-char
-      # budget), and we supply an explicit role name to avoid colliding
-      # with other MNGs if more are added later.
+      # Two name-prefix overflows to disable on the submodule when the
+      # cluster name is long (our CAF-style naming blows past both):
+      #
+      #  1. IAM role: submodule constructs `{cluster}-{ng}-eks-node-group-`
+      #     before AWS appends its 26-char random suffix. 38-char cap.
+      #     Switch off the prefix and supply an explicit role name.
+      #
+      #  2. Node-group resource: submodule constructs `{ng}-` (where
+      #     {ng} is the computed name `{cluster}-{default}`). 37-char cap
+      #     for the node_group_name_prefix. Switch off the prefix and let
+      #     the submodule use our explicit `name` directly.
+      #
+      # Both constraints are the same family as module.eks (v0.15.0) and
+      # module.karpenter (v0.15.2). Pinning explicit names keeps future
+      # additional MNGs colliding-free.
+      use_name_prefix          = false
       iam_role_use_name_prefix = false
       iam_role_name            = "${local.cluster_name}-default-node"
 

--- a/providers/aws/outputs.tf
+++ b/providers/aws/outputs.tf
@@ -212,18 +212,18 @@ output "opencost_role_arn" {
 # ===========================================================================
 
 output "karpenter_queue_name" {
-  description = "SQS interruption queue name for Karpenter (empty when autoscaler != 'karpenter')."
-  value       = var.autoscaler == "karpenter" ? module.karpenter[0].queue_name : ""
+  description = "SQS interruption queue name for Karpenter (empty when autoscaler does not provision Karpenter)."
+  value       = contains(["karpenter", "hybrid"], var.autoscaler) ? module.karpenter[0].queue_name : ""
 }
 
 output "karpenter_node_iam_role_name" {
-  description = "IAM role name used by Karpenter-provisioned nodes (empty when autoscaler != 'karpenter')."
-  value       = var.autoscaler == "karpenter" ? module.karpenter[0].node_iam_role_name : ""
+  description = "IAM role name used by Karpenter-provisioned nodes (empty when autoscaler does not provision Karpenter)."
+  value       = contains(["karpenter", "hybrid"], var.autoscaler) ? module.karpenter[0].node_iam_role_name : ""
 }
 
 output "karpenter_controller_role_arn" {
-  description = "IAM role ARN of the Karpenter controller (empty when autoscaler != 'karpenter')."
-  value       = var.autoscaler == "karpenter" ? module.karpenter[0].iam_role_arn : ""
+  description = "IAM role ARN of the Karpenter controller (empty when autoscaler does not provision Karpenter)."
+  value       = contains(["karpenter", "hybrid"], var.autoscaler) ? module.karpenter[0].iam_role_arn : ""
 }
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Two additional issues caught when retrying `terraform apply` on v0.17.1 against a CAF-style cluster name. Both are regressions-of-omission from the v0.17.0 rollout that only surfaced on a full end-to-end run.

### 1. `aws_eks_node_group.node_group_name_prefix` overflow

Submodule constructs `\"\${var.name}-\"` when `var.use_name_prefix = true` (default). Our `var.name` for the default MNG is `\"\${cluster_name}-default\"` → prefix becomes `\"eks-cortex-platform-prd-us-east-1-default-\"` (42 chars). AWS caps the node-group `name_prefix` at 37 chars:

```
Error: expected length of node_group_name_prefix to be in the range
(0 - 37), got eks-cortex-platform-prd-us-east-1-default-
```

**Fix:** `use_name_prefix = false` on the default MNG block (complements `iam_role_use_name_prefix = false` added in v0.17.1).

### 2. Karpenter outputs return `\"\"` under `hybrid`

`outputs.tf` still had three Karpenter outputs gated on `var.autoscaler == \"karpenter\"` strict — missed by the v0.17.0 rollout:

- `karpenter_queue_name`
- `karpenter_node_iam_role_name`
- `karpenter_controller_role_arn`

Consequence on `hybrid` apply: `terraform plan` shows these outputs flipping to `\"\"` even though `module.karpenter` is still provisioned (`hybrid` keeps it). Downstream consumers reading the outputs see a false \"Karpenter disabled\" signal.

**Fix:** switch to `contains([\"karpenter\", \"hybrid\"], var.autoscaler)`, matching the pattern already applied in `platform-outputs.tf` during v0.17.0.

## Files

| File | Change |
|---|---|
| `providers/aws/eks.tf` | MNG default gets `use_name_prefix = false`; comment expanded to explain both prefix constraints |
| `providers/aws/outputs.tf` | 3 Karpenter outputs use `contains([\"karpenter\", \"hybrid\"], ...)` |
| `CHANGELOG.md` | v0.17.2 entry documenting both fixes |

## Test plan

- [x] `terraform validate` passes
- [x] pre-commit hooks pass
- [ ] CI green
- [ ] cortex re-apply with `ref=v0.17.2` produces a plan where MNG creates with the explicit name + Karpenter outputs remain populated

## Release path

Squash-merge → manual tag `v0.17.2` (regex bug `Estabilis/estabilis-platform-tools#188` still open).

## Related

- Estabilis/estabilis-platform#77 — v0.17.1 (MNG IAM name_prefix fix; half of the MNG naming story)
- Estabilis/estabilis-platform#76 — v0.17.0 (hybrid mode)
- Cortex-Innovation/cortex-platform-aws-us-east-1-prd#5 — cortex bump PR surfacing both errors