### PR TITLE
fix(aws): grafana-loki + grafana-mimir null helm.parameters (v0.18.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,66 @@
 # Changelog
 
+## [0.18.3] - 2026-04-24
+
+### Fixed — AWS null `helm.parameters` in `grafana-loki` and `grafana-mimir` (same anti-pattern as v0.18.2 velero fix)
+
+v0.18.2 patched the `velero` Application in `platform-root` so the
+`parameters:` block is gated behind `{{- if eq .Values.global.provider
+"azure" }}`. The cortex AWS seed on 2026-04-24 then advanced past
+velero, into sync-wave 8, and hit the SAME anti-pattern in two more
+Applications rendered from `bootstrap/platform-root/templates/grafana-stack.yaml`:
+
+```
+Application.argoproj.io "grafana-loki" is invalid:
+  spec.sources[0].helm.parameters: Invalid value: "null":
+  spec.sources[0].helm.parameters in body must be of type array: "null"
+Application.argoproj.io "grafana-mimir" is invalid:
+  spec.sources[0].helm.parameters: Invalid value: "null":
+  spec.sources[0].helm.parameters in body must be of type array: "null"
+```
+
+Same shape as the velero bug: `parameters:` emitted unconditionally,
+Azure branch populated, AWS branch holding only a `# AWS — to be
+implemented` comment. On AWS the block renders as empty → YAML parses
+as `null` → CRD rejection → platform-root sync aborts mid-wave,
+blocking all later Applications from reconciling.
+
+### Fix
+
+Move `parameters:` inside the `{{- if azure }}` branch for both
+`grafana-loki` and `grafana-mimir`. AWS reads provider wiring from
+`core/components/grafana-stack/loki-values-aws.yaml` /
+`mimir-values-aws.yaml` — no helm parameter overrides needed (matches
+what velero.yaml already does in v0.18.2).
+
+### Audit — is the anti-pattern anywhere else?
+
+Cataloged every template under `bootstrap/platform-root/templates/*.yaml`
+with a `parameters:` block inside a provider conditional. Besides
+velero (fixed in v0.18.2) and grafana-loki/grafana-mimir (fixed here):
+
+- `cert-manager.yaml` — AWS branch IS populated (sets IRSA role-arn); safe.
+- `external-secrets.yaml` — AWS branch IS populated + unconditional
+  `installCRDs=false` always keeps the array non-empty; safe.
+- `external-dns.yaml` — unconditional `domainFilters[0]` + `txtOwnerId`
+  always keep the array non-empty; the AWS dnsProvider branch has a
+  TODO comment but it's additive, not a leading `parameters: []`; safe.
+- `cluster-secret-store.yaml` — whole Application is gated on
+  `provider == azure`; on AWS, no Application is emitted (different
+  gap — AWS ClusterSecretStore needs a separate implementation, tracked
+  elsewhere). Not a null-params bug.
+
+### Migration
+
+Operators on `v0.18.2` on AWS: bump to `v0.18.3`, `terraform apply`
+(no Terraform-tracked resources change — Helm template update only).
+Trigger a fresh sync of `platform-root` (use the top-level `operation`
+field on the Application, not `spec.operation`). Children on wave 8
+should reconcile.
+
+Azure is unaffected — Azure branches render their parameters as
+before.
+
 ## [0.18.2] - 2026-04-24
 
 ### Fixed — AWS platform-root seed: `velero` Application rendering `helm.parameters: null` + AppProject gate still keyed on legacy `configRepoVersion`

--- a/bootstrap/platform-root/templates/grafana-stack.yaml
+++ b/bootstrap/platform-root/templates/grafana-stack.yaml
@@ -105,19 +105,14 @@ spec:
                 "mode" $modeIngester
                 "paths" (list "ingester")
              ) | nindent 10 }}
+        {{- if eq .Values.global.provider "azure" }}
         parameters:
-          {{- if eq .Values.global.provider "azure" }}
           - name: loki.storage.azure.accountName
             value: "{{ .Values.global.storageAccountName }}"
           - name: serviceAccount.annotations.azure\.workload\.identity/client-id
             value: "{{ .Values.identity.loki.clientId }}"
