### PR TITLE
fix(aws): platformVersion ConfigMap key uses effective revision (v0.19.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,76 @@
 # Changelog
 
+## [0.19.1] - 2026-04-24
+
+### Fixed — AWS `platformVersion` ConfigMap key writes stale `var.platform_version` instead of the effective revision
+
+v0.19.0 shipped AWS provider parity (loki/mimir/velero S3 values +
+ClusterSecretStore AWS). After merge + cortex bump + `terraform apply`
+the live velero and grafana-loki Applications failed to load their
+`*-values-aws.yaml` files. Root cause: a latent ADR 0020 migration
+gap in the AWS `platform-outputs.tf` ConfigMap writer.
+
+#### The bug
+
+Child Application templates in `bootstrap/platform-root/templates/*.yaml`
+reference the platform repo via `targetRevision: {{ .Values.platformVersion }}`.
+Their `$values` multi-source ref uses the same `platformVersion` to
+check out the platform repo at the right tag, and `helm.valueFiles`
+resolves files inside that checkout (e.g. `$values/core/components/velero/values-aws.yaml`).
+
+`providers/aws/platform-outputs.tf` wrote the ConfigMap as:
+
+```hcl
+"platformVersion"  = var.platform_version      # literal legacy var
+"platformRevision" = local.platform_revision_effective  # derived
+```
+
+A downstream client that bumps only `platform_revision` in tfvars
+(the documented path since v0.13.0 / ADR 0020) leaves
+`var.platform_version` at its stale default. The ConfigMap's
+`platformVersion` key keeps pointing at the old tag; the `$values`
+source resolves against that old tag; the new `*-values-aws.yaml`
+files added in v0.19.0 are not present in the old ref; and
+`ignoreMissingValueFiles: true` silently skips them.
+
+Observed on cortex 2026-04-24:
+- `platformRevision` in ConfigMap = `v0.19.0` ✓
+- `platformVersion` in ConfigMap = `v0.18.0` (stale) ✗
+- `kubectl -n argocd get application velero -o yaml` → `source[1].targetRevision = v0.18.0`
+- Helm rendered with only `values.yaml` (not `values-aws.yaml`)
+- Velero schema failed: `missing property 'provider' at /configuration/{backup,volumeSnapshot}StorageLocation/0`
+- Loki failed: `You must provide a schema_config for Loki`
+
+Both errors collapsed to "values-aws.yaml didn't load".
+
+### Fix
+
+Write `platformVersion = local.platform_revision_effective` in the
+AWS `platform-outputs.tf` ConfigMap data. Both keys now carry the
+effective git ref. Child templates that read `.Values.platformVersion`
+always see the current platform tag without requiring the client to
+maintain two tfvars in lockstep.
+
+Azure is unaffected — `providers/azure/platform-outputs.tf` was not
+touched (Azure doesn't write `platformRevision` at all, and Azure's
+seed path populates `platformVersion` via CLI tfvars loading where
+operators set both fields historically).
+
+### Migration
+
+Operators on `v0.19.0` on AWS: bump to `v0.19.1`, `terraform apply`
+(ConfigMap data-only change; 1 in-place update). Child Applications
+re-render on next platform-root sync and `*-values-aws.yaml` files
+load correctly.
+
+### Follow-up (not blocking)
+
+Consider a `platform-root.platformRef` helper in `_helpers.tpl` that
+mirrors `clientGitopsRef` (prefer `platformRevision` over
+`platformVersion`) and migrate all `targetRevision: {{ .Values.platformVersion }}`
+call sites to it. That's a larger sweep (~30 files). This PR is the
+minimum to unblock cortex and ship AWS parity.
+
 ## [0.19.0] - 2026-04-24
 
 ### Added — AWS provider parity: Loki/Mimir S3, Velero S3, ClusterSecretStore via Secrets Manager

--- a/providers/aws/platform-outputs.tf
+++ b/providers/aws/platform-outputs.tf
@@ -43,8 +43,18 @@ resource "kubernetes_config_map" "platform_infrastructure" {
 
   data = {
     # Platform versions + revisions (ADR 0020)
+    #
+    # Legacy `platformVersion` key retained for backcompat — many child
+    # Application templates still read `.Values.platformVersion` directly
+    # (not via a helper that prefers `platformRevision`). Writing the
+    # same effective ref to both keys keeps the templates functional
+    # while downstream charts migrate to the *Revision keys. Without
+    # this, bumping only `platform_revision` in tfvars leaves the child
+    # Applications stuck at the old `platform_version` default, which
+    # silently fails to load newer $values files (e.g. loki-values-aws.yaml
+    # added in v0.19.0 only exists at >= v0.19.0 refs).
     "platformRepoUrl"          = var.platform_repo_url
-    "platformVersion"          = var.platform_version
+    "platformVersion"          = local.platform_revision_effective
     "platformRevision"         = local.platform_revision_effective
     "configRepoUrl"            = var.config_repo_url
     "configRepoVersion"        = var.config_repo_version


### PR DESCRIPTION
## Summary

v0.19.0 shipped AWS provider parity (loki/mimir/velero S3 values + ClusterSecretStore AWS). After cortex bump + `terraform apply`, the live `velero` and `grafana-loki` Applications failed to load their `*-values-aws.yaml` files. This PR fixes the root cause: a latent ADR 0020 migration gap in the AWS `platform-outputs.tf` ConfigMap writer.

## The bug

Child Application templates in `bootstrap/platform-root/templates/*.yaml` reference the platform repo via `targetRevision: {{ .Values.platformVersion }}`. Their `$values` multi-source ref uses the same `platformVersion` to check out the platform repo at the right tag, and `helm.valueFiles` resolves files inside that checkout.

AWS `platform-outputs.tf` wrote the ConfigMap as:

```hcl
"platformVersion"  = var.platform_version                # literal legacy
"platformRevision" = local.platform_revision_effective    # derived
```

Clients that only bump `platform_revision` in tfvars (the documented path since v0.13.0 / ADR 0020) leave `var.platform_version` at a stale default. Live observed on cortex:

- `platformRevision = v0.19.0` ✓
- `platformVersion = v0.18.0` (stale) ✗
- `kubectl -n argocd get application velero -o yaml` → `source[1].targetRevision = v0.18.0`
- Helm rendered with only `values.yaml` (not `values-aws.yaml` — `ignoreMissingValueFiles: true` silently skipped it)
- velero schema failed: `missing property 'provider' at /configuration/{backup,volumeSnapshot}StorageLocation/0`
- loki failed: `You must provide a schema_config for Loki`

Both errors collapsed to "values-aws.yaml didn't load on v0.18.0 ref".

## Fix

`providers/aws/platform-outputs.tf`: `platformVersion = local.platform_revision_effective`. Both keys now carry the effective ref. Child templates reading `.Values.platformVersion` always see the current platform tag.

Azure untouched — doesn't write `platformRevision`, and Azure's CLI seed path populates `platformVersion` from tfvars where operators set both fields historically.

## Test plan

- [ ] Tag v0.19.1 after merge.
- [ ] Bump cortex module ref to v0.19.1.
- [ ] `terraform apply` — expect only `kubernetes_config_map.platform_infrastructure` in-place update (1 data key: `platformVersion` v0.18.0 → v0.19.1).
- [ ] Re-seed platform-root + hard-refresh child Applications.
- [ ] Verify `velero.spec.sources[1].targetRevision = v0.19.1` (was v0.18.0).
- [ ] Verify helm rendered command for velero/grafana-loki loads `values-aws.yaml`.
- [ ] velero + grafana-loki + grafana-mimir render without ComparisonError.

## Follow-up (separate PR, not blocking)

A `platform-root.platformRef` helper mirroring the existing `clientGitopsRef` helper. Migrate all `targetRevision: {{ .Values.platformVersion }}` (~30 files) to `{{ include "platform-root.platformRef" . }}` that prefers `platformRevision` over `platformVersion`. Proper fix per ADR 0020; this PR is the minimum to unblock cortex.