### PR TITLE
fix(aws): platform-secrets kvSecrets path prefix for AWS SM (v0.19.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## [0.19.4] - 2026-04-24
+
+### Fixed — AWS ExternalSecret remoteRef.key path prefix
+
+Cortex seed after v0.19.3 observed all 7 platform-secrets ExternalSecrets
+failing with `AccessDeniedException: secretsmanager:GetSecretValue`.
+Root cause: the platform-secrets chart's `kvSecrets.*` default values
+use flat Key-Vault-style names (`platform-argocd-redis-password`),
+but AWS SM secrets under Estabilis convention live at full paths
+(`estabilis/<deploymentId>/platform-argocd-redis-password`). The
+external-secrets IRSA role (`module.external_secrets_irsa`) explicitly
+scopes its Secrets Manager access to that ARN pattern, so the flat
+names get denied.
+
+### Fix
+
+`bootstrap/platform-root/templates/platform-secrets.yaml` gains an AWS
+branch that passes each `kvSecrets.*` override as a helm parameter
+with the prefix prepended. Azure retains the flat default values.
+
+Secrets handled (6): argocdRedisPassword, grafanaAdminPassword,
+grafanaDbPassword, configRepoToken, clientGitopsRepoToken, openaiApiKey.
+Opencost secrets are already gated via `opencostEnabled` (v0.19.3)
+and not re-keyed here.
+
+### Operator caveat
+
+Secrets that Terraform does not auto-provision on AWS (configRepoToken,
+clientGitopsRepoToken, openaiApiKey) must be populated in AWS Secrets
+Manager by the operator before the corresponding ExternalSecret can
+reach `SecretSynced=True`. Same discipline as Azure Key Vault.
+
+### Azure impact
+
+Zero — the `{{- if eq .Values.global.provider "aws" }}` branch does
+not execute on Azure. Existing kvSecrets flat defaults continue to
+address Azure Key Vault secrets by name.
+
 ## [0.19.3] - 2026-04-24
 
 ### Fixed — Mimir S3 endpoint missing + platform-secrets opencost gate

--- a/bootstrap/platform-root/templates/platform-secrets.yaml
+++ b/bootstrap/platform-root/templates/platform-secrets.yaml
@@ -42,6 +42,30 @@ spec:
               namespace when that component is disabled downstream. */}}
         - name: opencostEnabled
           value: "{{ ne (index .Values.components "opencost") false }}"
+        {{- if eq .Values.global.provider "aws" }}
+        {{- /* AWS Secrets Manager secrets live under
+              estabilis/<deploymentId>/* path (the IRSA scope for
+              external-secrets). ExternalSecret remoteRef.key must be
+              the full SM secret name. Override each kvSecrets entry
+              with its prefixed path. Secrets not provisioned by TF
+              (configRepoToken, clientGitopsRepoToken, openaiApiKey,
+              opencost*) will fail individual SecretSynced reconciliation
+              until the operator populates them in SM — consistent with
+              how Azure deployments require the corresponding Key Vault
+              secrets to exist. */}}
+        - name: kvSecrets.argocdRedisPassword
+          value: "{{ .Values.global.secretsPathPrefix }}/platform-argocd-redis-password"
+        - name: kvSecrets.grafanaAdminPassword
+          value: "{{ .Values.global.secretsPathPrefix }}/platform-grafana-admin-password"
+        - name: kvSecrets.grafanaDbPassword
+          value: "{{ .Values.global.secretsPathPrefix }}/platform-grafana-db-password"
+        - name: kvSecrets.configRepoToken
+          value: "{{ .Values.global.secretsPathPrefix }}/platform-config-repo-token"
+        - name: kvSecrets.clientGitopsRepoToken
+          value: "{{ .Values.global.secretsPathPrefix }}/platform-client-gitops-repo-token"
+        - name: kvSecrets.openaiApiKey
+          value: "{{ .Values.global.secretsPathPrefix }}/platform-openai-api-key"
+        {{- end }}
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd


### PR DESCRIPTION
ExternalSecrets fail with AccessDeniedException because kvSecrets defaults use flat Key-Vault-style names but AWS SM (via IRSA-scoped path estabilis/<deploymentId>/*) needs full paths. Platform-root passes prefixed paths as helm.parameters on AWS. Azure unchanged.