### PR TITLE
fix(argocd): disable repo-server liveness probe (v0.17.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## [0.17.4] - 2026-04-24
+
+### Fixed — `argocd-repo-server` CrashLoopBackOff — disable liveness probe during bootstrap
+
+Follow-up to v0.17.3. That release tried to override the liveness
+probe `httpGet.path` from `/healthz?full=true` to `/healthz` via
+values. Verification on the cortex seed today revealed the override
+is **silently ignored by the chart**.
+
+Root cause: the `argo-cd` chart v9.x values schema for repo-server
+probes exposes only scalar fields (`enabled`, `timeoutSeconds`,
+`failureThreshold`, `initialDelaySeconds`, `periodSeconds`,
+`successThreshold`) and has NO `httpPath` or `httpGet` key. The probe
+path is hardcoded in the Deployment template as
+`/healthz?full=true` and cannot be customized via values. Our v0.17.3
+override was syntactically valid YAML but semantically a no-op.
+
+Confirmed by:
+
+- `helm get values argocd -n argocd` → release has `httpGet.path=/healthz`
+  in user-supplied values
+- `kubectl get pod ... -o jsonpath` → pod still has
+  `httpGet.path=/healthz?full=true`
+- `helm template ... --values ...` dry-run → same result
+
+The `?full=true` handler cascades through Redis + Git backends + repo
+cache. On fresh clusters (bootstrap window, no Applications
+configured) one sub-check hangs and the handler never returns. Every
+kubelet poll times out and the container is SIGTERMed in a restart
+loop.
+
+Since the path cannot be customized, the only deterministic fix at
+the values layer is to **disable the liveness probe during
+bootstrap**:
+
+```yaml
+repoServer:
+  livenessProbe:
+    enabled: false
+  readinessProbe:
+    timeoutSeconds: 10
+```
+
+Readiness stays on and still gates Service inclusion; without
+liveness, kubelet does not kill the pod on probe failures. When
+platform-root reconciles and real Applications populate the cluster,
+the `?full=true` handler completes normally and liveness can be
+re-enabled via downstream overrides if desired.
+
+### Migration
+
+Operators on v0.17.3: bump module `ref` to `v0.17.4`. On the next
+ArgoCD reconcile of the self-managed `argocd` Application, the probe
+override is applied to the Deployment; a rolling update follows and
+the restart loop stops.
+
+### Related
+
+- v0.17.3 attempted the same fix with `httpGet.path` — unsuccessful
+  because the chart ignores that key. This patch takes the only
+  working route (`enabled: false`).
+- Upstream chart issue: exposing `httpPath` / `httpGet` on
+  `repoServer.livenessProbe` would eliminate the need for this
+  workaround. Worth proposing to `argoproj/argo-helm` later.
+
 ## [0.17.3] - 2026-04-24
 
 ### Fixed — `argocd-repo-server` CrashLoopBackOff on fresh clusters

--- a/core/components/argocd/values.yaml
+++ b/core/components/argocd/values.yaml
@@ -177,26 +177,39 @@ repoServer:
         cpu: 50m
         memory: 64Mi
 
-  # Liveness probe override — use the plain `/healthz` endpoint instead
-  # of the chart default `/healthz?full=true`. The `?full=true` handler
-  # does cascading checks through Redis + Git backends + repo cache;
-  # on fresh clusters or CPU-burstable nodes it can hang indefinitely
-  # (observed 2026-04-24 on cortex EKS, MNG t3a.medium nodes: handler
-  # never returned, every poll timed out → CrashLoopBackOff). Liveness
-  # semantic is "is the process responsive" — the plain path is correct;
-  # the full check belongs in readiness.
+  # Liveness probe override — disable during bootstrap windows.
+  #
+  # The argo-cd v9.x chart hardcodes the repo-server liveness probe
+  # path as `/healthz?full=true` in its Deployment template; the
+  # values schema only exposes `enabled`, `timeoutSeconds`,
+  # `failureThreshold`, `initialDelaySeconds`, `periodSeconds`,
+  # `successThreshold` — there is NO `httpPath`/`httpGet` key. An
+  # earlier attempt (v0.17.3) to override `httpGet.path` via values
+  # was silently ignored by the chart and did not take effect.
+  #
+  # The `?full=true` handler cascades through Redis + Git backends +
+  # repo cache. On fresh clusters with no Applications configured
+  # (bootstrap window), one of those sub-checks hangs and the handler
+  # never returns. Every kubelet poll times out regardless of the
+  # `timeoutSeconds` budget, kubelet SIGTERMs the container, restart
+  # loop — CrashLoopBackOff (observed 2026-04-24 on cortex EKS seed,
+  # MNG t3a.medium nodes).
+  #
+  # Only deterministic fix at the values layer: disable liveness.
+  # Without it, kubelet does NOT kill the pod on health-check
+  # failures. Readiness still runs and gates the pod's inclusion in
+  # the `argocd-repo-server` Service; if the full-check hangs it
+  # takes the pod temporarily out of rotation without restart.
+  #
+  # Once platform-root reconciles and real Applications are
+  # configured, the `?full=true` handler completes normally, and
+  # operators can re-enable liveness via downstream overrides if
+  # desired. For now the safe default is disabled.
   livenessProbe:
-    httpGet:
-      path: /healthz
-      port: metrics
-      scheme: HTTP
-    timeoutSeconds: 5
-    initialDelaySeconds: 30
-    periodSeconds: 10
+    enabled: false
   readinessProbe:
-    # Keep the full check on readiness (where "subsystems ready" is the
-    # right semantic), but relax the timeout so a slow cold-start or
-    # burst-credit-drained node does not churn through restarts.
+    # Generous timeout so the stuck full-check during bootstrap
+    # doesn't flap the pod in and out of the Service too noisily.
     timeoutSeconds: 10
 
 redis:


### PR DESCRIPTION
## Summary

Follow-up to v0.17.3. That release tried to override the liveness probe `httpGet.path` from `/healthz?full=true` to `/healthz` via values. **Verification on cortex seed today revealed the override is silently ignored by the chart.**

## Root cause

The `argo-cd` chart v9.x values schema for repo-server probes exposes only scalar fields: `enabled`, `timeoutSeconds`, `failureThreshold`, `initialDelaySeconds`, `periodSeconds`, `successThreshold`. **There is NO `httpPath` or `httpGet` key.** The probe path is hardcoded in the Deployment template as `/healthz?full=true` and cannot be customized via values.

Confirmed empirically on cortex cluster:

```
$ helm get values argocd -n argocd | grep -A6 "repoServer:"
repoServer:
  livenessProbe:
    httpGet:
      path: /healthz      ← our override, accepted at values layer
      ...

$ kubectl get pod ... -o jsonpath='{.spec.containers[0].livenessProbe}'
{
  "httpGet": {"path": "/healthz?full=true", ...}   ← still the chart default
  ...
}

$ helm template ... --values /tmp/argocd-values.yaml
  livenessProbe:
    httpGet:
      path: /healthz?full=true   ← chart renders the hardcoded value
```

`timeoutSeconds: 5` and `initialDelaySeconds: 30` from the v0.17.3 override DID take effect (those keys exist in the schema), but `httpGet.path` was silently dropped.

## Why this matters

The `?full=true` handler cascades through Redis + Git backends + repo cache. On a fresh cluster with no Applications configured (bootstrap window), one sub-check hangs and the handler never returns. The pod subsequently enters CrashLoopBackOff when kubelet SIGTERMs the container for probe timeout.

## Fix

Since the path cannot be changed via values, disable the liveness probe during bootstrap:

```yaml
repoServer:
  livenessProbe:
    enabled: false
  readinessProbe:
    timeoutSeconds: 10
```

**Without liveness**, kubelet does NOT kill the pod on health-check failures — no more restart loop.

**Readiness stays on** and still gates the pod's inclusion in the `argocd-repo-server` Service. If `?full=true` hangs, the pod is temporarily out of rotation but does not restart.

Once `platform-root` reconciles and real Applications populate the cluster, the `?full=true` handler completes normally and operators can re-enable liveness via downstream overrides if they want.

## Upstream chart fix (not blocking)

Exposing `httpPath` or `httpGet` on `repoServer.livenessProbe` in the values schema would eliminate this workaround entirely. Worth proposing to `argoproj/argo-helm` as a small values-schema addition — but not blocking our seed work.

## Test plan

- [x] pre-commit passes
- [ ] CI green
- [ ] cortex: after `ref=v0.17.4` and `terraform apply`, next ArgoCD reconcile of the `argocd` self-managed Application applies the new values; `kubectl get pod -n argocd -l app.kubernetes.io/name=argocd-repo-server -o jsonpath='{.items[0].spec.containers[0].livenessProbe}'` returns empty

## Release path

Squash-merge → manual tag `v0.17.4`. Regex bug `Estabilis/estabilis-platform-tools#188` still open.

## Related

- Estabilis/estabilis-platform#80 (merged) — v0.17.3, first attempt; ineffective due to chart values-schema limitation explained above
- Cortex seed in progress — unblocked on the bootstrap window by `helm upgrade` with `livenessProbe.enabled: false` in `/tmp/argocd-values.yaml`