### PR TITLE
feat(aws): CNPG Postgres Cluster on S3 via IRSA (v0.20.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,72 @@
 # Changelog
 
+## [0.20.0] - 2026-04-24
+
+### Added — CNPG Postgres Cluster on AWS (Barman Cloud → S3 via IRSA)
+
+Closes the "cnpg backup on AWS" gap tracked in
+Estabilis/estabilis-platform-tools#186 (explicitly deferred on Phase 1).
+
+The `cnpg-cluster` Application was gated azure-only in
+`bootstrap/platform-root/templates/cnpg.yaml`, so AWS clusters ran the
+cnpg operator but never got a `Cluster` CR. Grafana (and any other
+component that talks to `platform-postgres-rw.cnpg-system`) could not
+come up.
+
+### Changes
+
+#### 1. Chart: `core/components/cnpg-cluster/`
+
+- `templates/cluster-azure.yaml` now wrapped in
+  `{{- if eq .Values.global.provider "azure" }}` (was unconditional).
+- **NEW** `templates/cluster-aws.yaml`: emits the same 3 resources as
+  Azure (`Cluster`, `ScheduledBackup`, `ServiceAccount`) with:
+  - `backup.barmanObjectStore.destinationPath: s3://<bucket>/platform-postgres`
+  - `endpointURL: https://s3.<region>.amazonaws.com`
+  - `s3Credentials.inheritFromIAMRole: true` (no static keys)
+  - `ServiceAccount.annotations.eks.amazonaws.com/role-arn` (IRSA)
+  - Generic EKS tolerations (no `kubernetes.azure.com/scalesetpriority`).
+- `values.yaml` grows provider-neutral fields with AWS (bucket, region,
+  roleArn) alongside the Azure (storageAccount, containerName, clientId)
+  originals. Both coexist safely since only one branch renders.
+
+#### 2. platform-root: `bootstrap/platform-root/templates/cnpg.yaml`
+
+- Gate widened from `azure-only` to `azure OR aws`.
+- AWS `{{- else if }}` helm.parameters branch passes:
+  - `global.cnpgBackupBucketName` → `aws_s3_bucket.cnpg_backup.id`
+  - `global.region` → `var.region`
+  - `identity.cnpg.roleArn` → `aws_iam_role.cnpg.arn`
+- Provider-agnostic parameters (retention days, schedule) hoisted
+  outside the provider conditional.
+- Added `global.provider` parameter so the chart templates can gate
+  themselves.
+
+### Terraform: already provisioned
+
+`providers/aws/` already had everything in place since Phase 1:
+- `aws_s3_bucket.cnpg_backup` + encryption/versioning/public-block
+- `aws_iam_role.cnpg` + `aws_iam_role_policy.cnpg_s3` (trust scoped to
+  SA `cnpg-system:platform-postgres`; policy grants S3 CRUD on the
+  cnpg_backup bucket + KMS ops on `aws_kms_key.s3_data`).
+- ConfigMap writes `global.cnpgBackupBucketName` + `identity.cnpg.roleArn`.
+
+### Azure impact
+
+Zero. The azure branch of `cnpg.yaml` carries identical parameter
+names and the `cluster-azure.yaml` template is untouched beyond the
+outer `{{- if azure }}` guard — which never evaluates false on Azure.
+The values.yaml additions are ignored (no template references them
+on Azure).
+
+### Migration
+
+v0.19.4 → v0.20.0 on AWS: pure chart update, no TF churn. Re-seed
+`platform-root`, hard-refresh + sync `cnpg-cluster`. Expect a new
+`Cluster/platform-postgres` CR in `cnpg-system`, followed by
+`platform-postgres-{1,2,3}` Pods and the `platform-postgres-rw`
+Service that `grafana-db` is waiting on.
+
 ## [0.19.4] - 2026-04-24
 
 ### Fixed — AWS ExternalSecret remoteRef.key path prefix

--- a/bootstrap/platform-root/templates/cnpg.yaml
+++ b/bootstrap/platform-root/templates/cnpg.yaml
@@ -44,16 +44,22 @@ spec:
       - CreateNamespace=true
       - ServerSideApply=true
 ---
-{{- /* cnpg-cluster — AZURE-ONLY on Phase 1. The chart wires backup
-      storage against Azure Blob via managed identity; the AWS backup
-      path (Barman Cloud against S3 with IRSA) is not implemented yet.
-      When the AWS backup story lands, replace this gate with a
-      provider-aware rendering (follow-up issue below).
+{{- /* cnpg-cluster — provider-aware rendering (v0.20.0+).
 
-      Tracker: Estabilis/estabilis-platform-tools#186 — this is the
-      "cnpg backup on AWS" slice explicitly deferred. Open a dedicated
-      issue before shipping AWS CNPG backups. */ -}}
-{{- if eq .Values.global.provider "azure" }}
+      The chart under core/components/cnpg-cluster carries two templates:
+        - cluster-azure.yaml: Barman Cloud → Azure Blob Storage, auth
+          via Azure Workload Identity (inheritFromAzureAD: true).
+        - cluster-aws.yaml: Barman Cloud → S3, auth via IRSA
+          (s3Credentials.inheritFromIAMRole: true).
+
+      Each template is gated on `.Values.global.provider`, so this
+      Application emits exactly one Cluster CR + ScheduledBackup +
+      ServiceAccount per cluster.
+
+      The AWS branch lands in v0.20.0, replacing the Azure-only gate
+      that used to guard this Application. Closes the gap flagged in
+      Estabilis/estabilis-platform-tools#186. */ -}}
+{{- if or (eq .Values.global.provider "azure") (eq .Values.global.provider "aws") }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -70,16 +76,27 @@ spec:
           - $values/core/components/cnpg-cluster/values.yaml
         parameters:
           {{- include "platform-root.provenanceParameters" $ | nindent 10 }}
-          - name: global.storageAccountName
-            value: "{{ .Values.global.cnpgStorageAccountName }}"
-          - name: global.cnpgBackupContainerName
-            value: "{{ .Values.global.cnpgBackupContainerName }}"
+          - name: global.provider
+            value: "{{ .Values.global.provider }}"
           - name: global.cnpgBackupRetentionDays
             value: "{{ .Values.global.cnpgBackupRetentionDays }}"
           - name: global.cnpgBackupSchedule
             value: "{{ .Values.global.cnpgBackupSchedule }}"
+          {{- if eq .Values.global.provider "azure" }}
+          - name: global.storageAccountName
+            value: "{{ .Values.global.cnpgStorageAccountName }}"
+          - name: global.cnpgBackupContainerName
+            value: "{{ .Values.global.cnpgBackupContainerName }}"
           - name: identity.cnpg.clientId
             value: "{{ .Values.identity.cnpg.clientId }}"
+          {{- else if eq .Values.global.provider "aws" }}
+          - name: global.cnpgBackupBucketName
+            value: "{{ .Values.global.cnpgBackupBucketName }}"
+          - name: global.region
+            value: "{{ .Values.global.region }}"
+          - name: identity.cnpg.roleArn
+            value: "{{ .Values.identity.cnpg.roleArn }}"
+          {{- end }}
     - repoURL: {{ .Values.platformRepoUrl }}
       targetRevision: {{ .Values.platformVersion }}
       ref: values

--- a/core/components/cnpg-cluster/templates/cluster-aws.yaml
+++ b/core/components/cnpg-cluster/templates/cluster-aws.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.global.provider "azure" }}
+{{- if eq .Values.global.provider "aws" }}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
@@ -16,10 +16,6 @@ spec:
       cpu: {{ .Values.postgres.resources.limits.cpu | quote }}
       memory: {{ .Values.postgres.resources.limits.memory | quote }}
 
