### PR TITLE
fix(aws): velero null helm.parameters + AppProject gate for configRepoRevision (v0.18.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,81 @@
 # Changelog
 
+## [0.18.2] - 2026-04-24
+
+### Fixed — AWS platform-root seed: `velero` Application rendering `helm.parameters: null` + AppProject gate still keyed on legacy `configRepoVersion`
+
+Two AWS-seed bugs surfaced by the cortex EKS first-seed on 2026-04-24
+after `v0.18.1` unblocked the `clientGitopsRepoRevision` key mismatch.
+
+#### 1. `bootstrap/platform-root/templates/velero.yaml` — empty `parameters:` key on AWS
+
+The `velero` Application template emitted `parameters:` unconditionally,
+with an `azure` branch supplying parameters and an `aws` branch holding
+only a `# AWS — to be implemented` comment. Rendered output on AWS:
+
+```yaml
+helm:
+  valueFiles: [...]
+  parameters:
+```
+
+which YAML parses as `parameters: null`. The ArgoCD Application CRD
+rejects `null` for `spec.sources[].helm.parameters` (expects an array),
+so `platform-root` sync aborted mid-flight:
+
+```
+Application.argoproj.io "velero" is invalid:
+  spec.sources[0].helm.parameters: Invalid value: "null":
+  spec.sources[0].helm.parameters in body must be of type array: "null"
+```
+
+Downstream Applications never reached Synced state because the apply
+batch aborted before reconciling them.
+
+**Fix:** move `parameters:` inside the Azure provider branch so AWS
+simply omits the key. AWS velero reads its provider wiring from
+`core/components/velero/values-aws.yaml` — no helm parameter overrides
+needed.
+
+#### 2. `bootstrap/platform-root/templates/argocd-project.yaml` — `sourceRepos` gate still requires legacy `configRepoVersion`
+
+Three `AppProject.sourceRepos` blocks (the `platform`, `workload-baseline`,
+and `applications` projects) gated inclusion of `configRepoUrl` on
+`and .Values.configRepoUrl .Values.configRepoVersion`. After ADR 0020
+(v0.13.0) migrated own-content repo refs to `*Revision` keys, clients
+using only the new `configRepoRevision` (e.g. cortex) never added their
+config repo to `sourceRepos`, producing:
+
+```
+InvalidSpecError:
+  application repo <config-repo> is not permitted in project 'platform'
+```
+
+Every child Application with an `$overrides` source failed spec
+validation. The sibling `clientGitopsRepoUrl` gate (lines 20 and 145)
+already requires only the URL — the asymmetry with `configRepoUrl` was
+pre-existing.
+
+**Fix:** drop the version requirement on all three gates. Align with
+the `clientGitopsRepoUrl` pattern — the URL alone is sufficient to
+authorize the repo as a source. Legacy clients using `configRepoVersion`
+are unaffected; new clients using `configRepoRevision` start working.
+
+### Migration
+
+Operators on `v0.18.1` on AWS: bump to `v0.18.2`, `terraform apply`
+(no Terraform-tracked resources change — this only updates Helm
+templates sourced by `platform-root` via `$values`). Trigger a sync /
+hard refresh of `platform-root`; the helm template re-renders without
+the `null` parameters error and the `platform` AppProject
+`sourceRepos` now includes `configRepoUrl`.
+
+Azure is unaffected by bug #1 (Azure branch of the template was already
+correct). Azure is unaffected by bug #2 in practice because existing
+Azure clients set the legacy `config_repo_version` tfvar — but the fix
+is safe for them and future-proofs the Azure migration to
+`configRepoRevision`.
+
 ## [0.18.1] - 2026-04-24
 
 ### Fixed — ConfigMap key mismatch: `clientGitopsRevision` → `clientGitopsRepoRevision`

--- a/bootstrap/platform-root/templates/argocd-project.yaml
+++ b/bootstrap/platform-root/templates/argocd-project.yaml
@@ -11,7 +11,7 @@ spec:
   description: Estabilis Platform core components
   sourceRepos:
     - {{ .Values.platformRepoUrl | quote }}
-    {{- if and .Values.configRepoUrl .Values.configRepoVersion }}
+    {{- if .Values.configRepoUrl }}
     - {{ .Values.configRepoUrl | quote }}
     {{- end }}
     {{- if and .Values.platformGitopsRepoUrl .Values.platformGitopsVersion }}
@@ -139,7 +139,7 @@ spec:
     {{- if and .Values.platformGitopsRepoUrl .Values.platformGitopsVersion }}
     - {{ .Values.platformGitopsRepoUrl | quote }}
     {{- end }}
