### PR TITLE
fix(aws): ConfigMap key clientGitopsRevision -> clientGitopsRepoRevision (v0.18.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## [0.18.1] - 2026-04-24
+
+### Fixed — ConfigMap key mismatch: `clientGitopsRevision` → `clientGitopsRepoRevision`
+
+The AWS `platform-outputs.tf` wrote the client-gitops ref to the
+`platform-infrastructure` ConfigMap under the key `clientGitopsRevision`
+(no `Repo` in the middle). The `platform-root` chart expects
+`clientGitopsRepoRevision` (matching the pattern of
+`clientGitopsRepoUrl` + `clientGitopsRepoVersion`). See
+`bootstrap/platform-root/values.yaml:191` and
+`bootstrap/platform-root/templates/_helpers.tpl:120`.
+
+Result: when downstream operators pass the ConfigMap values through
+as Helm parameters (as the estabilis CLI and manual seed scripts
+both do), the key never lands on `.Values.clientGitopsRepoRevision`
+inside the chart. Combined with `clientGitopsRepoUrl` being set, the
+`platform-root.clientGitopsRefRequired` helper fires its `fail`:
+
+```
+execution error at (platform-root/templates/hub-client-apps.yaml:45:21):
+  clientGitopsRepoRevision (or legacy clientGitopsRepoVersion) is required
+  when clientGitopsRepoUrl is set
+```
+
+Observed 2026-04-24 on the cortex AWS seed: platform-root Application
+stuck in `ComparisonError` with exactly this helm template failure.
+
+### Fix
+
+Rename the key in `providers/aws/platform-outputs.tf` from
+`clientGitopsRevision` to `clientGitopsRepoRevision`. One-character-
+semantic change; no schema breakage for consumers because the old key
+was never consumed (nothing in the chart read it — that was the bug).
+
+### Migration
+
+Operators on `v0.18.0` on AWS: bump to `v0.18.1`, `terraform apply`
+(ConfigMap data updates in place, no infra changes). Re-trigger the
+platform-root Application (or the CLI re-runs the manifest generation)
+and the helm template completes.
+
+Azure is unaffected — `providers/azure/platform-outputs.tf` never
+wrote this key at all, so no drift existed.
+
 ## [0.18.0] - 2026-04-24
 
 ### Added — `modules/github-app-credentials/` (cloud-agnostic) + AWS caller

--- a/providers/aws/platform-outputs.tf
+++ b/providers/aws/platform-outputs.tf
@@ -43,16 +43,16 @@ resource "kubernetes_config_map" "platform_infrastructure" {
 
   data = {
     # Platform versions + revisions (ADR 0020)
-    "platformRepoUrl"         = var.platform_repo_url
-    "platformVersion"         = var.platform_version
-    "platformRevision"        = local.platform_revision_effective
-    "configRepoUrl"           = var.config_repo_url
-    "configRepoVersion"       = var.config_repo_version
-    "configRepoRevision"      = local.config_repo_revision_effective
-    "clientGitopsRepoUrl"     = var.client_gitops_repo_url
-    "clientGitopsRepoVersion" = var.client_gitops_repo_version
-    "clientGitopsRevision"    = local.client_gitops_revision_effective
-    "deploymentId"            = var.deployment_id
+    "platformRepoUrl"          = var.platform_repo_url
+    "platformVersion"          = var.platform_version
+    "platformRevision"         = local.platform_revision_effective
+    "configRepoUrl"            = var.config_repo_url
+    "configRepoVersion"        = var.config_repo_version
+    "configRepoRevision"       = local.config_repo_revision_effective
+    "clientGitopsRepoUrl"      = var.client_gitops_repo_url
+    "clientGitopsRepoVersion"  = var.client_gitops_repo_version
+    "clientGitopsRepoRevision" = local.client_gitops_revision_effective
+    "deploymentId"             = var.deployment_id
 
     # Global
     "global.provider"         = "aws"


### PR DESCRIPTION
## Summary

- AWS `platform-outputs.tf` wrote `clientGitopsRevision` (missing the `Repo` infix) into the `platform-infrastructure` ConfigMap. The platform-root chart expects `.Values.clientGitopsRepoRevision` — so manual seed / CLI bootstrap paths that forward ConfigMap entries as helm parameters hit the `clientGitopsRefRequired` fail.
- Azure is unaffected: `providers/azure/platform-outputs.tf` never wrote this key at all. Azure clients satisfy the chart's requirement via `overrides/platform-root/values.yaml` shipped inside the client config repo. After this fix, AWS derives the revision from Terraform (single source of truth) — better than the Azure pattern.

## Observed

2026-04-24, cortex AWS seed. Helm template rendered:

```
execution error at (platform-root/templates/hub-client-apps.yaml:45:21):
  clientGitopsRepoRevision (or legacy clientGitopsRepoVersion) is required
  when clientGitopsRepoUrl is set
```

## Changes

- `providers/aws/platform-outputs.tf`: rename `clientGitopsRevision` → `clientGitopsRepoRevision` and align the `clientGitopsRepoVersion` entry to use `local.client_gitops_revision_effective` for parity with the Azure resolver.
- `CHANGELOG.md`: add v0.18.1 entry.

## Test plan

- [ ] Tag v0.18.1 after merge.
- [ ] Bump cortex downstream module ref to v0.18.1.
- [ ] Run `terraform apply` on cortex (ConfigMap data-only change, no infra churn).
- [ ] Re-run the cortex manual seed script; verify `platform-root` Application renders child Applications (cert-manager, kyverno, etc.) instead of failing at `hub-client-apps.yaml`.

## Follow-ups (separate)

- Decide whether `providers/azure/platform-outputs.tf` should also emit `clientGitopsRepoRevision` (lift the latent "client must remember to add this to overrides" gap). Track under the version-management problem map (Issue #15).