-  inheritedMetadata:
-    labels:
-      azure.workload.identity/use: "true"
-
   # PostgreSQL version
   imageName: ghcr.io/cloudnative-pg/postgresql:18.1
 
@@ -33,7 +29,7 @@ spec:
       database: app
       owner: app
 
-  # Roles managed declaratively
+  # Roles managed declaratively — mirrors the Azure variant.
   managed:
     roles:
       - name: grafana
@@ -45,23 +41,31 @@ spec:
         passwordSecret:
           name: grafana-db-credentials
 
-  # Backup to Azure Blob Storage via WAL archiving
+  # Backup to S3 via Barman Cloud.
+  #
+  # `s3Credentials.inheritFromIAMRole: true` makes CNPG rely on the IRSA
+  # annotation set on the ServiceAccount below (no static keys). The IAM
+  # policy is provisioned by providers/aws/iam.tf:
+  #   - aws_iam_role.cnpg — trust scoped to cnpg-system:platform-postgres
+  #   - aws_iam_role_policy.cnpg_s3 — s3:{Get,Put,Delete,List} on the
+  #     cnpg_backup bucket + KMS permissions on aws_kms_key.s3_data.
   backup:
     barmanObjectStore:
-      destinationPath: "https://{{ .Values.global.storageAccountName }}.blob.core.windows.net/{{ .Values.global.cnpgBackupContainerName }}"
-      azureCredentials:
-        inheritFromAzureAD: true
+      destinationPath: "s3://{{ .Values.global.cnpgBackupBucketName }}/platform-postgres"
+      endpointURL: "https://s3.{{ .Values.global.region }}.amazonaws.com"
+      s3Credentials:
+        inheritFromIAMRole: true
     retentionPolicy: "{{ .Values.global.cnpgBackupRetentionDays }}d"
 
