### PR TITLE
feat(github): cloud-agnostic github-app-credentials module + AWS caller (v0.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,92 @@
 # Changelog
 
+## [0.18.0] - 2026-04-24
+
+### Added — `modules/github-app-credentials/` (cloud-agnostic) + AWS caller
+
+Organization-scoped GitHub App authentication for ArgoCD git access,
+managed by Terraform. Introduces a transversal module plus the AWS
+provider wiring that makes it usable today. Azure/GCP callers will
+follow the same shape in subsequent releases.
+
+#### Why GitHub App (vs. PAT or deploy keys)
+
+- Belongs to the GitHub organization — **not user-scoped**. When the
+  user who set up the credential leaves the org, the App keeps working.
+- One install covers N repos; **scales to multi-repo clients**.
+- Fine-grained permissions: `Contents: Read-only` is enough.
+- ArgoCD renews installation tokens (1h TTL) automatically — **no
+  external rotation infrastructure needed**.
+
+Deploy keys (per-repo) and per-user PATs are viable fallbacks but don't
+scale or survive personnel changes. Pattern used by the legacy
+`cortex-eks-prod` cluster pinned an SSH key to a specific user account,
+which this release supersedes going forward.
+
+#### Module: `modules/github-app-credentials/`
+
+Cloud-agnostic. Creates one Kubernetes Secret with the
+`argocd.argoproj.io/secret-type: repo-creds` label, carrying
+`githubAppID`, `githubAppInstallationID`, `githubAppPrivateKey`, and a
+normalized `url`. ArgoCD matches repos by URL prefix — one credential
+template covers every repo under the org.
+
+Inputs:
+- `github_app_id`, `github_app_installation_id` (numeric IDs)
+- `github_app_private_key` (PEM, sensitive, validated)
+- `github_org_url` (e.g. `https://github.com/Cortex-Innovation`)
+- `namespace` (default `argocd`), `secret_name` (default derived from org slug)
+
+Outputs: `secret_name`, `namespace`, `org_slug`.
+
+#### AWS wiring: `providers/aws/github-app.tf`
+
+Composes the module call with AWS Secrets Manager mirror:
+
+1. Module creates the in-cluster Kubernetes Secret ArgoCD reads.
+2. `aws_secretsmanager_secret.github_app_private_key` stores the PEM
+   under `${secrets_path_prefix}/platform-github-app-private-key` —
+   becomes source of truth for rotation + the handoff path for
+   ExternalSecrets once `platform-secrets` chart is reconciling.
+
+Both are gated on `github_app_private_key != ""`; a deployment that
+uses a different auth path (deploy keys, per-user PATs) can leave all
+four `github_app_*` variables empty and nothing is created.
+
+Cross-input validation via `null_resource` precondition: if any of the
+four `github_app_*` variables is set, all four must be set. Leaving
+all four empty disables the feature entirely.
+
+#### ConfigMap: new non-sensitive identifiers
+
+`providers/aws/platform-outputs.tf` exposes three new keys on the
+`platform-infrastructure` ConfigMap:
+
+- `global.githubAppID`
+- `global.githubAppInstallationID`
+- `global.githubOrgUrl`
+
+These are public identifiers (not secrets) needed by downstream charts
+(e.g. future `platform-secrets` ExternalSecret) to build the
+credential template shape. The PEM stays **only** in AWS Secrets
+Manager and the existing in-cluster Secret.
+
+### Migration
+
+- Operators who want to adopt GitHub App: create the App on the org
+  (see `modules/github-app-credentials/README.md` for step-by-step),
+  set the four `github_app_*` variables in `terraform.tfvars` (or
+  `secrets.auto.tfvars` for the private key), `terraform apply`.
+- Operators who stay on other auth paths: no change, no new resources.
+
+### Follow-up (tracked separately)
+
+- `providers/azure/` caller that mirrors to Key Vault — same shape.
+- `core/components/platform-secrets/` chart adds an ExternalSecret that
+  reconciles the K8s Secret from the SM/KV entry post-bootstrap,
+  enabling key rotation in the secret store to propagate without a
+  Terraform apply.
+
 ## [0.17.5] - 2026-04-24
 
 ### Fixed — MNG nodes lose DNS to Fargate pods (CoreDNS, ArgoCD)

--- a/modules/github-app-credentials/README.md
+++ b/modules/github-app-credentials/README.md
@@ -1,0 +1,88 @@
+# github-app-credentials
+
+Cloud-agnostic Terraform module that creates a Kubernetes Secret with the
+ArgoCD `repo-creds` credential-template label, carrying GitHub App
+installation identifiers and PEM-encoded private key.
+
+Once applied, any ArgoCD Application whose `repoURL` starts with the
+provided `github_org_url` uses the GitHub App installation token for
+authentication — no user-scoped PATs, no deploy keys per repo.
+
+## Why a GitHub App
+
+- **Not user-scoped**: the credential belongs to the organization, not to
+  a specific GitHub user. If the user who created it leaves the org, the
+  App (and this credential) continue working.
+- **Fine-grained permissions**: read-only access to `Contents` is enough.
+- **Automatic token rotation**: ArgoCD internally exchanges the JWT for
+  installation access tokens (1-hour TTL) and refreshes on expiry. No
+  external rotation infrastructure needed.
+- **Scales across repos**: one App installation can cover every repo in
+  the org, including new repos added later.
+
+## Inputs
+
+| Variable | Required | Description |
+|---|---|---|
+| `github_app_id` | yes | App ID (numeric) |
+| `github_app_installation_id` | yes | Installation ID (from the org install URL) |
+| `github_app_private_key` | yes | PEM-encoded private key (sensitive) |
+| `github_org_url` | yes | `https://github.com/<org>` (no trailing path) |
+| `namespace` | no (default `argocd`) | Kubernetes namespace for the Secret |
+| `secret_name` | no | Override the default `github-app-<slug>` name |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `secret_name` | Name of the created Secret |
+| `namespace` | Namespace of the Secret |
+| `org_slug` | Derived lowercased slug of the org |
+
+## Usage
+
+```hcl
+module "github_app" {
+  source = "../../modules/github-app-credentials"
+
+  github_app_id              = var.github_app_id
+  github_app_installation_id = var.github_app_installation_id
+  github_app_private_key     = var.github_app_private_key
+  github_org_url             = "https://github.com/Cortex-Innovation"
+}
+```
+
+The caller is responsible for mirroring the private key into whichever
+cloud secret store is appropriate (AWS Secrets Manager, Azure Key Vault,
+GCP Secret Manager, ...) for audit, rotation, and disaster recovery.
+That intentionally lives outside this module — the module owns only the
+rendering of the Kubernetes-side credential.
+
+## How to create the GitHub App
+
+1. Navigate to `https://github.com/organizations/<org>/settings/apps/new`
+2. Set a unique name (e.g. `estabilis-argocd-<client>`)
+3. Disable the webhook (uncheck "Active")
+4. Repository permissions: `Contents: Read-only`, `Metadata: Read-only`
+5. Organization / Account permissions: all `No access`
+6. Scope: "Only on this account"
+7. Create the App and note the **App ID**
+8. On the App settings page, scroll to "Private keys" and generate one —
+   download the `.pem` file
+9. In the sidebar, click "Install App" → install on the org →
+   "Only select repositories" → pick the repos that need ArgoCD access
+10. The post-install URL contains the **Installation ID**:
+    `https://github.com/organizations/<org>/settings/installations/<ID>`
+
+Pass the three values (App ID, Installation ID, PEM contents) into the
+module.
+
+## What this module does NOT do
+
+- Does not create the GitHub App itself (GitHub has no public API for
+  that — manifest-based OAuth flow is close but still needs browser
+  handshake)
+- Does not install the App on repos (manual or via the GitHub API
+  outside Terraform)
+- Does not handle rotation of the GitHub App private key (rare
+  operation — follow the usual credential rotation runbook)

--- a/modules/github-app-credentials/main.tf
+++ b/modules/github-app-credentials/main.tf
@@ -1,0 +1,54 @@
+# ---------------------------------------------------------------------------
+# github-app-credentials module — main
+#
+# Creates a Kubernetes Secret with the ArgoCD repo-creds label, carrying
+# a GitHub App's installation identifiers + PEM-encoded private key.
+# ArgoCD internally exchanges (app_id, installation_id, private_key) for
+# installation access tokens (1-hour TTL, auto-renewed on expiry) when
+# cloning any repository under the matching org URL.
+#
+# Reference: https://argo-cd.readthedocs.io/en/stable/user-guide/private-repositories/#github-app-credential
+# ---------------------------------------------------------------------------
+
+locals {
+  # Extract the organization slug from the URL (e.g. "Cortex-Innovation"
+  # from "https://github.com/Cortex-Innovation") and lowercase it for
+  # RFC 1123 compatibility of the Kubernetes Secret name.
+  org_slug_raw   = regex("^https://github\\.com/([^/]+)/?$", var.github_org_url)[0]
+  org_slug       = lower(replace(local.org_slug_raw, "_", "-"))
+  effective_name = var.secret_name != "" ? var.secret_name : "github-app-${local.org_slug}"
+
+  # Normalize URL (strip trailing slash if present) — ArgoCD prefix
+  # matching is exact up to the first `/` after the host.
+  normalized_url = replace(var.github_org_url, "/+$", "")
+}
+
+resource "kubernetes_secret" "repo_creds" {
+  metadata {
+    name      = local.effective_name
+    namespace = var.namespace
+
+    labels = {
+      # Credential template — ArgoCD matches repos by URL prefix and
+      # applies this credential. Distinct from `secret-type: repository`
+      # (which registers a specific repo); `repo-creds` is a template.
+      "argocd.argoproj.io/secret-type" = "repo-creds"
+      "app.kubernetes.io/managed-by"   = "terraform"
+      "app.kubernetes.io/part-of"      = "estabilis-platform"
+      "estabilis.io/component"         = "github-app-credentials"
+    }
+  }
+
+  type = "Opaque"
+
+  # Using data (not string_data) so Terraform plan diffs stay stable
+  # across runs — string_data always shows as a change even when the
+  # value hasn't moved.
+  data = {
+    type                    = "git"
+    url                     = local.normalized_url
+    githubAppID             = var.github_app_id
+    githubAppInstallationID = var.github_app_installation_id
+    githubAppPrivateKey     = var.github_app_private_key
+  }
+}

--- a/modules/github-app-credentials/outputs.tf
+++ b/modules/github-app-credentials/outputs.tf
@@ -1,0 +1,14 @@
+output "secret_name" {
+  description = "Name of the Kubernetes Secret created. Useful for downstream references (e.g. ExternalSecret target when migrating to cloud-store-driven reconciliation)."
+  value       = kubernetes_secret.repo_creds.metadata[0].name
+}
+
+output "namespace" {
+  description = "Namespace where the Secret was created."
+  value       = kubernetes_secret.repo_creds.metadata[0].namespace
+}
+
+output "org_slug" {
+  description = "Lowercased organization slug derived from github_org_url. Useful for composing related resource names in the caller."
+  value       = local.org_slug
+}

--- a/modules/github-app-credentials/variables.tf
+++ b/modules/github-app-credentials/variables.tf
@@ -1,0 +1,68 @@
+# ---------------------------------------------------------------------------
+# github-app-credentials module — inputs
+#
+# Cloud-agnostic module that creates the Kubernetes Secret ArgoCD reads for
+# authentication against a GitHub organization via GitHub App installation
+# tokens. The secret carries the credential-template label
+# (argocd.argoproj.io/secret-type: repo-creds) with the org URL as `url`,
+# so ArgoCD matches it as credentials for any repository under that org.
+#
+# The module touches ONLY the Kubernetes cluster — no cloud-specific
+# resources. Each provider (providers/aws/, providers/azure/, ...) is
+# expected to additionally mirror the private key into its own cloud
+# secret store for rotation / audit / recovery (see the caller in
+# providers/aws/github-app.tf as reference).
+# ---------------------------------------------------------------------------
+
+variable "github_app_id" {
+  description = "GitHub App ID (numeric). Found at the top of the App's Developer Settings page after creation."
+  type        = string
+
+  validation {
+    condition     = length(var.github_app_id) > 0
+    error_message = "github_app_id is required."
+  }
+}
+
+variable "github_app_installation_id" {
+  description = "GitHub App Installation ID (numeric). Found in the URL of the installation page after installing the App on an organization: https://github.com/organizations/<org>/settings/installations/<ID>."
+  type        = string
+
+  validation {
+    condition     = length(var.github_app_installation_id) > 0
+    error_message = "github_app_installation_id is required."
+  }
+}
+
+variable "github_app_private_key" {
+  description = "PEM-encoded private key downloaded from the GitHub App 'Private keys' section. Must include the standard PEM header/footer markers. Sensitive."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = can(regex("BEGIN.*PRIVATE KEY", var.github_app_private_key))
+    error_message = "github_app_private_key must be a PEM-encoded key."
+  }
+}
+
+variable "github_org_url" {
+  description = "Organization URL used as the `url` field in the ArgoCD repo-creds Secret. ArgoCD matches repository URLs by prefix — any repo under this org inherits the credential. Example: 'https://github.com/Cortex-Innovation'."
+  type        = string
+
+  validation {
+    condition     = can(regex("^https://github\\.com/[^/]+/?$", var.github_org_url))
+    error_message = "github_org_url must be in the form https://github.com/<org> (no trailing path)."
+  }
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace where the Secret is created. ArgoCD reads credential templates from its own namespace, so this typically matches the ArgoCD install namespace."
+  type        = string
+  default     = "argocd"
+}
+
+variable "secret_name" {
+  description = "Name of the Kubernetes Secret. When empty, derived as 'github-app-<lowercased-org-slug>' from github_org_url."
+  type        = string
+  default     = ""
+}

