### PR TITLE
fix(aws): mimir S3 storage prefix per class (blocks/ruler/alertmanager) (v0.19.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [0.19.2] - 2026-04-24
+
+### Fixed — Mimir AWS S3 storage collision (blocks/ruler/alertmanager same bucket+prefix)
+
+v0.19.0 shipped `mimir-values-aws.yaml` with `blocks_storage`,
+`ruler_storage`, and `alertmanager_storage` all backed by the shared
+observability S3 bucket without differentiating prefixes. Mimir's chart
+validator rejects this:
+
+```
+error validating config: invalid bucket config:
+  ruler storage: S3 bucket name and storage prefix cannot be the same as
+  the one used in blocks storage config
+```
+
+The grafana-mimir-ruler and grafana-mimir-querier pods CrashLoopBackOff;
+`grafana-mimir-alertmanager` fails to start too.
+
+### Fix
+
+Add `storage_prefix` to each storage class in `mimir-values-aws.yaml`:
+
+```yaml
+blocks_storage:       { storage_prefix: "blocks",       ... }
+ruler_storage:        { storage_prefix: "ruler",        ... }
+alertmanager_storage: { storage_prefix: "alertmanager", ... }
+```
+
+Single bucket, three prefixes — no IAM changes, no new infra.
+
+### Azure impact
+
+Zero. Azure mimir uses `container_name: mimir-blocks` at blocks_storage
+only; ruler + alertmanager inherit common config. Pattern works because
+Azure Blob Storage distinguishes by container_name natively in the
+mimir chart. This is an AWS-specific file edit.
+
 ## [0.19.1] - 2026-04-24
 
 ### Fixed — AWS `platformVersion` ConfigMap key writes stale `var.platform_version` instead of the effective revision

--- a/core/components/grafana-stack/mimir-values-aws.yaml
+++ b/core/components/grafana-stack/mimir-values-aws.yaml
@@ -22,16 +22,24 @@ mimir:
           bucket_name: ""   # injected
           region: ""        # injected
           insecure: false
+    # Mimir requires each storage class (blocks/ruler/alertmanager) to
+    # have a DIFFERENT bucket+prefix combination — chart validator rejects
+    # matching bucket_name with matching (empty) storage_prefix. We share
+    # the observability bucket across all three by differentiating via
+    # storage_prefix within the bucket.
     blocks_storage:
       backend: s3
+      storage_prefix: "blocks"
       s3:
         bucket_name: ""     # injected
     ruler_storage:
       backend: s3
+      storage_prefix: "ruler"
       s3:
         bucket_name: ""     # injected
     alertmanager_storage:
       backend: s3
+      storage_prefix: "alertmanager"
       s3:
         bucket_name: ""     # injected
 


### PR DESCRIPTION
## Summary

Mimir chart validator rejects matching S3 bucket+empty-prefix across storage classes:

```
error validating config: invalid bucket config:
  ruler storage: S3 bucket name and storage prefix cannot be the same as
  the one used in blocks storage config
```

v0.19.0's `mimir-values-aws.yaml` shared the observability bucket across `blocks_storage`, `ruler_storage`, and `alertmanager_storage` without differentiating — result: grafana-mimir-ruler + grafana-mimir-querier CrashLoopBackOff.

## Fix

Add `storage_prefix` per class — `blocks`, `ruler`, `alertmanager`. Single bucket, three prefixes inside it. No IAM or infra changes.

## Azure impact

Zero. Azure mimir uses `container_name: mimir-blocks` only at `blocks_storage`; ruler + alertmanager inherit common config and Azure Blob distinguishes via `container_name` natively.