+  # AWS EKS uses generic node pools — no provider-specific taint
+  # tolerations. The `estabilis.io/workload-type: platform` toleration
+  # matches the MNG node group annotations written by
+  # providers/aws/eks.tf.
   affinity:
     tolerations:
       - key: "estabilis.io/workload-type"
         operator: "Equal"
         value: "platform"
-        effect: "NoSchedule"
-      - key: "kubernetes.azure.com/scalesetpriority"
-        operator: "Equal"
-        value: "spot"
         effect: "NoSchedule"
     topologyKey: topology.kubernetes.io/zone
     nodeAffinity:
@@ -90,13 +94,15 @@ spec:
   cluster:
     name: platform-postgres
 ---
+# IRSA ServiceAccount consumed by the cnpg Cluster above via its
+# `inheritFromIAMRole` backup credentials path. The role ARN is
+# injected as a helm parameter from the platform-root cnpg.yaml
+# template (identity.cnpg.roleArn → aws_iam_role.cnpg.arn).
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: platform-postgres
   namespace: cnpg-system
   annotations:
-    azure.workload.identity/client-id: "{{ .Values.identity.cnpg.clientId }}"
-  labels:
-    azure.workload.identity/use: "true"
+    eks.amazonaws.com/role-arn: "{{ .Values.identity.cnpg.roleArn }}"
 {{- end }}

--- a/core/components/cnpg-cluster/values.yaml
+++ b/core/components/cnpg-cluster/values.yaml
@@ -1,6 +1,12 @@
 global:
+  provider: ""                         # injected by platform-root (azure|aws)
+  # Azure only:
   storageAccountName: ""
   cnpgBackupContainerName: "cnpg-backup"
+  # AWS only:
+  cnpgBackupBucketName: ""
+  region: ""
+  # Provider-agnostic:
   cnpgBackupRetentionDays: 7
   cnpgBackupSchedule: "0 2 * * *"
 postgres:
@@ -14,4 +20,5 @@ postgres:
       memory: "1Gi"
 identity:
   cnpg:
-    clientId: ""
+    clientId: ""                       # Azure only (Workload Identity)
+    roleArn: ""                        # AWS only (IRSA)


### PR DESCRIPTION
Closes cnpg-cluster AWS gap explicitly deferred on Phase 1 (Estabilis/estabilis-platform-tools#186).

New cluster-aws.yaml template: Barman Cloud → S3 with s3Credentials.inheritFromIAMRole. ServiceAccount annotated for IRSA. Platform-root widens gate from azure-only to azure|aws and passes the AWS-specific helm.parameters. Zero Azure impact (outer if-azure wrapper on existing template; rendered output identical).

TF side was already provisioned in Phase 1 (aws_s3_bucket.cnpg_backup + aws_iam_role.cnpg with full policy). Pure chart change.