### PR TITLE
fix(aws): gate per-repo PAT ExternalSecrets when GitHub App configured (v0.20.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog
 
+## [0.20.1] - 2026-04-24
+
+### Fixed — Repo-creds collision when GitHub App is configured
+
+The `platform-secrets` chart emits two `ExternalSecret` resources
+(`repo-config-client`, `repo-client-gitops`) that produce argocd
+`type: repository` Secrets with per-repo URL + token. When a GitHub
+App is ALSO configured (via `modules/github-app-credentials/`, new
+in v0.18.0), the resulting `repo-creds` Secret covers the whole org
+by prefix match.
+
+ArgoCD's repo matching prefers `type: repository` (exact URL) over
+`type: repo-creds` (prefix). If the per-repo `password` field is
+empty/placeholder — which happens on AWS when the `configRepoToken`
+and `clientGitopsRepoToken` secrets have not been populated in AWS
+Secrets Manager (the default, since TF does not provision them) —
+ArgoCD authenticates with the empty/placeholder value and fails:
+
+```
+level=error msg="Failed to get git client for repo
+  https://github.com/<org>/<repo>.git: failed to list refs:
+  authentication required: Invalid username or token.
+  Password authentication is not supported for Git operations."
+```
+
+This blocks platform-root `$overrides` source resolution and every
+child Application goes `ComparisonError` until the placeholders are
+replaced with real tokens — defeating the purpose of having the
+GitHub App in the first place.
+
+### Fix
+
+- `core/components/platform-secrets/templates/argocd.yaml`: both
+  ExternalSecrets now gated on
+  `and .Values.<url> (not .Values.githubAppEnabled)` — so they only
+  render on deployments that lack a GitHub App (legacy PAT path).
+- `core/components/platform-secrets/values.yaml`:
+  `githubAppEnabled: false` default.
+- `bootstrap/platform-root/templates/platform-secrets.yaml` passes
+  `githubAppEnabled = (ne global.githubAppID "")` as helm parameter.
+
+### Azure impact
+
+Neutral. Existing Azure deployments that do not set
+`github_app_id` (most or all of them today) get
+`githubAppEnabled=false` → gate behaves identically to pre-0.20.1 →
+the per-repo ExternalSecrets still render exactly as before. Azure
+deployments that later adopt the GitHub App module
+(cloud-agnostic since v0.18.0) benefit from the same collision fix.
+
+### Migration
+
+v0.20.0 → v0.20.1 on AWS with GitHub App: pure chart update, no TF.
+After bump + sync, manually delete the stale
+`repo-config-client` and `repo-client-gitops` Secrets in the `argocd`
+namespace (they are no longer managed by the ExternalSecrets) so that
+ArgoCD falls back to the `github-app-<org>` repo-creds Secret for
+repo auth.
+
 ## [0.20.0] - 2026-04-24
 
 ### Added — CNPG Postgres Cluster on AWS (Barman Cloud → S3 via IRSA)

--- a/bootstrap/platform-root/templates/platform-secrets.yaml
+++ b/bootstrap/platform-root/templates/platform-secrets.yaml
@@ -42,6 +42,15 @@ spec:
               namespace when that component is disabled downstream. */}}
         - name: opencostEnabled
           value: "{{ ne (index .Values.components "opencost") false }}"
+        {{- /* When a GitHub App is configured, the platform module writes
+              a cluster-wide repo-creds Secret that covers every repo
+              under the org. The per-repo PAT ExternalSecrets in
+              platform-secrets.yaml become redundant AND collide with
+              repo-creds matching (type: repository outranks
+              type: repo-creds). Propagate a flag so the chart skips
+              them. */}}
+        - name: githubAppEnabled
+          value: "{{ ne (.Values.global.githubAppID | toString) "" }}"
         {{- if eq .Values.global.provider "aws" }}
         {{- /* AWS Secrets Manager secrets live under
               estabilis/<deploymentId>/* path (the IRSA scope for

--- a/core/components/platform-secrets/templates/argocd.yaml
+++ b/core/components/platform-secrets/templates/argocd.yaml
@@ -1,4 +1,12 @@
-{{- if .Values.configRepoUrl }}
+{{- /* Per-repo PAT ExternalSecrets are skipped when the cluster has
+       a GitHub App credentials Secret wired (githubAppEnabled=true).
+       ArgoCD's `type: repository` secrets match by exact URL and
+       outrank `type: repo-creds` prefix matches — so leaving both in
+       place makes ArgoCD prefer the per-repo PAT (empty/unpopulated
+       by default on AWS), breaking repo auth. With GitHub App
+       configured, the org-wide repo-creds Secret covers every repo
+       under the org without needing these per-repo entries. */}}
+{{- if and .Values.configRepoUrl (not .Values.githubAppEnabled) }}
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -29,7 +37,7 @@ spec:
         key: {{ .Values.kvSecrets.configRepoToken | quote }}
 {{- end }}
 ---
-{{- if .Values.clientGitopsRepoUrl }}
+{{- if and .Values.clientGitopsRepoUrl (not .Values.githubAppEnabled) }}
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/core/components/platform-secrets/values.yaml
+++ b/core/components/platform-secrets/values.yaml
@@ -15,6 +15,16 @@ acrLoginServer: ""
 # its own `components.opencost` value.
 opencostEnabled: true
 
+# GitHub App credentials Secret is wired by the estabilis-platform
+# `github-app-credentials` module (providers/aws/github-app.tf). When
+# present, it covers all repos under the configured org via ArgoCD's
+# `argocd.argoproj.io/secret-type: repo-creds` prefix match, so the
+# per-repo PAT ExternalSecrets (repo-config-client, repo-client-gitops)
+# below are redundant AND actively harmful: `type: repository` secrets
+# outrank `type: repo-creds` and break auth when their `password` field
+# holds a placeholder.
+githubAppEnabled: false
+
 # Key Vault secret names — must exist in Key Vault before platform deploy
 kvSecrets:
   configRepoToken: "platform-config-repo-token"


### PR DESCRIPTION
When GitHub App is configured, its repo-creds Secret covers the whole org by prefix. ArgoCD prefers per-repo `type: repository` Secrets over `type: repo-creds` — so leaving both creates a collision where ArgoCD auths with the placeholder PAT and breaks every repo fetch.

Gate the per-repo ExternalSecrets on `(not githubAppEnabled)`. Azure-neutral.