--- a/modules/github-app-credentials/versions.tf
+++ b/modules/github-app-credentials/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.30"
+    }
+  }
+}

--- a/providers/aws/github-app.tf
+++ b/providers/aws/github-app.tf
@@ -1,0 +1,73 @@
+# ---------------------------------------------------------------------------
+# GitHub App credentials for ArgoCD — AWS-side wiring.
+#
+# Composed of two pieces:
+#
+#  1. modules/github-app-credentials/ creates the in-cluster Kubernetes
+#     Secret ArgoCD reads (cloud-agnostic — same module is used by
+#     providers/azure/, providers/gcp/, ...).
+#
+#  2. AWS Secrets Manager stores the PEM as source-of-truth for audit
+#     and rotation. When platform-secrets chart is in place (post-seed),
+#     ExternalSecrets Operator reconciles the Kubernetes Secret with the
+#     SM entry — rotation in SM propagates to the K8s Secret within the
+#     refresh interval without a Terraform apply.
+#
+# Both parts are gated on `github_app_private_key != ""` so a deployment
+# that opts for a different auth path (deploy keys, per-user PATs) can
+# leave all four github_app_* variables empty and nothing is created.
+# ---------------------------------------------------------------------------
+
+# Validation that composes across multiple inputs — can't live in a
+# single variable's validation block because it needs to inspect several
+# values.
+resource "null_resource" "github_app_vars_validation" {
+  count = var.github_app_id != "" || var.github_app_installation_id != "" || var.github_app_private_key != "" || var.github_org_url != "" ? 1 : 0
+
+  lifecycle {
+    precondition {
+      condition     = var.github_app_id != "" && var.github_app_installation_id != "" && var.github_app_private_key != "" && var.github_org_url != ""
+      error_message = "When using GitHub App authentication, all four of github_app_id, github_app_installation_id, github_app_private_key, and github_org_url must be set. Leave all four empty to disable."
+    }
+  }
+}
+
+module "github_app_credentials" {
+  count  = var.github_app_private_key != "" && var.platform_outputs_enabled ? 1 : 0
+  source = "../../modules/github-app-credentials"
+
+  github_app_id              = var.github_app_id
+  github_app_installation_id = var.github_app_installation_id
+  github_app_private_key     = var.github_app_private_key
+  github_org_url             = var.github_org_url
+  namespace                  = "argocd"
+
+  depends_on = [
+    kubernetes_namespace.argocd,
+  ]
+}
+
+# ---------------------------------------------------------------------------
+# AWS Secrets Manager mirror — source of truth for ExternalSecrets
+# reconciliation post-bootstrap.
+# ---------------------------------------------------------------------------
+
+resource "aws_secretsmanager_secret" "github_app_private_key" {
+  count                   = var.github_app_private_key != "" ? 1 : 0
+  name                    = "${local.secrets_path_prefix}/platform-github-app-private-key"
+  kms_key_id              = aws_kms_key.platform_secrets.arn
+  recovery_window_in_days = var.secretsmanager_recovery_days
+}
+
+resource "aws_secretsmanager_secret_version" "github_app_private_key" {
+  count         = var.github_app_private_key != "" ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.github_app_private_key[0].id
+  secret_string = var.github_app_private_key
+}
+
+resource "aws_secretsmanager_secret_policy" "github_app_private_key" {
+  count               = var.github_app_private_key != "" && var.secretsmanager_resource_policy_enabled ? 1 : 0
+  secret_arn          = aws_secretsmanager_secret.github_app_private_key[0].arn
+  policy              = data.aws_iam_policy_document.platform_secret_policy[0].json
+  block_public_policy = true
+}

