### PR TITLE
feat(aws): observability/backup/secrets provider parity (v0.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,133 @@
 # Changelog
 
+## [0.19.0] - 2026-04-24
+
+### Added — AWS provider parity: Loki/Mimir S3, Velero S3, ClusterSecretStore via Secrets Manager
+
+v0.18.1 → v0.18.3 fixed the AWS seed path enough to get platform-root
+to finish its first sync (rename ConfigMap key, fix AppProject gate,
+gate null `parameters:` in velero/grafana-loki/grafana-mimir). The
+cortex seed then advanced past those and surfaced the deeper gap: AWS
+provider was **not feature-complete** — several components had Azure
+wiring only and no AWS equivalent.
+
+This release ships the missing AWS values + template wiring for three
+stacks: observability (loki, mimir), backup (velero), and secrets
+(ClusterSecretStore). Net effect: an AWS cluster can now reach Healthy
+for the same component set Azure has been shipping since v0.1.x.
+
+#### 1. Loki AWS S3 backend
+
+New `core/components/grafana-stack/loki-values-aws.yaml`:
+- `loki.storage.type: s3`
+- `loki.storage.s3.region` (injected)
+- `loki.storage.bucketNames.{chunks,ruler,admin}` (injected, all point
+  to the shared observability bucket)
+- `schemaConfig.configs[0].object_store: s3`
+- `serviceAccount.annotations.eks.amazonaws.com/role-arn` (injected)
+
+`bootstrap/platform-root/templates/grafana-stack.yaml` `grafana-loki`
+gains a `{{- else if aws }}` helm.parameters branch emitting:
+- `loki.storage.bucketNames.{chunks,ruler,admin}` → `global.observabilityBucketName`
+- `loki.storage.s3.region` → `global.region`
+- `serviceAccount.annotations.eks\.amazonaws\.com/role-arn` → `identity.loki.roleArn`
+
+#### 2. Mimir AWS S3 backend
+
+New `core/components/grafana-stack/mimir-values-aws.yaml`:
+- `mimir.structuredConfig.common.storage.backend: s3`
+- `mimir.structuredConfig.{common,blocks_storage,ruler_storage,alertmanager_storage}.s3.bucket_name` (all injected)
+- `serviceAccount.annotations.eks.amazonaws.com/role-arn` (injected)
+- `global.podLabels: {}` — removes Azure Workload Identity label (IRSA
+  uses annotations, not labels)
+
+`bootstrap/platform-root/templates/grafana-stack.yaml` `grafana-mimir`
+gains the equivalent `{{- else if aws }}` branch.
+
+#### 3. Velero AWS S3 backend
+
+New `core/components/velero/values-aws.yaml`:
+- `configuration.backupStorageLocation[0].provider: aws` (+ bucket/region injected)
+- `configuration.volumeSnapshotLocation[0].provider: aws` (+ region injected)
+- `initContainers[0].image: velero/velero-plugin-for-aws:v1.12.0`
+- `serviceAccount.server.annotations.eks.amazonaws.com/role-arn` (injected)
+
+`bootstrap/platform-root/templates/velero.yaml` gains `{{- else if aws }}`
+helm.parameters:
+- `configuration.backupStorageLocation[0].bucket` → `global.veleroBackupBucketName`
+- `configuration.backupStorageLocation[0].config.region` → `global.region`
+- `configuration.volumeSnapshotLocation[0].config.region` → `global.region`
+- `serviceAccount.server.annotations.eks\.amazonaws\.com/role-arn` → `identity.velero.roleArn`
+- `schedules.platform-daily.*` — shared with Azure path
+
+#### 4. ClusterSecretStore AWS via Secrets Manager
+
+`bootstrap/platform-root/templates/cluster-secret-store.yaml` gate
+widened from `azure`-only to `azure OR aws`. The Application is now
+emitted on both providers; the provider-specific helm parameters
+differ:
+- Azure: `vaultUrl` + `tenantId`
+- AWS: `region`
+
+The underlying chart lives in `estabilis-platform-gitops` at
+`components/cluster-secret-store/`. That chart was updated in
+`estabilis-platform-gitops` **v0.34.0** to support the `provider`
+field and render an AWS ClusterSecretStore via IRSA (JWT
+`serviceAccountRef`). See that repo's CHANGELOG for the chart-side
+details.
+
+**Requires `estabilis-platform-gitops >= v0.34.0`.** Older gitops
+releases don't know the AWS template; platformGitopsVersion must be
+bumped together with this platform release on AWS clusters. Azure
+clusters can roll forward independently since the chart defaults to
+Azure when no `provider` value is set.
+
+#### 5. IAM — loki/mimir S3 scope broadened to bucket-wide
+
+`providers/aws/iam.tf` `data.aws_iam_policy_document.{loki_s3,mimir_s3}`
+previously restricted object access to `<bucket>/loki/*` and
+`<bucket>/mimir/*` prefixes. The loki chart (6.54) and mimir chart
+(6.0.5) do not support a global object-key prefix — objects land at
+bucket root. Without bucket-wide access the components get
+AccessDenied on every PutObject.
+
+Fix: broaden `resources` to `<bucket>/*`. Loki + mimir share the
+`observability` bucket and each has full access. Narrowing to a
+per-component prefix would require provisioning separate buckets —
+tracked as a follow-up if hard isolation between loki/mimir data
+becomes a requirement. Azure is unaffected (separate blob containers
+per component).
+
+### Migration
+
+1. Bump `estabilis-platform-gitops` to v0.34.0+ first.
+2. Bump `estabilis-platform` to v0.19.0.
+3. Update downstream:
+   - `main.tf ref=v0.19.0`
+   - `terraform.tfvars platform_revision = "v0.19.0"`
+   - `overrides/platform-root/values.yaml platformGitopsVersion: "v0.34.0"`
+   - downstream tag
+4. `terraform apply` — expect:
+   - `aws_iam_role_policy.loki_s3` in-place update (resource list)
+   - `aws_iam_role_policy.mimir_s3` in-place update (resource list)
+   - `kubernetes_config_map.platform_infrastructure` in-place update
+     (platformRevision key flip to v0.19.0)
+   - no infrastructure churn beyond those three
+5. Hard refresh + sync `platform-root`. Expect grafana-loki +
+   grafana-mimir + velero + cluster-secret-store + platform-secrets
+   to reach Synced/Healthy.
+
+### Azure impact
+
+- Loki/Mimir/Velero template fixes include `{{- else if aws }}`
+  branches — Azure branches render exactly as before.
+- cluster-secret-store template gate widened; when
+  `global.provider == "azure"` the emitted Application is byte-
+  identical to before (same helm parameters, same values files, same
+  path).
+- IAM changes are in `providers/aws/iam.tf` — never evaluated on
+  Azure.
+
 ## [0.18.3] - 2026-04-24
 
 ### Fixed — AWS null `helm.parameters` in `grafana-loki` and `grafana-mimir` (same anti-pattern as v0.18.2 velero fix)

--- a/bootstrap/platform-root/templates/cluster-secret-store.yaml
+++ b/bootstrap/platform-root/templates/cluster-secret-store.yaml
@@ -1,5 +1,5 @@
 {{- /* core: secrets store — conditional on provider, cannot be disabled */ -}}
-{{- if eq .Values.global.provider "azure" }}
+{{- if or (eq .Values.global.provider "azure") (eq .Values.global.provider "aws") }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -22,10 +22,17 @@ spec:
         ignoreMissingValueFiles: true
         parameters:
           {{- include "platform-root.provenanceParameters" $ | nindent 10 }}
+          - name: provider
+            value: "{{ .Values.global.provider }}"
+          {{- if eq .Values.global.provider "azure" }}
           - name: vaultUrl
             value: "{{ .Values.global.keyVaultUri }}"
           - name: tenantId
             value: "{{ .Values.global.tenantId }}"
+          {{- else if eq .Values.global.provider "aws" }}
+          - name: region
+            value: "{{ .Values.global.region }}"
+          {{- end }}
     - repoURL: {{ .Values.platformGitopsRepoUrl }}
       targetRevision: {{ .Values.platformGitopsVersion }}
       ref: values
@@ -44,7 +51,4 @@ spec:
         maxDuration: 3m
     syncOptions:
       - CreateNamespace=true
-{{- else if eq .Values.global.provider "aws" }}
-# AWS ClusterSecretStore — to be implemented
-# Will point to AWS Secrets Manager via IRSA
 {{- end }}

--- a/bootstrap/platform-root/templates/grafana-stack.yaml
+++ b/bootstrap/platform-root/templates/grafana-stack.yaml
@@ -111,8 +111,19 @@ spec:
             value: "{{ .Values.global.storageAccountName }}"
           - name: serviceAccount.annotations.azure\.workload\.identity/client-id
             value: "{{ .Values.identity.loki.clientId }}"
+        {{- else if eq .Values.global.provider "aws" }}
+        parameters:
+          - name: loki.storage.bucketNames.chunks
+            value: "{{ .Values.global.observabilityBucketName }}"
+          - name: loki.storage.bucketNames.ruler
+            value: "{{ .Values.global.observabilityBucketName }}"
+          - name: loki.storage.bucketNames.admin
+            value: "{{ .Values.global.observabilityBucketName }}"
+          - name: loki.storage.s3.region
+            value: "{{ .Values.global.region }}"
+          - name: serviceAccount.annotations.eks\.amazonaws\.com/role-arn
+            value: "{{ .Values.identity.loki.roleArn }}"
         {{- end }}
-        {{- /* AWS: S3 bucket + IRSA wiring read from loki-values-aws.yaml — no helm parameters needed here. */}}
     - repoURL: {{ .Values.platformRepoUrl }}
       targetRevision: {{ .Values.platformVersion }}
       ref: values
@@ -171,8 +182,21 @@ spec:
             value: "{{ .Values.global.storageAccountName }}"
           - name: serviceAccount.annotations.azure\.workload\.identity/client-id
             value: "{{ .Values.identity.mimir.clientId }}"
+        {{- else if eq .Values.global.provider "aws" }}
+        parameters:
+          - name: mimir.structuredConfig.common.storage.s3.bucket_name
+            value: "{{ .Values.global.observabilityBucketName }}"
+          - name: mimir.structuredConfig.common.storage.s3.region
+            value: "{{ .Values.global.region }}"
+          - name: mimir.structuredConfig.blocks_storage.s3.bucket_name
+            value: "{{ .Values.global.observabilityBucketName }}"
+          - name: mimir.structuredConfig.ruler_storage.s3.bucket_name
+            value: "{{ .Values.global.observabilityBucketName }}"
+          - name: mimir.structuredConfig.alertmanager_storage.s3.bucket_name
+            value: "{{ .Values.global.observabilityBucketName }}"
+          - name: serviceAccount.annotations.eks\.amazonaws\.com/role-arn
+            value: "{{ .Values.identity.mimir.roleArn }}"
         {{- end }}
-        {{- /* AWS: S3 bucket + IRSA wiring read from mimir-values-aws.yaml — no helm parameters needed here. */}}
     - repoURL: {{ .Values.platformRepoUrl }}
       targetRevision: {{ .Values.platformVersion }}
       ref: values

--- a/bootstrap/platform-root/templates/velero.yaml
+++ b/bootstrap/platform-root/templates/velero.yaml
@@ -44,8 +44,21 @@ spec:
             value: "{{ .Values.global.veleroBackupSchedule }}"
           - name: schedules.platform-daily.template.ttl
             value: "{{ .Values.global.veleroBackupRetentionHours }}h0m0s"
+        {{- else if eq .Values.global.provider "aws" }}
+        parameters:
+          - name: configuration.backupStorageLocation[0].bucket
+            value: "{{ .Values.global.veleroBackupBucketName }}"
+          - name: configuration.backupStorageLocation[0].config.region
+            value: "{{ .Values.global.region }}"
+          - name: configuration.volumeSnapshotLocation[0].config.region
+            value: "{{ .Values.global.region }}"
+          - name: serviceAccount.server.annotations.eks\.amazonaws\.com/role-arn
+            value: "{{ .Values.identity.velero.roleArn }}"
+          - name: schedules.platform-daily.schedule
+            value: "{{ .Values.global.veleroBackupSchedule }}"
+          - name: schedules.platform-daily.template.ttl
+            value: "{{ .Values.global.veleroBackupRetentionHours }}h0m0s"
         {{- end }}
-        {{- /* AWS reads all provider wiring from core/components/velero/values-aws.yaml — no extra helm parameters needed. */}}
     - repoURL: {{ .Values.platformRepoUrl }}
       targetRevision: {{ .Values.platformVersion }}
       ref: values

--- a/core/components/grafana-stack/loki-values-aws.yaml
+++ b/core/components/grafana-stack/loki-values-aws.yaml
@@ -1,0 +1,50 @@
+# AWS-specific Loki values
+# Loaded in addition to loki-values.yaml when provider=aws.
+#
+# Wiring requirements (all injected via helm.parameters from platform-root
+# grafana-stack.yaml template's AWS branch):
+#   - loki.storage.bucketNames.{chunks,ruler,admin}  → global.observabilityBucketName
+#   - loki.storage.s3.region                         → global.region
+#   - serviceAccount.annotations.<role-arn>          → identity.loki.roleArn
+#
+# IAM: aws_iam_role.loki has s3:{Get,Put,Delete,List}Object on the
+# observability bucket. v0.19.0 broadened the scope from /loki/* to the
+# whole bucket (loki chart 6.54 does not support a global object prefix;
+# objects land at bucket root).
+
+loki:
+  storage:
+    type: s3
+    bucketNames:
+      chunks: ""   # injected
+      ruler: ""    # injected
+      admin: ""    # injected
+    s3:
+      region: ""   # injected
+      s3ForcePathStyle: false
+      insecure: false
+  compactor:
+    delete_request_store: s3
+  schemaConfig:
+    configs:
+      - from: "2024-01-01"
+        store: tsdb
+        object_store: s3
+        schema: v13
+        index:
+          prefix: loki_index_
+          period: 24h
+
+serviceAccount:
+  create: true
+  name: grafana-loki
+  annotations:
+    eks.amazonaws.com/role-arn: ""   # injected
+
+singleBinary:
+  # AWS EKS uses generic node pools; no provider-specific tolerations here.
+  # The platform-level node selector + estabilis.io/workload-type toleration
+  # from loki-values.yaml already places loki on platform nodes.
+  serviceAccount:
+    create: false
+    name: grafana-loki

--- a/core/components/grafana-stack/mimir-values-aws.yaml
+++ b/core/components/grafana-stack/mimir-values-aws.yaml
@@ -1,0 +1,47 @@
+# AWS-specific Mimir values
+# Loaded in addition to mimir-values.yaml when provider=aws.
+#
+# Wiring (injected via helm.parameters from platform-root grafana-stack.yaml
+# template's AWS branch):
+#   - mimir.structuredConfig.common.storage.s3.bucket_name   → global.observabilityBucketName
+#   - mimir.structuredConfig.common.storage.s3.region        → global.region
+#   - mimir.structuredConfig.blocks_storage.s3.bucket_name   → global.observabilityBucketName
+#   - mimir.structuredConfig.ruler_storage.s3.bucket_name    → global.observabilityBucketName
+#   - serviceAccount.annotations.eks.amazonaws.com/role-arn  → identity.mimir.roleArn
+#
+# IAM: aws_iam_role.mimir has s3:{Get,Put,Delete,List}Object on the
+# observability bucket (v0.19.0 broadened to bucket-wide so the mimir S3
+# backend can write at bucket root).
+
+mimir:
+  structuredConfig:
+    common:
+      storage:
+        backend: s3
+        s3:
+          bucket_name: ""   # injected
+          region: ""        # injected
+          insecure: false
+    blocks_storage:
+      backend: s3
+      s3:
+        bucket_name: ""     # injected
+    ruler_storage:
+      backend: s3
+      s3:
+        bucket_name: ""     # injected
+    alertmanager_storage:
+      backend: s3
+      s3:
+        bucket_name: ""     # injected
+
+global:
+  # No Azure Workload Identity labels on AWS; IRSA works via the
+  # serviceAccount annotation below.
+  podLabels: {}
+
+serviceAccount:
+  create: true
+  name: grafana-mimir
+  annotations:
+    eks.amazonaws.com/role-arn: ""   # injected

--- a/core/components/velero/values-aws.yaml
+++ b/core/components/velero/values-aws.yaml
@@ -1,0 +1,39 @@
+# AWS-specific Velero values
+# Loaded in addition to values.yaml when provider=aws.
+#
+# Wiring (injected via helm.parameters from platform-root velero.yaml
+# template's AWS branch):
+#   - configuration.backupStorageLocation[0].bucket          → global.veleroBackupBucketName
+#   - configuration.backupStorageLocation[0].config.region   → global.region
+#   - configuration.volumeSnapshotLocation[0].config.region  → global.region
+#   - serviceAccount.server.annotations.eks.amazonaws.com/role-arn → identity.velero.roleArn
+#   - schedules.platform-daily.schedule                      → global.veleroBackupSchedule
+#   - schedules.platform-daily.template.ttl                  → global.veleroBackupRetentionHours (h0m0s suffix)
+
+configuration:
+  backupStorageLocation:
+    - name: default
+      provider: aws
+      bucket: ""                   # injected
+      config:
+        region: ""                 # injected
+  volumeSnapshotLocation:
+    - name: default
+      provider: aws
+      config:
+        region: ""                 # injected
+
+initContainers:
+  - name: velero-plugin-for-aws
+    image: velero/velero-plugin-for-aws:v1.12.0
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+      - mountPath: /target
+        name: plugins
+
+# AWS EKS uses generic node pools; no provider-specific tolerations.
+
+serviceAccount:
+  server:
+    annotations:
+      eks.amazonaws.com/role-arn: ""   # injected

--- a/providers/aws/iam.tf
+++ b/providers/aws/iam.tf
@@ -130,9 +130,14 @@ data "aws_iam_policy_document" "loki_s3" {
       "s3:ListBucket",
       "s3:GetBucketLocation",
     ]
+    # Bucket-wide access: the loki chart (6.54) does not support a global
+    # object-key prefix, so objects land at bucket root. Loki + mimir share
+    # the observability bucket and each has full access. Narrowing to a
+    # per-component prefix would require provisioning separate buckets
+    # (tracked as a follow-up if isolation becomes a hard requirement).
     resources = [
       aws_s3_bucket.observability.arn,
-      "${aws_s3_bucket.observability.arn}/loki/*",
+      "${aws_s3_bucket.observability.arn}/*",
     ]
   }
 
@@ -195,9 +200,10 @@ data "aws_iam_policy_document" "mimir_s3" {
       "s3:ListBucket",
       "s3:GetBucketLocation",
     ]
+    # See comment on loki_s3 — bucket-wide access, shared with loki.
     resources = [
       aws_s3_bucket.observability.arn,
-      "${aws_s3_bucket.observability.arn}/mimir/*",
+      "${aws_s3_bucket.observability.arn}/*",
     ]
   }
 


