### PR TITLE
fix(aws): attach cluster primary SG to MNG nodes (v0.17.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,68 @@
 # Changelog
 
+## [0.17.5] - 2026-04-24
+
+### Fixed — MNG nodes lose DNS to Fargate pods (CoreDNS, ArgoCD)
+
+The `terraform-aws-modules/eks/aws` module defaults
+`attach_cluster_primary_security_group = false` on managed node
+groups. Without that attachment, MNG ENIs receive only the module's
+`-node` shared security group — a DIFFERENT SG from the `eks-cluster-sg-*`
+that EKS auto-creates and attaches to Fargate pod ENIs.
+
+Consequence: traffic between MNG pods and Fargate pods (including
+CoreDNS which runs on Fargate by default) is not in the same intra-
+cluster trust boundary. DNS queries from MNG pods time out because
+the `kube-dns` service endpoints are Fargate ENIs on a different SG.
+**Every service lookup by name breaks** when originated from an MNG
+pod: Application Controller can't reach `argocd-redis` or
+`argocd-repo-server`, platform-root stalls with "ComparisonError: dns:
+A record lookup error".
+
+Observed 2026-04-24 on the cortex seed: `nslookup
+kubernetes.default.svc.cluster.local` from a debug pod on an MNG
+node → "connection timed out; no servers could be reached". CoreDNS
+itself was Ready and responsive — the path from MNG ENI to Fargate
+ENI was blocked at the SG layer.
+
+The legacy `cortex-eks-prod` cluster (provisioned outside this
+module) works because its MNG nodes were attached to the EKS
+cluster primary SG directly. Our module-provisioned MNGs were not.
+
+### Fix
+
+Set `attach_cluster_primary_security_group = true` on the `default`
+MNG block in `eks.tf`. The next `terraform apply` updates the MNG
+launch template; the MNG rolls nodes (brief ~2min drain/replace) so
+new ENIs receive both the node SG and the cluster primary SG.
+
+```hcl
+eks_managed_node_groups = {
+  default = {
+    ...
+    attach_cluster_primary_security_group = true
+  }
+}
+```
+
+### Migration
+
+Operators on v0.17.4 on AWS with MNG (`autoscaler = "hybrid"` or
+`"cluster_autoscaler"`): bump module `ref` to `v0.17.5`, run
+`terraform plan`. Expected plan diff: the MNG launch template adds
+the cluster primary SG to `vpc_security_group_ids`. Apply triggers a
+rolling update of MNG nodes; brief pod reschedule across nodes but
+no cluster-wide disruption because Fargate-hosted system workloads
+(CoreDNS, ebs-csi-controller, etc.) stay up. Post-apply, DNS
+resolution from MNG pods works.
+
+### Related
+
+- Estabilis/estabilis-platform#76 — v0.17.0, introduced `hybrid`
+  autoscaler (MNG + Karpenter); this patch is the missing piece that
+  lets MNG pods integrate with Fargate-hosted system services
+- Cortex seed 2026-04-24 — real-world reproducer
+
 ## [0.17.4] - 2026-04-24
 
 ### Fixed — `argocd-repo-server` CrashLoopBackOff — disable liveness probe during bootstrap

--- a/providers/aws/eks.tf
+++ b/providers/aws/eks.tf
@@ -215,6 +215,25 @@ module "eks" {
       iam_role_use_name_prefix = false
       iam_role_name            = "${local.cluster_name}-default-node"
 
+      # Attach the EKS cluster primary security group to the MNG nodes.
+      # Without this, the MNG ENIs only receive the module's node
+      # shared SG, which is a DIFFERENT SG from the cluster primary
+      # (the SG EKS auto-creates and attaches to Fargate pod ENIs).
+      # Result: traffic between MNG pods and Fargate pods (including
+      # CoreDNS!) is not in the same intra-cluster trust boundary,
+      # and DNS queries from MNG pods time out because the kube-dns
+      # service endpoints are Fargate ENIs using a different SG.
+      #
+      # Observed on cortex seed 2026-04-24: DNS fully broken from
+      # MNG pods, ArgoCD Application Controller unable to reach
+      # argocd-redis or repo-server by service name, platform-root
+      # stuck in "ComparisonError: dns: A record lookup error".
+      #
+      # The legacy cortex-eks-prod cluster (provisioned outside this
+      # module) works because its MNG nodes end up with the cluster
+      # primary SG attached directly.
+      attach_cluster_primary_security_group = true
+
       labels = {
         "estabilis.io/workload-type" = "platform"
         "estabilis.io/pool-type"     = "regular"


### PR DESCRIPTION
## Summary

`terraform-aws-modules/eks/aws` defaults `attach_cluster_primary_security_group = false` on managed node groups. Without it, MNG ENIs only receive the module's `-node` shared SG — a DIFFERENT SG from the `eks-cluster-sg-*` that EKS auto-creates and attaches to Fargate pod ENIs.

**Consequence:** traffic between MNG pods and Fargate pods (including CoreDNS) is not in the same intra-cluster trust boundary at the SG layer. DNS queries from MNG pods time out because `kube-dns` Endpoints resolve to Fargate ENIs on a different SG.

## Evidence from cortex seed (2026-04-24)

```bash
$ kubectl exec -n default dns-debug-mng -- nslookup kubernetes.default.svc.cluster.local
;; connection timed out; no servers could be reached

$ # MNG node ENI SGs
$ aws ec2 describe-instances ... --query '...NetworkInterfaces[0].Groups[].Id'
["sg-06f3ed8922600bdc8"]   # eks-cortex-platform-prd-us-east-1-node-...

$ # Fargate pod ENI SGs
$ aws ec2 describe-network-interfaces --filters "Name=addresses.private-ip-address,Values=<coredns-ip>"
SGs: ["sg-08c3da1a6628e31e5"]   # eks-cluster-sg-...   ← different SG!
```

Legacy `cortex-eks-prod` cluster (outside this module) does NOT have the issue — its MNG nodes carry the cluster primary SG directly.

## Fix

One-line addition to the `default` MNG block in `eks.tf`:

```hcl
eks_managed_node_groups = {
  default = {
    ...
    attach_cluster_primary_security_group = true
  }
}
```

## Plan expectations

- Launch template of the `default` MNG gets the cluster primary SG added to `vpc_security_group_ids`
- MNG rolls nodes (terminate + replace with new launch template spec) — typical ~2 min drain
- Brief pod reschedule across nodes, but no cluster-wide disruption (Fargate-hosted system workloads stay up)
- Post-apply: DNS from MNG pods resolves normally, ArgoCD Application Controller can reach services by name

## Test plan

- [x] `terraform validate` passes
- [x] pre-commit hooks pass
- [ ] CI green
- [ ] cortex: after bump to `v0.17.5` + `terraform apply`, verify via in-cluster debug pod that `nslookup kubernetes.default` succeeds and platform-root Application transitions out of `ComparisonError`

## Release path

Squash-merge → manual tag `v0.17.5` (regex bug `Estabilis/estabilis-platform-tools#188` still open).

## Related

- Estabilis/estabilis-platform#76 — v0.17.0 introduced `hybrid` (MNG + Karpenter); this patch is the missing piece for MNG pods to integrate with Fargate-hosted system services
- Cortex-Innovation/cortex-platform-aws-us-east-1-prd seed — real-world reproducer