### PR TITLE
fix(argocd): override repoServer livenessProbe path to /healthz (v0.17.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog
 
+## [0.17.3] - 2026-04-24
+
+### Fixed — `argocd-repo-server` CrashLoopBackOff on fresh clusters
+
+The upstream `argo-cd` chart v9.x defaults the `repoServer.livenessProbe`
+to `GET /healthz?full=true` on port `metrics` (8084). The `?full=true`
+handler does cascading checks across Redis, Git backends, and the repo
+cache. On a cluster where no Applications have been configured yet
+(the very first seed window), one of those sub-checks hangs without
+an internal timeout, and the handler simply never returns.
+
+Consequence: every kubelet poll of the liveness probe times out,
+kubelet kills the container, kubelet restarts it — CrashLoopBackOff
+with exit code 0 ("Completed" / "clean shutdown"), confusing to read
+because the process is not crashing, it is being SIGTERM'd for
+health-check failure.
+
+Observed on cortex EKS seed 2026-04-24 (MNG `t3a.medium` / `t3.medium`
+nodes). On Azure AKS with `Standard_D2s_v5`-class nodes the symptom
+does not appear — consistent CPU (no burst credits) + the
+`replicas: 2` override mean probe noise is absorbed. AWS burstable
+MNGs expose the latent bug.
+
+### Fix
+
+`core/components/argocd/values.yaml` overrides the `repoServer`
+livenessProbe to use the plain `/healthz` endpoint (not `?full=true`),
+with `timeoutSeconds: 5` and `initialDelaySeconds: 30`. The readiness
+probe keeps the full check (where "subsystems ready" is the right
+semantic) but with `timeoutSeconds: 10` to absorb slow cold-starts.
+
+Semantic split:
+- **Liveness** = "is the process responsive" → plain `/healthz`
+- **Readiness** = "are all subsystems ready" → `/healthz?full=true`
+
+This is how most ArgoCD deployments configure it in production; the
+chart's default choice of `?full=true` for liveness is arguably a
+chart bug, but overriding at the platform level keeps us unblocked.
+
+### Where this fix applies
+
+`core/components/argocd/values.yaml` is the file consumed by the
+`argocd` Application rendered by `platform-root` (self-managed ArgoCD).
+Once platform-root syncs the `argocd` Application after bootstrap, the
+self-manage apply of these values fixes the probe for the steady
+state.
+
+The **bootstrap window** (helm install before ArgoCD takes over via
+self-manage) still uses the CLI's inline `seed_values` in
+`estabilis-platform-tools/src/estabilis/kubernetes.py:_helm_install_argocd`,
+which does NOT carry this override. That window is the vulnerable
+one on AWS — a complementary patch in the tools repo is tracked
+separately.
+
+### Files
+
+- `core/components/argocd/values.yaml`: add `repoServer.livenessProbe`
+  and `repoServer.readinessProbe` blocks.
+- `CHANGELOG.md`: v0.17.3 entry.
+
+### Migration
+
+Existing clusters on v0.17.2 pick up the fix on the next
+`estabilis promote` (or equivalent platform-root refresh) once bumped
+to `v0.17.3`. No destroy of the repo-server Deployment — the
+Deployment is patched in place with new probe config on the next
+ArgoCD reconcile.
+
 ## [0.17.2] - 2026-04-24
 
 ### Fixed — MNG `node_group_name_prefix` overflow + Karpenter outputs under `hybrid` mode

--- a/core/components/argocd/values.yaml
+++ b/core/components/argocd/values.yaml
@@ -177,6 +177,28 @@ repoServer:
         cpu: 50m
         memory: 64Mi
 
+  # Liveness probe override — use the plain `/healthz` endpoint instead
+  # of the chart default `/healthz?full=true`. The `?full=true` handler
+  # does cascading checks through Redis + Git backends + repo cache;
+  # on fresh clusters or CPU-burstable nodes it can hang indefinitely
+  # (observed 2026-04-24 on cortex EKS, MNG t3a.medium nodes: handler
+  # never returned, every poll timed out → CrashLoopBackOff). Liveness
+  # semantic is "is the process responsive" — the plain path is correct;
+  # the full check belongs in readiness.
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: metrics
+      scheme: HTTP
+    timeoutSeconds: 5
+    initialDelaySeconds: 30
+    periodSeconds: 10
+  readinessProbe:
+    # Keep the full check on readiness (where "subsystems ready" is the
+    # right semantic), but relax the timeout so a slow cold-start or
+    # burst-credit-drained node does not churn through restarts.
+    timeoutSeconds: 10
+
 redis:
   serviceAccount:
     create: true


### PR DESCRIPTION
## Summary

The upstream `argo-cd` chart v9.x defaults the `repoServer.livenessProbe` to `GET /healthz?full=true` on port `metrics` (8084). The `?full=true` handler does cascading checks across Redis, Git backends, and the repo cache. **On a cluster where no Applications have been configured yet (the bootstrap window), one of those sub-checks hangs indefinitely** and the handler never returns.

Consequence: every kubelet poll of the liveness probe times out, kubelet SIGTERMs the container, restart loop — `CrashLoopBackOff` with exit code 0 ("Completed"), confusing because the process is not crashing, it's being killed for health-check failure.

Observed 2026-04-24 on cortex EKS seed (MNG `t3a.medium` / `t3.medium` nodes).

## Evidence

Confirmed via port-forward test from inside the cluster:

```
GET http://.../healthz               → "ok" in 0.84s  ✅
GET http://.../healthz?full=true     → timeout after 15s  ❌
GET http://.../metrics               → normal  ✅
```

Handler `?full=true` simply doesn't return in the fresh-cluster state.

## Why Azure didn't show this

Azure `Standard_D2s_v5`-class nodes have consistent CPU (no burst throttle) and the `replicas: 2` override in the same values file means probe noise is absorbed by the second pod. AWS burstable MNGs (`t3a.medium`/`t3.medium`) expose the latent bug during the bootstrap window, before Applications are configured.

## Fix

`core/components/argocd/values.yaml` overrides `repoServer.livenessProbe` to use the plain `/healthz`:

```yaml
repoServer:
  livenessProbe:
    httpGet:
      path: /healthz         # ← was /healthz?full=true (chart default)
      port: metrics
      scheme: HTTP
    timeoutSeconds: 5
    initialDelaySeconds: 30
    periodSeconds: 10
  readinessProbe:
    timeoutSeconds: 10
```

**Semantic split:** liveness = "is the process responsive" → plain `/healthz`. Readiness = "are all subsystems ready" → can keep `?full=true` with relaxed timeout. The chart's default of putting `?full=true` on liveness is arguably a chart bug, but overriding at the platform level keeps us unblocked.

## Scope of the fix

This patch covers the **steady state** — once `platform-root` syncs the `argocd` Application, self-manage applies this values file and the probe is corrected.

**The bootstrap window** (helm install BEFORE ArgoCD self-manage via platform-root) still uses the CLI's inline `seed_values` in `estabilis-platform-tools/src/estabilis/kubernetes.py:_helm_install_argocd`, which does NOT carry this override. That window needs a complementary patch in the tools repo (tracked separately; out of scope for this PR).

For the cortex cluster currently mid-seed, a manual `helm upgrade --values /tmp/argocd-values.yaml` (with the same probe override) is unblocking the bootstrap window right now.

## Migration

Existing clusters on v0.17.2 pick up the fix on the next `estabilis promote` after bumping to `v0.17.3`. No destroy — the repo-server Deployment is patched in place on the next ArgoCD reconcile.

## Test plan

- [x] pre-commit hooks pass
- [ ] CI green
- [ ] cortex: after bumping client to `ref=v0.17.3` and running `estabilis promote`, the argocd-repo-server Deployment shows `livenessProbe.httpGet.path: /healthz` (no `?full=true`) and restartCount stays stable

## Release path

Squash-merge → manual tag `v0.17.3` (auto-tag regex bug `Estabilis/estabilis-platform-tools#188` still open).

## Related

- `Estabilis/estabilis-platform-tools` (follow-up): patch `_helm_install_argocd` seed_values to carry the same override during the bootstrap window
- Cortex-Innovation/cortex-platform-aws-us-east-1-prd seed — real-world reproducer for this patch