### PR TITLE
feat(aws): expose _argocd_redis_password in Secret (v0.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## [0.18.0] - 2026-04-24
+
+### Added — `_argocd_redis_password` in platform-infrastructure-sensitive Secret (AWS)
+
+The AWS provider already generated a random ArgoCD Redis password
+(`random_password.argocd_redis` in `secrets-manager.tf`, in place
+since the initial AWS provider) and published it to AWS Secrets
+Manager at `${secrets_path_prefix}/platform-argocd-redis-password`.
+What was missing: exposing the value to `estabilis upstart` so it can
+**pre-create** the `argocd-redis` Kubernetes Secret *before* the
+helm install, which lets the chart skip its `redis-secret-init`
+bootstrap Job.
+
+This release adds one field to the `platform-infrastructure-sensitive`
+Kubernetes Secret written by `platform-outputs.tf`:
+
+```yaml
+_argocd_redis_password: <random_password.argocd_redis.result>
+```
+
+### Why this matters
+
+Consistency with the Azure bootstrap flow, and a concrete deadlock
+fix on fresh EKS hubs. Observed on the cortex test deployment
+(2026-04-24): the helm install of ArgoCD left the
+`argocd-redis-secret-init` Job in `Pending` when the `argocd`
+namespace was not covered by a Fargate Profile. The CLI's
+`_helm_install_argocd` sets `redisSecretInit.enabled = false` when
+it has a redis password to pre-create the Secret, avoiding the Job
+entirely — but the Azure path relies on an `az keyvault secret show`
+lookup that has no AWS analogue. Exposing the value in the K8s Secret
+gives the CLI a cloud-agnostic read path.
+
+### Cloud-agnostic convention
+
+The name `_argocd_redis_password` follows the underscore-prefix
+convention already in use by `params.py` for bootstrap-only values
+that never render into chart Helm parameters. Azure's CLI path
+(`az keyvault secret show` lookup) continues to work as before — this
+release only adds the AWS path. A follow-up ADR will propose
+migrating Azure to write the same K8s Secret field, eliminating the
+az-CLI dependency entirely.
+
+### Migration
+
+Operators with an existing AWS deployment: next `terraform apply`
+updates the K8s Secret `platform-infrastructure-sensitive` with the
+new field. No destroy, no recreation. The value was already being
+generated — just not exposed.
+
+### Files
+
+- `providers/aws/platform-outputs.tf`: add `_argocd_redis_password` to the K8s Secret data map.
+- `CHANGELOG.md`: v0.18.0 entry.
+
 ## [0.17.2] - 2026-04-24
 
 ### Fixed — MNG `node_group_name_prefix` overflow + Karpenter outputs under `hybrid` mode

--- a/providers/aws/platform-outputs.tf
+++ b/providers/aws/platform-outputs.tf
@@ -154,6 +154,21 @@ resource "kubernetes_secret" "platform_infrastructure" {
 
     # Cloudflare API token — only populated when dns_provider = "cloudflare".
     "global.cloudflareApiToken" = var.dns_provider == "cloudflare" ? var.cloudflare_api_token : ""
+
+    # ArgoCD Redis password — consumed by `estabilis upstart` to pre-create
+    # the argocd-redis Kubernetes Secret BEFORE helm install. Without it the
+    # chart's redis-secret-init Job runs, which on fresh clusters can hang
+    # (observed on EKS with Fargate Profile not covering the argocd namespace
+    # on first try). The password is generated once by the
+    # `random_password.argocd_redis` resource in secrets-manager.tf and also
+    # published to AWS Secrets Manager under
+    # `${secrets_path_prefix}/platform-argocd-redis-password` for
+    # ExternalSecrets reconcile later on.
+    #
+    # This mirrors the Azure equivalent, but replaces the `az keyvault secret
+    # show` lookup path the CLI does today with a direct K8s Secret read —
+    # cloud-agnostic, no CLI dependency.
+    "_argocd_redis_password" = random_password.argocd_redis.result
   }
 }
 


### PR DESCRIPTION
## Summary

The AWS provider already generated a random ArgoCD Redis password (`random_password.argocd_redis` in `secrets-manager.tf`, in place since the initial AWS provider) and published it to AWS Secrets Manager at `\${secrets_path_prefix}/platform-argocd-redis-password`. **What was missing:** exposing the value to `estabilis upstart` so it can **pre-create** the `argocd-redis` Kubernetes Secret *before* the helm install, which lets the chart skip its `redis-secret-init` bootstrap Job.

## Why

Observed on the cortex test deployment 2026-04-24: on the first helm install attempt, `argocd-redis-secret-init` pod stayed `Pending` because the `argocd` namespace was not covered by a Fargate Profile, and no MNG existed yet (chicken-and-egg solved in v0.17.x).

The CLI's `_helm_install_argocd` already handles this correctly — when it has a redis password, it pre-creates the Secret and disables `redisSecretInit.enabled`, avoiding the Job entirely. The Azure path gets the value via `az keyvault secret show platform-argocd-redis-password` (see `tools/src/estabilis/params.py:474-499`). **AWS has no analogue** — the CLI falls back to enabling the Job.

This release closes the gap: one field added to the K8s Secret the CLI already reads.

## Change

```hcl
# providers/aws/platform-outputs.tf (inside kubernetes_secret.platform_infrastructure data{})

"_argocd_redis_password" = random_password.argocd_redis.result
```

## Naming convention

The underscore prefix matches the existing convention in `tools/src/estabilis/params.py` for bootstrap-only values that never render into chart Helm parameters. `params.py` strips `_`-prefixed entries from the helm-parameters list and keeps them as internal state only.

## Security

The K8s Secret `platform-infrastructure-sensitive` is encrypted at rest via `aws_kms_key.cluster_secrets` (EKS envelope encryption). Adding one more field to a Secret that already contains IAM role ARNs and other sensitive infra identifiers does not change the threat model. Access is scoped to the `argocd` namespace; only Terraform + the ESO controller + explicit kubectl callers can read it.

The value also remains in AWS Secrets Manager (unchanged) — that path is consumed by `platform-secrets` chart ExternalSecrets later in the bootstrap, and continues to work independently.

## Azure parity (follow-up, not in this PR)

A subsequent ADR + PR should migrate the Azure flow to write the same K8s Secret field, eliminating the `az CLI` dependency in `params.py`. Cloud-agnostic CLI is the goal. This PR does not touch Azure — fully backward compatible.

## Test plan

- [x] `terraform validate` passes
- [x] pre-commit hooks pass
- [ ] CI green
- [ ] cortex re-apply with `ref=v0.18.0` produces a plan where the only change on the K8s Secret is the new field; next `helm install` from the `estabilis upstart` path (or a manual install replicating the CLI values) can now pre-create `argocd-redis` Secret and skip the init Job

## Release path

Squash-merge → manual tag `v0.18.0` (regex bug `Estabilis/estabilis-platform-tools#188` still open).

## Related

- Estabilis/estabilis-platform#76, #77, #78 — the v0.17.x series that unblocked the first AWS seed
- Upcoming ADR/issue: Azure migration from `az CLI` lookup to K8s Secret field (cloud-agnostic CLI path)