### PR DESCRIPTION
## Summary

v0.18.1 → v0.18.3 fixed the AWS seed mechanics (ConfigMap key rename, AppProject gate, null-params anti-pattern in velero + loki + mimir). The cortex EKS seed on 2026-04-24 then advanced far enough to expose the deeper gap: AWS provider was **not feature-complete**. Several components shipped Azure wiring only with no AWS equivalent:

- `grafana-loki` had no `loki-values-aws.yaml` → helm failed at `loki.storage.bucketNames.chunks required`.
- `grafana-mimir` had no `mimir-values-aws.yaml` → same class of helm failure (missing `common.storage.s3.*`).
- `velero` had no `values-aws.yaml` → chart schema rejected BSL/VSL entries missing `provider`.
- `cluster-secret-store.yaml` template was gated on `provider == azure` → no `ClusterSecretStore` Application emitted on AWS, so `platform-secrets` stuck `Missing`.
- IAM for loki/mimir restricted S3 access to `/loki/*` and `/mimir/*` prefixes, but neither chart supports a global object-key prefix.

This PR ships the missing AWS provider equivalents for observability (loki/mimir), backup (velero), and secrets (ClusterSecretStore). Net effect: an AWS cluster reaches Healthy for the same component set Azure has been shipping since v0.1.x.