--- a/providers/aws/platform-outputs.tf
+++ b/providers/aws/platform-outputs.tf
@@ -112,6 +112,15 @@ resource "kubernetes_config_map" "platform_infrastructure" {
 
     # Hub Secrets Manager prefix (for workload-operator to publish hub-registrar-token)
     "hubSecretsPathPrefix" = var.shared_hub_secrets_enabled ? local.shared_hub_secrets_prefix_effective : ""
+
+    # GitHub App — non-sensitive identifiers. The App ID and Installation
+    # ID are public identifiers that ArgoCD needs to build installation
+    # tokens (paired with the private key from the Secret). The private
+    # key stays in AWS Secrets Manager and is never exposed in the
+    # ConfigMap.
+    "global.githubAppID"             = var.github_app_id
+    "global.githubAppInstallationID" = var.github_app_installation_id
+    "global.githubOrgUrl"            = var.github_org_url
   }
 }
 

--- a/providers/aws/variables.tf
+++ b/providers/aws/variables.tf
@@ -132,6 +132,39 @@ variable "client_gitops_repo_token" {
 }
 
 # ---------------------------------------------------------------------------
+# GitHub App — organization-scoped credential for ArgoCD git access.
+# Preferred over per-repo deploy keys or per-user PATs because the App
+# belongs to the GitHub organization (not a specific user), permissions
+# are fine-grained, and ArgoCD renews installation tokens automatically.
+# See modules/github-app-credentials/ for the full pattern.
+# ---------------------------------------------------------------------------
+
+variable "github_app_id" {
+  description = "GitHub App ID (numeric string). Leave empty to skip the ArgoCD GitHub App credential setup (fallback: config_repo_token / client_gitops_repo_token)."
+  type        = string
+  default     = ""
+}
+
+variable "github_app_installation_id" {
+  description = "GitHub App Installation ID (numeric string). Found in the URL after installing the App on the organization."
+  type        = string
+  default     = ""
+}
+
+variable "github_app_private_key" {
+  description = "PEM-encoded private key downloaded from the GitHub App settings. Pass via secrets.auto.tfvars or TF_VAR_github_app_private_key (do not commit). Sensitive."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "github_org_url" {
+  description = "Organization URL for GitHub App credential matching (ArgoCD matches repos by URL prefix). Example: 'https://github.com/Cortex-Innovation'. Required when github_app_id is set."
+  type        = string
+  default     = ""
+}
+
+# ---------------------------------------------------------------------------
 # EKS cluster
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Introduces `modules/github-app-credentials/` — a **cloud-agnostic** Terraform module that creates the Kubernetes Secret ArgoCD reads for GitHub App installation-token authentication. The module lives under `modules/` (not `providers/aws/`) because GitHub is a transversal SaaS provider that every cloud caller can consume.

Shipped alongside: `providers/aws/github-app.tf` composes the module with AWS Secrets Manager as the mirror for the private key. Azure / GCP callers will follow the same shape in subsequent releases.

## Why GitHub App (vs. PAT or deploy keys)

- **Not user-scoped** — App belongs to the GitHub organization. When the person who set up the credential leaves, the App keeps working.
- **Scales** — one install covers N repos in the org; adding a repo doesn't add a credential.
- **Fine-grained permissions** — `Contents: Read-only` is enough.
- **Automatic token rotation** — ArgoCD exchanges the JWT for 1-hour installation tokens and renews on expiry. No external rotation system needed.

The legacy `cortex-eks-prod` cluster pinned an SSH key to a specific user account — this release supersedes that approach for new deployments.

## Architecture — 3 layers cleanly separated

| Layer | Owner | Implementation |
|---|---|---|
| **Credential rendering** | `modules/github-app-credentials/` (universal) | `kubernetes_secret` with `argocd.argoproj.io/secret-type=repo-creds` label |
| **Cloud persistence** | `providers/<cloud>/github-app.tf` (per-cloud caller) | mirror PEM in cloud secret store (Secrets Manager / Key Vault / GCP Secret Manager) |
| **Continuous reconciliation** (post-bootstrap) | `core/components/platform-secrets/` chart (future) | ExternalSecret reconciles K8s Secret from cloud store; rotation propagates without `terraform apply` |

This release implements layer 1 (universal) + layer 2 (AWS only). Layer 3 is tracked as a follow-up when relevant.

## Files

### `modules/github-app-credentials/` (new, transversal)

- `main.tf` — `kubernetes_secret` + org-slug derivation from URL via `regex()`
- `variables.tf` — 4 inputs (`github_app_id`, `github_app_installation_id`, `github_app_private_key` sensitive, `github_org_url`) + 2 optional (`namespace`, `secret_name`)
- `outputs.tf` — `secret_name`, `namespace`, `org_slug` for callers to reference
- `versions.tf` — pins `kubernetes >= 2.30`, `terraform >= 1.9`
- `README.md` — usage + rationale + step-by-step GitHub App creation walkthrough

### `providers/aws/` (AWS caller — 3 file touches)

- `github-app.tf` (new):
  - `module "github_app_credentials"` call (creates K8s Secret)
  - `aws_secretsmanager_secret.github_app_private_key` + version + policy (mirror for ESO reconciliation later)
  - `null_resource.github_app_vars_validation` — cross-input precondition: if any of the four vars is set, all four must be set
- `variables.tf` — 4 new vars (`github_app_id`, `github_app_installation_id`, `github_app_private_key`, `github_org_url`), all default empty (feature opt-in)
- `platform-outputs.tf` — ConfigMap gains `global.githubAppID`, `global.githubAppInstallationID`, `global.githubOrgUrl` (non-sensitive identifiers)

### `CHANGELOG.md`

v0.18.0 entry documenting the rationale, architecture, and migration.

## Opt-in semantics

All four `github_app_*` variables default to empty. A deployment that uses a different auth path (deploy keys, per-user PATs) can leave them empty and **nothing is created** — no module call, no Secret, no SM entry. To enable: set all four (validation enforces the "all or nothing" rule).

## Test plan

- [x] `terraform init -upgrade` + `terraform validate` passes
- [x] pre-commit: fmt, validate, tflint, hygiene, gitleaks all green
- [ ] CI green
- [ ] cortex: set the four vars in `secrets.auto.tfvars` (gitignored); `terraform apply` shows: K8s Secret created (replaces the bootstrap-workaround Secret created manually), SM entry created, ConfigMap updated. `argocd` picks up the credential via label match.

## Release path

Squash-merge → manual tag `v0.18.0` (release regex bug `Estabilis/estabilis-platform-tools#188` still open).

## Related

- Cortex seed 2026-04-24 — real-world driver for this pattern
- Follow-up (not this PR): `providers/azure/` caller that mirrors to Key Vault; `core/components/platform-secrets/` chart ExternalSecret