### PR TITLE
fix(aws): mimir S3 endpoint + platform-secrets opencost gate (v0.19.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## [0.19.3] - 2026-04-24
+
+### Fixed — Mimir S3 endpoint missing + platform-secrets opencost gate
+
+Two issues surfaced by the cortex seed after v0.19.2 unblocked the
+storage_prefix collision:
+
+#### 1. Mimir: `no s3 endpoint in config file`
+
+Mimir's thanos-io/objstore library requires an explicit `s3.endpoint`
+config entry even on AWS-native S3 (unlike Loki which auto-derives
+from region). The v0.19.0 mimir-values-aws.yaml + helm.parameters
+didn't set it, so mimir-ingester/querier/ruler/alertmanager
+CrashLoopBackOff with:
+
+```
+level=error msg="error running application"
+  err="no s3 endpoint in config file"
+```
+
+Fix: `bootstrap/platform-root/templates/grafana-stack.yaml` grafana-mimir
+AWS branch now injects
+`mimir.structuredConfig.common.storage.s3.endpoint = s3.<region>.amazonaws.com`.
+
+#### 2. platform-secrets: opencost ExternalSecrets fail on opencost-disabled clusters
+
+`core/components/platform-secrets/templates/opencost.yaml` emitted
+two ExternalSecrets targeting `namespace: opencost` unconditionally.
+When a downstream sets `components.opencost: false` (cortex does —
+AWS CUR integration is deferred), the opencost Application is never
+created, the namespace doesn't exist, and platform-secrets sync
+fails:
+
+```
+one or more objects failed to apply, reason: namespaces "opencost"
+not found
+```
+
+Fix:
+- Wrap opencost.yaml in `{{- if .Values.opencostEnabled }}`.
+- Add `opencostEnabled: true` default in platform-secrets values.yaml
+  (keeps existing Azure deployments unchanged).
+- platform-root's platform-secrets.yaml passes
+  `opencostEnabled = (ne components.opencost false)` as helm parameter.
+
+### Migration
+
+v0.19.2 → v0.19.3: pure Helm template update, no TF churn.
+
+### Azure impact
+
+Zero on mimir side (Azure uses container_name, different code path).
+Zero on opencost side (Azure clients ship with opencost enabled; the
+new gate defaults true).
+
 ## [0.19.2] - 2026-04-24
 
 ### Fixed — Mimir AWS S3 storage collision (blocks/ruler/alertmanager same bucket+prefix)

--- a/bootstrap/platform-root/templates/grafana-stack.yaml
+++ b/bootstrap/platform-root/templates/grafana-stack.yaml
@@ -188,6 +188,8 @@ spec:
             value: "{{ .Values.global.observabilityBucketName }}"
           - name: mimir.structuredConfig.common.storage.s3.region
             value: "{{ .Values.global.region }}"
+          - name: mimir.structuredConfig.common.storage.s3.endpoint
+            value: "s3.{{ .Values.global.region }}.amazonaws.com"
           - name: mimir.structuredConfig.blocks_storage.s3.bucket_name
             value: "{{ .Values.global.observabilityBucketName }}"
           - name: mimir.structuredConfig.ruler_storage.s3.bucket_name

--- a/bootstrap/platform-root/templates/platform-secrets.yaml
+++ b/bootstrap/platform-root/templates/platform-secrets.yaml
@@ -37,6 +37,11 @@ spec:
         - name: acrLoginServer
           value: {{ .Values.global.acrLoginServer | quote }}
         {{- end }}
+        {{- /* Propagate components.opencost to the platform-secrets chart
+              so opencost ExternalSecrets don't render into the opencost
+              namespace when that component is disabled downstream. */}}
+        - name: opencostEnabled
+          value: "{{ ne (index .Values.components "opencost") false }}"
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd

--- a/core/components/platform-secrets/templates/opencost.yaml
+++ b/core/components/platform-secrets/templates/opencost.yaml
@@ -1,3 +1,11 @@
+{{- /* Opencost ExternalSecrets target the `opencost` namespace, which
+       is only created by the opencost Application when that component
+       is enabled. Downstream can disable opencost via
+       `components.opencost: false` in overrides/platform-root/values.yaml;
+       platform-root propagates this to the platform-secrets chart via
+       the `opencostEnabled` helm parameter. Guard against rendering
+       these ExternalSecrets in a namespace that doesn't exist. */}}
+{{- if .Values.opencostEnabled }}
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -43,3 +51,4 @@ spec:
     - secretKey: serviceKey
       remoteRef:
         key: {{ .Values.kvSecrets.opencostServiceKey | quote }}
+{{- end }}

--- a/core/components/platform-secrets/values.yaml
+++ b/core/components/platform-secrets/values.yaml
@@ -7,6 +7,14 @@ clientGitopsRepoUrl: ""
 # ACR OCI credentials — only created when acrLoginServer is set
 acrLoginServer: ""
 
+# Opencost ExternalSecrets — only created when opencostEnabled is true.
+# Set to false on deployments that disable opencost via
+# components.opencost: false in platform-root overrides, so the chart
+# does not attempt to render ExternalSecrets into a non-existent
+# opencost namespace. The platform-root template passes this flag from
+# its own `components.opencost` value.
+opencostEnabled: true
+
 # Key Vault secret names — must exist in Key Vault before platform deploy
 kvSecrets:
   configRepoToken: "platform-config-repo-token"


### PR DESCRIPTION
Mimir requires explicit s3.endpoint on AWS; platform-secrets opencost gate added so cortex (opencost disabled) doesn't fail on missing namespace. Full details: Estabilis/estabilis-platform PR body.