## Changes

### Values files (new)

- `core/components/grafana-stack/loki-values-aws.yaml` — S3 storage, schema `object_store: s3`, IRSA annotation.
- `core/components/grafana-stack/mimir-values-aws.yaml` — S3 across common/blocks_storage/ruler_storage/alertmanager_storage, IRSA.
- `core/components/velero/values-aws.yaml` — BSL/VSL `provider: aws`, `velero-plugin-for-aws:v1.12.0` initContainer, IRSA.

### Template updates (add `{{- else if aws }}` helm.parameters branches)

- `bootstrap/platform-root/templates/grafana-stack.yaml` — grafana-loki + grafana-mimir.
- `bootstrap/platform-root/templates/velero.yaml` — BSL/VSL/schedules/IRSA.
- `bootstrap/platform-root/templates/cluster-secret-store.yaml` — widen gate from azure-only to azure OR aws; provider-specific helm parameters.

### IAM

`providers/aws/iam.tf` loki_s3 + mimir_s3 resources: `/loki/*` + `/mimir/*` → `/*`. Required because loki/mimir charts do not support a global object-key prefix.

## Dependency

**Requires `estabilis-platform-gitops >= v0.34.0`** (just released in Estabilis/estabilis-platform-gitops#24). The AWS ClusterSecretStore template lives in that chart. Older gitops releases will fall back to Azure (default chart behavior) and break AWS deployments.

## Test plan

- [ ] Tag `v0.19.0` after merge.
- [ ] Bump cortex downstream:
  - `main.tf ref=v0.19.0`
  - `terraform.tfvars platform_revision = "v0.19.0"`
  - `overrides/platform-root/values.yaml platformGitopsVersion: "v0.34.0"`
- [ ] `terraform apply` — expect only 3 changes: two IAM policy in-place updates (loki/mimir S3 resource list) + ConfigMap data flip (platformRevision to v0.19.0).
- [ ] Hard refresh + sync `platform-root`.
- [ ] Verify:
  - grafana-loki + grafana-mimir Applications render and reach Synced (Healthy if chart comes up).
  - velero Application renders with valid spec.
  - cluster-secret-store Application appears and produces ClusterSecretStore/platform-secret-store.
  - platform-secrets transitions Missing → Synced/Healthy.

## Azure impact

Zero.
- Template `{{- else if aws }}` branches: Azure path renders byte-identical.
- cluster-secret-store.yaml: when `global.provider == "azure"`, Application spec is byte-identical to pre-change (same helm.parameters for vaultUrl + tenantId, gitops chart defaults provider to azure).
- IAM: only AWS branch affected.