### PR TITLE
feat(aws): metrics-server + Karpenter v1.12.0 + AppProject whitelists (v0.21.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,129 @@
 # Changelog
 
+## [0.21.0] - 2026-04-24
+
+### Added — metrics-server (AWS) + Karpenter v1.12.0 (AWS) + ArgoCD AppProject whitelists
+
+Two cluster-autoscaling and observability primitives that EKS does NOT
+ship by default but the legacy `cortex-eks-prod` cluster has run in
+production for months. AKS provides metrics-server natively and uses
+its own cluster-autoscaler — both Applications are gated on
+`provider == "aws"`.
+
+#### 1. metrics-server
+
+EKS doesn't include metrics-server in its managed addon set; without
+it, `kubectl top`, HPA, and any controller that reads the Resource
+Metrics API stay broken. New Application:
+
+- `bootstrap/platform-root/templates/metrics-server.yaml` — chart
+  pinned to 3.12.2 (image v0.7.x), gated on
+  `provider == "aws"` AND `components.metrics-server != false`.
+- Values live in
+  `estabilis-platform-gitops/values/platform/metrics-server.yaml`
+  (ADR 0002 Phase 3 layout — values in gitops, Application in platform).
+- Defaults mirror the legacy cortex configuration: 2 replicas,
+  podAntiAffinity by hostname, `--kubelet-insecure-tls`, tight
+  resource ask + limit.
+
+#### 2. Karpenter v1.12.0
+
+Despite Terraform provisioning the IAM controller role, IAM node role,
+SQS interruption queue, and instance-profile-gc policy since Phase 1,
+the Karpenter Helm chart was never installed on AWS clusters. Result:
+`autoscaler = "karpenter"` and `autoscaler = "hybrid"` resolved to
+"only the static MNG scales" — no spot capacity, no consolidation, no
+elastic ceiling.
+
+Three Applications added (`bootstrap/platform-root/templates/karpenter.yaml`):
+
+1. **`karpenter-crds`** (sync-wave -1) — chart
+   `oci://public.ecr.aws/karpenter/karpenter-crd` v1.12.0. Installs
+   `NodePool`, `EC2NodeClass`, `NodeClaim`. `SkipDryRunOnMissingResource=true`
+   prevents the next wave from blocking on Establishment timing.
+
+2. **`karpenter`** (sync-wave 0) — chart
+   `oci://public.ecr.aws/karpenter/karpenter` v1.12.0. Controller +
+   webhook. Helm parameters wired from `platform-infrastructure`
+   ConfigMap: `settings.clusterName`, `settings.interruptionQueue`,
+   IRSA `serviceAccount.annotations.eks.amazonaws.com/role-arn`. Values
+   in `gitops/values/platform/karpenter.yaml` mirror the legacy cortex
+   release (controller resources, fargate toleration, `featureGates.spotToSpotConsolidation: true`).
+
+3. **`karpenter-resources`** (sync-wave 1) — Estabilis-authored chart at
+   `gitops/components/karpenter-resources/` with `NodePool` +
+   `EC2NodeClass` templates. Defaults match legacy production:
+   - NodePool: limits cpu=32 mem=64Gi, disruption
+     `WhenEmptyOrUnderutilized` after 1m, requirements amd64 + spot/on-demand,
+     instance categories c/m/r/t, generation > 4, sizes medium/large/xlarge,
+     `expireAfter: 720h`.
+   - EC2NodeClass: AMI alias `al2023@latest`, BDM `/dev/xvda` 30Gi gp3
+     encrypted, **IMDSv2 enforcement** (`httpTokens: required`,
+     `httpPutResponseHopLimit: 1`, `httpProtocolIPv6: disabled`) — same
+     security baseline as the legacy cluster.
+   - Subnet/SG selection via Terraform-applied
+     `<global.karpenterDiscoveryTagKey>=<clusterName>` tags (default
+     `estabilis.io/discovery=<cluster>`, allows multiple Estabilis
+     deployments to coexist in one VPC).
+
+Activation gate: `provider == "aws"` AND
+`components.karpenter != false` AND `autoscaler in [karpenter, hybrid]`.
+Provider asymmetry (Azure NAP / `karpenter-provider-azure`) tracked
+in `Estabilis/estabilis-platform-tools#197`.
+
+#### 3. AppProject `platform` — sourceRepos, destinations, clusterResourceWhitelist
+
+`bootstrap/platform-root/templates/argocd-project.yaml` updated so
+new Applications validate cleanly:
+
+- `sourceRepos`: added `https://kubernetes-sigs.github.io/metrics-server/`
+  and `public.ecr.aws/karpenter`.
+- `destinations`: added `metrics-server` and `karpenter` namespaces.
+- `clusterResourceWhitelist`: added `karpenter.sh/*` (NodePool, NodeClaim
+  are cluster-scoped) and `karpenter.k8s.aws/*` (EC2NodeClass).
+
+Without these, ArgoCD rejects the Applications at sync time with
+`InvalidSpecError: application repo X is not permitted in project 'platform'`
+or `Resource X is not allowed in project`.
+
+### Components map
+
+`bootstrap/platform-root/values.yaml` `components:` map gains
+`metrics-server: true`, `karpenter: true`, `karpenter-resources: true`
+defaults so downstream can disable individually via overrides.
+
+### Provenance
+
+Both new Applications include the standard
+`platform-root.provenanceParameters` /
+`platform-root.provenanceParametersBlock` helpers so ADR 0005 L1
+supply-chain annotations flow onto every rendered resource.
+
+### Dependency
+
+**Requires `estabilis-platform-gitops >= v0.35.0`** — the new
+`karpenter-resources` chart and the `values/platform/{metrics-server,karpenter}.yaml`
+overlays are published from that release.
+
+### Migration
+
+Operators on AWS at `v0.20.1` → `v0.21.0`:
+
+1. Bump `estabilis-platform-gitops` to v0.35.0+ first
+   (`platformGitopsVersion` in `overrides/platform-root/values.yaml`).
+2. Bump `estabilis-platform` to v0.21.0
+   (`main.tf ref=v0.21.0`, `terraform.tfvars platform_revision`).
+3. `terraform apply` — no infra-side changes, only the platform-root
+   ConfigMap data refresh.
+4. Refresh + sync `platform-root`. Three new Applications appear:
+   `metrics-server`, `karpenter-crds`, `karpenter`, `karpenter-resources`.
+5. After Karpenter controller is Healthy, scale the static MNG down
+   (Karpenter handles burst capacity from there).
+
+### Azure impact
+
+Zero. All new Applications are `provider == "aws"` gated.
+
 ## [0.20.1] - 2026-04-24
 
 ### Fixed — Repo-creds collision when GitHub App is configured

--- a/bootstrap/platform-root/templates/argocd-project.yaml
+++ b/bootstrap/platform-root/templates/argocd-project.yaml
@@ -32,6 +32,8 @@ spec:
     - "https://cloudnative-pg.github.io/charts"
     - "https://vmware-tanzu.github.io/helm-charts"
     - "https://prometheus-community.github.io/helm-charts"
+    - "https://kubernetes-sigs.github.io/metrics-server/"
+    - "public.ecr.aws/karpenter"
     {{- /*
     Platform add-on repos: must match the repoURL emitted by
     platform-addons.yaml. ArgoCD 3.x requires OCI Helm repoURL WITHOUT
@@ -90,6 +92,10 @@ spec:
       namespace: policy-reporter
     - server: https://kubernetes.default.svc
       namespace: estabilis-system
+    - server: https://kubernetes.default.svc
+      namespace: metrics-server
+    - server: https://kubernetes.default.svc
+      namespace: karpenter
     {{- range $name, $addon := .Values.platformAddons }}
     {{- if $addon.namespace }}
     - server: https://kubernetes.default.svc
@@ -121,6 +127,10 @@ spec:
       kind: VolumeSnapshotClass
     - group: policy
       kind: PodDisruptionBudget
+    - group: karpenter.sh
+      kind: "*"
+    - group: karpenter.k8s.aws
+      kind: "*"
 ---
 # Workload-baseline project — for platform baseline components deployed
 # to workload clusters via the workload-bootstrap ApplicationSets.

--- a/bootstrap/platform-root/templates/karpenter.yaml
+++ b/bootstrap/platform-root/templates/karpenter.yaml
@@ -1,0 +1,159 @@
+{{- /*
+  Karpenter — cluster autoscaler for EKS.
+
+  AWS-only. Azure clusters use the AKS native autoscaler. Renders
+  three Applications:
+
+    1. karpenter-crds — installs Karpenter CRDs (NodePool,
+       EC2NodeClass, NodeClaim). Sync wave -1 so CRDs exist before
+       the controller chart references them and before the resources
+       chart attempts to render the CRs.
+
+    2. karpenter — controller + webhook. Sync wave 0. IRSA role,
+       interruption queue, cluster name come from the
+       `platform-infrastructure` ConfigMap (Terraform-written) and
+       are passed through as helm parameters.
+
+    3. karpenter-resources — default NodePool + EC2NodeClass. Sync
+       wave 1, after the CRDs are established. Subnet/SG discovery
+       uses `var.karpenter_discovery_tag_key` (default
+       `estabilis.io/discovery`) to coexist with other Estabilis
+       deployments in the same VPC.
+
+  Active when `autoscaler` is `karpenter` or `hybrid` (the latter
+  combines a small Managed Node Group for system workloads with
+  Karpenter on top for elastic capacity). When `autoscaler` is
+  `none` or `cluster-autoscaler`, all three Applications are
+  skipped — Terraform leaves the IAM/SQS resources unprovisioned
+  in those modes.
+*/ -}}
+{{- if and (eq .Values.global.provider "aws") (ne (index .Values.components "karpenter") false) (or (eq .Values.global.autoscaler "karpenter") (eq .Values.global.autoscaler "hybrid")) }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: karpenter-crds
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  project: platform
+  source:
+    repoURL: public.ecr.aws/karpenter
+    chart: karpenter-crd
+    targetRevision: "1.12.0"
+    {{- /* karpenter-crd chart version stays in lockstep with the
+          karpenter controller chart — both published at the same
+          SemVer per release. Latest as of 2026-04-24: v1.12.0
+          (additive changes only vs v1.9.x baseline). */}}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: karpenter
+  syncPolicy:
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      {{- /* CRDs need Established=True before karpenter-resources (wave 1)
+            attempts to render NodePool/EC2NodeClass. ArgoCD waves only
+            order Application sync starts, not resource readiness — this
+            option lets the next wave proceed past the dry-run check
+            even if a CRD is still being established at apply time. */}}
+      - SkipDryRunOnMissingResource=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: karpenter
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: platform
+  sources:
+    - repoURL: public.ecr.aws/karpenter
+      chart: karpenter
+      targetRevision: "1.12.0"
+      helm:
+        valueFiles:
+          - $values/values/platform/karpenter.yaml
+          {{- include "platform-root.overrideValueFile" (dict "component" "karpenter" "root" $) | nindent 10 }}
+          {{- include "platform-root.gitopsValueFile" (dict "component" "karpenter" "root" $) | nindent 10 }}
+        {{- include "platform-root.ignoreMissingValueFiles" $ | nindent 8 }}
+        parameters:
+          {{- include "platform-root.provenanceParameters" $ | nindent 10 }}
+          - name: settings.clusterName
+            value: "{{ .Values.global.clusterName }}"
+          - name: settings.interruptionQueue
+            value: "{{ .Values.global.karpenterQueueName }}"
+          - name: serviceAccount.annotations.eks\.amazonaws\.com/role-arn
+            value: "{{ .Values.global.karpenterControllerRole }}"
+    - repoURL: {{ .Values.platformGitopsRepoUrl }}
+      targetRevision: {{ .Values.platformGitopsVersion }}
+      ref: values
+    {{- include "platform-root.overrideSource" . | nindent 4 }}
+    {{- include "platform-root.gitopsSource" . | nindent 4 }}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: karpenter
+  syncPolicy:
+    {{- include "platform-root.managedNamespaceMetadataExcluded" . | nindent 4 }}
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: karpenter-resources
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: platform
+  sources:
+    - repoURL: {{ .Values.platformGitopsRepoUrl }}
+      targetRevision: {{ .Values.platformGitopsVersion }}
+      path: components/karpenter-resources
+      helm:
+        valueFiles:
+          - $values/components/karpenter-resources/values.yaml
+          {{- include "platform-root.overrideValueFile" (dict "component" "karpenter-resources" "root" $) | nindent 10 }}
+          {{- include "platform-root.gitopsValueFile" (dict "component" "karpenter-resources" "root" $) | nindent 10 }}
+        ignoreMissingValueFiles: true
+        parameters:
+          {{- include "platform-root.provenanceParameters" $ | nindent 10 }}
+          - name: clusterName
+            value: "{{ .Values.global.clusterName }}"
+          - name: nodeRole
+            value: "{{ .Values.global.karpenterNodeRoleName }}"
+          - name: discoveryTagKey
+            value: "{{ .Values.global.karpenterDiscoveryTagKey }}"
+    - repoURL: {{ .Values.platformGitopsRepoUrl }}
+      targetRevision: {{ .Values.platformGitopsVersion }}
+      ref: values
+    {{- include "platform-root.overrideSource" . | nindent 4 }}
+    {{- include "platform-root.gitopsSource" . | nindent 4 }}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: karpenter
+  syncPolicy:
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+    syncOptions:
+      - ServerSideApply=true
+{{- end }}

--- a/bootstrap/platform-root/templates/metrics-server.yaml
+++ b/bootstrap/platform-root/templates/metrics-server.yaml
@@ -1,0 +1,64 @@
+{{- /*
+  metrics-server — Resource Metrics API server (`v1beta1.metrics.k8s.io`).
+
+  AKS provides metrics-server natively as part of the managed control
+  plane, so this Application is only emitted on AWS. EKS does not
+  include metrics-server in its default addon set; without it,
+  `kubectl top`, HPA, and any controller that reads the Resource
+  Metrics API stay broken.
+
+  Pinned to chart 3.12.x (image v0.7.x) — same configuration validated
+  on the legacy cortex-eks-prod cluster.
+
+  Born following the ADR 0002 Phase 3 layout: values live in
+  `estabilis-platform-gitops/values/platform/metrics-server.yaml`,
+  `$values` ref is the gitops repo. No detour through
+  `estabilis-platform/core/components/`.
+*/ -}}
+{{- if eq .Values.global.provider "aws" }}
+{{- if ne (index .Values.components "metrics-server") false }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metrics-server
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: platform
+  sources:
+    - repoURL: https://kubernetes-sigs.github.io/metrics-server/
+      chart: metrics-server
+      targetRevision: "3.12.2"
+      helm:
+        valueFiles:
+          - $values/values/platform/metrics-server.yaml
+          {{- include "platform-root.overrideValueFile" (dict "component" "metrics-server" "root" $) | nindent 10 }}
+          {{- include "platform-root.gitopsValueFile" (dict "component" "metrics-server" "root" $) | nindent 10 }}
+        {{- include "platform-root.ignoreMissingValueFiles" $ | nindent 8 }}
+        valuesObject:
+          {{- /* Scheduling (ADR 0012 — issue #97) */}}
+          {{- include "platform-root.schedulingValuesTopLevel" (dict
+                "mode" (default "auto" (index .Values.scheduling "metrics-server"))
+             ) | nindent 10 }}
+        {{- include "platform-root.provenanceParametersBlock" $ | nindent 8 }}
+    - repoURL: {{ .Values.platformGitopsRepoUrl }}
+      targetRevision: {{ .Values.platformGitopsVersion }}
+      ref: values
+    {{- include "platform-root.overrideSource" . | nindent 4 }}
+    {{- include "platform-root.gitopsSource" . | nindent 4 }}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: metrics-server
+  syncPolicy:
+    {{- include "platform-root.managedNamespaceMetadataExcluded" . | nindent 4 }}
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+    syncOptions:
+      - CreateNamespace=true
+{{- end }}
+{{- end }}

--- a/bootstrap/platform-root/values.yaml
+++ b/bootstrap/platform-root/values.yaml
@@ -148,6 +148,9 @@ components:
   velero: true               # optional: backup/restore (disable if handled externally)
   external-dns: true         # optional: DNS record management (disable if manual DNS)
   argocd-image-updater: false # optional: auto-update container images via registry polling (opt-in)
+  metrics-server: true       # optional: AWS-only — Resource Metrics API server (kubectl top, HPA). Azure AKS provides natively
+  karpenter: true            # optional: AWS-only — node autoscaler. Activates when global.autoscaler is `karpenter` or `hybrid`
+  karpenter-resources: true  # optional: AWS-only — default NodePool + EC2NodeClass. Same activation as karpenter
 
   # --- observability (disable individually or set all to false) ---
   grafana: true              # observability: dashboards and visualization


### PR DESCRIPTION
Adds metrics-server (chart 3.12.2) and Karpenter (chart 1.12.0 — released today, additive features only) to AWS clusters. Both gated on `provider == "aws"`; Azure unchanged.

Layout follows ADR 0002 Phase 3 — values + custom chart in estabilis-platform-gitops, Application templates in this repo. Companion gitops release v0.35.0 already shipped (Estabilis/estabilis-platform-gitops#25).

**Reviewed by quality-control-validator and brutal-code-critic; all critical issues addressed:**
- IMDSv2 enforcement on EC2NodeClass (security regression vs legacy fixed)
- AppProject `platform` sourceRepos + destinations + clusterResourceWhitelist updated
- `components.{metrics-server,karpenter,karpenter-resources}` map declared
- `provenanceParameters` / `provenanceParametersBlock` on both new Applications
- `SkipDryRunOnMissingResource=true` on karpenter-crds wave -1→0 timing

**Karpenter Azure** parity tracked separately in Estabilis/estabilis-platform-tools#197.

Closes the metrics-server / karpenter gap that surfaced when comparing cortex-EKS new vs legacy production. `kubectl top` and HPA will work; node autoscaling no longer needs manual MNG resizing.