-    {{- if and .Values.configRepoUrl .Values.configRepoVersion }}
+    {{- if .Values.configRepoUrl }}
     - {{ .Values.configRepoUrl | quote }}
     {{- end }}
     {{- if .Values.clientGitopsRepoUrl }}
@@ -293,7 +293,7 @@ spec:
     - group: "*"
       kind: "*"
 {{- end }}
-{{- if and .Values.configRepoUrl .Values.configRepoVersion }}
+{{- if .Values.configRepoUrl }}
 ---
 # Applications project — for client custom apps in app-* namespaces
 apiVersion: argoproj.io/v1alpha1

--- a/bootstrap/platform-root/templates/velero.yaml
+++ b/bootstrap/platform-root/templates/velero.yaml
@@ -24,8 +24,8 @@ spec:
           {{- include "platform-root.schedulingValuesTopLevel" (dict
                 "mode" (default "auto" (index .Values.scheduling "velero"))
              ) | nindent 10 }}
+        {{- if eq .Values.global.provider "azure" }}
         parameters:
-          {{- if eq .Values.global.provider "azure" }}
           - name: configuration.backupStorageLocation[0].bucket
             value: "{{ .Values.global.veleroBackupContainerName }}"
           - name: configuration.backupStorageLocation[0].config.storageAccount
@@ -44,9 +44,8 @@ spec:
             value: "{{ .Values.global.veleroBackupSchedule }}"
           - name: schedules.platform-daily.template.ttl
             value: "{{ .Values.global.veleroBackupRetentionHours }}h0m0s"
-          {{- else if eq .Values.global.provider "aws" }}
-          # AWS — to be implemented
-          {{- end }}
+        {{- end }}
+        {{- /* AWS reads all provider wiring from core/components/velero/values-aws.yaml — no extra helm parameters needed. */}}
     - repoURL: {{ .Values.platformRepoUrl }}
       targetRevision: {{ .Values.platformVersion }}
       ref: values


### PR DESCRIPTION
## Summary

Two AWS-seed bugs surfaced by the cortex EKS first-seed on 2026-04-24 after v0.18.1 unblocked the `clientGitopsRepoRevision` key mismatch. Both are platform-root chart bugs — no Terraform changes.

### Bug 1 — `velero` Application renders `helm.parameters: null` on AWS

`bootstrap/platform-root/templates/velero.yaml` emitted `parameters:` unconditionally. The Azure branch filled it in; the AWS branch only had a `# AWS — to be implemented` comment. YAML renders as `parameters: null`, which the ArgoCD Application CRD rejects:

```
spec.sources[0].helm.parameters: Invalid value: "null":
spec.sources[0].helm.parameters in body must be of type array: "null"
```

`platform-root` sync aborted mid-flight, so downstream Applications never reached Synced.

**Fix:** move `parameters:` inside the Azure branch. AWS velero reads provider wiring from `core/components/velero/values-aws.yaml` — no helm parameter overrides needed.

### Bug 2 — `AppProject.sourceRepos` gate still requires legacy `configRepoVersion`

Three AppProject sourceRepos blocks (platform, workload-baseline, applications) gated `configRepoUrl` on `and .Values.configRepoUrl .Values.configRepoVersion`. After ADR 0020 migrated own-content repo refs to `*Revision` keys, clients using only `configRepoRevision` never added their config repo to sourceRepos:

```
InvalidSpecError:
  application repo <config-repo> is not permitted in project 'platform'
```

Every child Application with an `$overrides` source failed spec validation. The sibling `clientGitopsRepoUrl` gate (same file, two other places) already required only the URL — the asymmetry was pre-existing.

**Fix:** drop the version requirement on all three gates. Align with `clientGitopsRepoUrl`. Legacy clients with `configRepoVersion` unaffected; new clients with `configRepoRevision` start working.

## Observed

Cortex EKS seed, 2026-04-24. Agent-observed terminal states:

- `platform-root` operationState.phase = Failed: velero null parameters
- 9+ children with `InvalidSpecError` repo-not-permitted on project `platform`

## Test plan

- [ ] Tag v0.18.2 after merge.
- [ ] Bump cortex downstream to v0.18.2.
- [ ] `terraform apply` (no Terraform-tracked resources change; only Helm templates served via `$values`).
- [ ] Trigger `platform-root` hard refresh + sync.
- [ ] Verify children no longer show `InvalidSpecError` and velero renders with valid spec.

## Azure impact

- Bug 1: Azure branch was already correct — no change.
- Bug 2: Pre-existing Azure clients set legacy `config_repo_version` — gate fired before and still fires. Fix is safe for them and future-proofs Azure migration to `configRepoRevision`.