-          {{- else if eq .Values.global.provider "aws" }}
-          # AWS — to be implemented
-          # - name: loki.storage.s3.bucketname
-          #   value: "{{ .Values.global.lokiBucket }}"
-          # - name: serviceAccount.annotations.eks\.amazonaws\.com/role-arn
-          #   value: "{{ .Values.identity.loki.roleArn }}"
-          {{- end }}
+        {{- end }}
+        {{- /* AWS: S3 bucket + IRSA wiring read from loki-values-aws.yaml — no helm parameters needed here. */}}
     - repoURL: {{ .Values.platformRepoUrl }}
       targetRevision: {{ .Values.platformVersion }}
       ref: values
@@ -170,19 +165,14 @@ spec:
                 "mode" $modeIngester
                 "paths" (list "ingester")
              ) | nindent 10 }}
+        {{- if eq .Values.global.provider "azure" }}
         parameters:
-          {{- if eq .Values.global.provider "azure" }}
           - name: mimir.structuredConfig.common.storage.azure.account_name
             value: "{{ .Values.global.storageAccountName }}"
           - name: serviceAccount.annotations.azure\.workload\.identity/client-id
             value: "{{ .Values.identity.mimir.clientId }}"
-          {{- else if eq .Values.global.provider "aws" }}
-          # AWS — to be implemented
-          # - name: mimir.structuredConfig.common.storage.s3.bucket_name
-          #   value: "{{ .Values.global.mimirBucket }}"
-          # - name: serviceAccount.annotations.eks\.amazonaws\.com/role-arn
-          #   value: "{{ .Values.identity.mimir.roleArn }}"
-          {{- end }}
+        {{- end }}
+        {{- /* AWS: S3 bucket + IRSA wiring read from mimir-values-aws.yaml — no helm parameters needed here. */}}
     - repoURL: {{ .Values.platformRepoUrl }}
       targetRevision: {{ .Values.platformVersion }}
       ref: values


### PR DESCRIPTION
## Summary

Same anti-pattern as the v0.18.2 velero fix. After v0.18.2 unblocked velero, the cortex AWS seed advanced into sync-wave 8 and hit the identical null-parameters bug in two more Applications rendered from `bootstrap/platform-root/templates/grafana-stack.yaml`:

```
Application.argoproj.io "grafana-loki" is invalid:
  spec.sources[0].helm.parameters: Invalid value: "null":
  spec.sources[0].helm.parameters in body must be of type array: "null"
Application.argoproj.io "grafana-mimir" is invalid:
  <same message>
```

Definitive evidence from read-only monitor: when `parameters:` key is omitted entirely, the Application is accepted (velero at v0.18.2 is now `Unknown/Healthy` with `parameters: ABSENT`). When emitted with no list items (YAML null), the CRD rejects it.

## Fix

Move `parameters:` inside the `{{- if azure }}` gate for both `grafana-loki` and `grafana-mimir`, matching what v0.18.2 did for velero. AWS reads S3 + IRSA wiring from `core/components/grafana-stack/loki-values-aws.yaml` and `mimir-values-aws.yaml` — no helm parameter overrides needed.

## Audit — is the anti-pattern anywhere else?

Catalogued every template under `bootstrap/platform-root/templates/*.yaml` with a `parameters:` block inside a provider conditional:

| Template | AWS-safe? | Why |
|---|---|---|
| `velero.yaml` | ✅ (v0.18.2) | parameters gated inside azure branch |
| `grafana-stack.yaml` grafana-loki | ❌ → ✅ this PR | same fix as velero |
| `grafana-stack.yaml` grafana-mimir | ❌ → ✅ this PR | same fix as velero |
| `cert-manager.yaml` | ✅ | AWS branch populated (IRSA role-arn) |
| `external-secrets.yaml` | ✅ | unconditional `installCRDs=false` + populated AWS branch |
| `external-dns.yaml` | ✅ | unconditional `domainFilters[0]` + `txtOwnerId` always keep array non-empty |
| `cluster-secret-store.yaml` | N/A | whole Application is azure-only; AWS emits no Application (separate gap, tracked elsewhere) |

## Observed

Cortex EKS seed 2026-04-24. 29/31 resources synced in the fresh v0.18.2 run; only `grafana-loki` and `grafana-mimir` were rejected by the Application CRD.

## Test plan

- [ ] Tag v0.18.3 after merge.
- [ ] Bump cortex downstream to v0.18.3.
- [ ] `terraform apply` (no TF-tracked resources change — Helm template only).
- [ ] Force platform-root sync via top-level `operation` field (NOT `spec.operation`).
- [ ] Expect grafana-loki and grafana-mimir Applications to be created, and the remaining 20+ children to reconcile past wave 8.

## Azure impact

Zero. Azure branches render their parameters exactly as before.