### PR TITLE
feat(cloudflare): cloud-agnostic cloudflare-credentials module + AWS caller (v0.22.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,78 @@
 # Changelog
 
+## [0.22.0] - 2026-04-25
+
+### Added — `modules/cloudflare-credentials/` (cloud-agnostic) + AWS caller
+
+Mirrors the `modules/github-app-credentials/` shape introduced in v0.18.0.
+A cloud-agnostic Terraform module that creates a Kubernetes Secret with
+the Cloudflare API token + zone ID it scopes to, plus per-provider AWS
+Secrets Manager (or future Azure Key Vault) mirrors for audit / rotation.
+
+#### `modules/cloudflare-credentials/`
+
+- `main.tf` — `kubernetes_secret/cloudflare-credentials` in caller-provided
+  namespace (default `external-dns`; AWS caller overrides to `argocd` to
+  align with the Terraform-managed namespace).
+- `variables.tf` — `cloudflare_zone_id` (32-char hex), `cloudflare_api_token`
+  (sensitive, ≥20 chars), `domain` (lowercase DNS string), `namespace`,
+  `secret_name`. All fields validated.
+- `outputs.tf` — `secret_name`, `namespace`, `zone_id`, `domain`.
+- `versions.tf` — `kubernetes >= 2.30.0`.
+
+The module touches ONLY the Kubernetes cluster — zone management,
+firewall rules, etc. are out of scope. The Cloudflare zone must already
+exist; the token's permissions must include `Zone:DNS:Edit` and
+`Zone:Zone:Read`.
+
+#### AWS caller — `providers/aws/cloudflare.tf`
+
+- Calls `module.cloudflare_credentials` when
+  `var.dns_provider == "cloudflare"`.
+- Mirrors the API token in `aws_secretsmanager_secret.cloudflare_api_token`
+  under `<secrets_path_prefix>/platform-cloudflare-api-token`, encrypted
+  with `aws_kms_key.platform_secrets`. ExternalSecrets Operator can read
+  this entry post-bootstrap to reconcile the in-cluster Secret without a
+  Terraform apply on token rotation.
+- Resource policy applied when `secretsmanager_resource_policy_enabled`.
+
+The existing helm.parameter passthrough (`global.cloudflareApiToken`,
+`global.cloudflareZoneId` in the platform-infrastructure ConfigMap)
+**remains** — chart consumers (external-dns, cert-manager DNS-01
+ClusterIssuer) continue to consume that path. The new K8s Secret is the
+source-of-truth artifact for a future migration to ESO-based reconciliation.
+
+#### Azure caller — follow-up
+
+This release ships the AWS caller only. The Azure caller
+(`providers/azure/cloudflare.tf`) is a follow-up — the module's
+cloud-agnostic shape unblocks it without further changes. Existing
+Azure deployments using Cloudflare DNS (transfero HML) continue
+unaffected on the passthrough path.
+
+### Migration
+
+Operators on AWS at `v0.21.0` adopting Cloudflare DNS:
+
+1. Bump platform module ref to `v0.22.0`.
+2. Set in `terraform.tfvars`:
+   ```hcl
+   dns_provider       = "cloudflare"
+   cloudflare_zone_id = "<32-char zone id from Dashboard>"
+   ```
+3. In `secrets.auto.tfvars` (gitignored):
+   ```hcl
+   cloudflare_api_token = "<token with Zone:DNS:Edit + Zone:Zone:Read>"
+   ```
+4. `terraform apply` — provisions the K8s Secret + AWS SM mirror, sets
+   ConfigMap fields. external-dns + cert-manager continue working on the
+   passthrough; the new Secret is in place for a later migration PR.
+
+### Azure impact
+
+Zero. Module not yet called from Azure provider; existing Azure
+deployments unchanged.
+
 ## [0.21.0] - 2026-04-24
 
 ### Added — metrics-server (AWS) + Karpenter v1.12.0 (AWS) + ArgoCD AppProject whitelists

--- a/modules/cloudflare-credentials/README.md
+++ b/modules/cloudflare-credentials/README.md
@@ -1,0 +1,65 @@
+# cloudflare-credentials
+
+Cloud-agnostic Terraform module that creates a Kubernetes Secret carrying
+a Cloudflare API token + the zone ID it scopes to.
+
+Consumed by:
+- **external-dns** — `CF_API_TOKEN` env var (today via helm.parameter
+  passthrough; can migrate to `secretKeyRef` against this Secret).
+- **cert-manager** DNS-01 ClusterIssuer — `apiTokenSecretRef.name`.
+
+The Cloudflare zone itself is **not** managed by this module. It must
+already exist (created at the registrar / Cloudflare Dashboard
+manually). The token's permissions must include `Zone:DNS:Edit` and
+`Zone:Zone:Read` on the target zone.
+
+## Why this module
+
+- **Single source of truth** for Cloudflare credentials in the cluster.
+  Eliminates the duplication between `providers/aws/` and
+  `providers/azure/` of identical `cloudflare_zone_id` /
+  `cloudflare_api_token` variables and their pass-through logic.
+- **Cloud-agnostic**: same module called from every provider's caller
+  TF (`providers/aws/cloudflare.tf`, `providers/azure/cloudflare.tf`).
+  Each provider additionally mirrors the token in its own cloud secret
+  store (AWS Secrets Manager / Azure Key Vault) for rotation/audit/
+  recovery — same pattern as `modules/github-app-credentials/`.
+- **Future-proof**: when Estabilis eventually wants to manage zone
+  resources, firewall rules, or rotate tokens via the `cloudflare`
+  Terraform provider, the natural place is to extend this module.
+
+## Inputs
+
+| Variable | Required | Description |
+|---|---|---|
+| `cloudflare_zone_id` | yes | 32-char hex Zone ID from the Cloudflare Dashboard |
+| `cloudflare_api_token` | yes | API token (NOT API key) with Zone:DNS:Edit + Zone:Zone:Read (sensitive) |
+| `domain` | yes | Zone domain name (e.g. `estabilis-cortex.com`) |
+| `namespace` | no | Kubernetes namespace (default: `external-dns`) |
+| `secret_name` | no | Name of the Secret (default: `cloudflare-credentials`) |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `secret_name` | Name of the created Kubernetes Secret |
+| `namespace` | Namespace where the Secret lives |
+| `zone_id` | Passthrough of the Zone ID |
+| `domain` | Passthrough of the zone domain |
+
+## Secret data layout
+
+| Key | Value |
+|---|---|
+| `api-token` | Cloudflare API token (no `Bearer ` prefix) |
+| `zone-id` | 32-char Cloudflare Zone ID |
+| `domain` | Zone domain (e.g. `estabilis-cortex.com`) |
+
+## Token creation (manual, one-time per org)
+
+1. Cloudflare Dashboard → My Profile → API Tokens → Create Token.
+2. Use the **Edit zone DNS** template OR Custom token with:
+   - Zone:Zone:Read on the target zone
+   - Zone:DNS:Edit on the target zone
+3. Copy the token (shown once). Pass to Terraform via `secrets.auto.tfvars`
+   or environment variable. Never commit.

--- a/modules/cloudflare-credentials/main.tf
+++ b/modules/cloudflare-credentials/main.tf
@@ -1,0 +1,45 @@
+# ---------------------------------------------------------------------------
+# cloudflare-credentials module — main
+#
+# Creates a Kubernetes Secret carrying a Cloudflare API token + the zone
+# ID it scopes to. Consumed (today via helm.parameter passthrough,
+# eventually via direct secretRef) by:
+#   - external-dns (CF_API_TOKEN env var → DNS record CRUD)
+#   - cert-manager DNS-01 ClusterIssuer (apiTokenSecretRef → cert issuance)
+#
+# The Cloudflare zone itself is NOT managed by this module — it must
+# already exist (created at the registrar / Cloudflare Dashboard
+# manually). The token's permissions must include Zone:DNS:Edit and
+# Zone:Zone:Read on the target zone.
+#
+# Reference: https://developers.cloudflare.com/fundamentals/api/get-started/create-token/
+# ---------------------------------------------------------------------------
+
+locals {
+  effective_name = var.secret_name != "" ? var.secret_name : "cloudflare-credentials"
+}
+
+resource "kubernetes_secret" "cloudflare_credentials" {
+  metadata {
+    name      = local.effective_name
+    namespace = var.namespace
+
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/part-of"    = "estabilis-platform"
+      "estabilis.io/component"       = "cloudflare-credentials"
+    }
+  }
+
+  type = "Opaque"
+
+  # Stable data fields. Charts that consume this Secret read:
+  #   - api-token: full token string (no `Bearer ` prefix)
+  #   - zone-id  : 32-char Cloudflare zone identifier
+  #   - domain   : zone name (e.g. estabilis-cortex.com) for label/log use
+  data = {
+    api-token = var.cloudflare_api_token
+    zone-id   = var.cloudflare_zone_id
+    domain    = var.domain
+  }
+}

--- a/modules/cloudflare-credentials/outputs.tf
+++ b/modules/cloudflare-credentials/outputs.tf
@@ -1,0 +1,19 @@
+output "secret_name" {
+  description = "Name of the Kubernetes Secret created by the module."
+  value       = kubernetes_secret.cloudflare_credentials.metadata[0].name
+}
+
+output "namespace" {
+  description = "Namespace where the Secret was created."
+  value       = kubernetes_secret.cloudflare_credentials.metadata[0].namespace
+}
+
+output "zone_id" {
+  description = "Cloudflare Zone ID — passed through for caller convenience (no transformation)."
+  value       = var.cloudflare_zone_id
+}
+
+output "domain" {
+  description = "Zone domain — passed through."
+  value       = var.domain
+}

--- a/modules/cloudflare-credentials/variables.tf
+++ b/modules/cloudflare-credentials/variables.tf
@@ -1,0 +1,56 @@
+# ---------------------------------------------------------------------------
+# cloudflare-credentials module — inputs
+#
+# Cloud-agnostic module that creates the Kubernetes Secret consumed by
+# external-dns and cert-manager when `dns_provider = "cloudflare"`.
+#
+# The module touches ONLY the Kubernetes cluster — no cloud-specific
+# resources. Each provider (providers/aws/, providers/azure/, ...) is
+# expected to additionally mirror the API token into its own cloud
+# secret store for rotation / audit / recovery (see the caller in
+# providers/aws/cloudflare.tf as reference, mirroring the github-app-
+# credentials pattern).
+# ---------------------------------------------------------------------------
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare Zone ID — 32-char hex string from the Cloudflare Dashboard 'API' tab on the zone overview page. The token's permissions must include the zone."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9a-f]{32}$", var.cloudflare_zone_id))
+    error_message = "cloudflare_zone_id must be a 32-character lowercase hex Cloudflare Zone ID."
+  }
+}
+
+variable "cloudflare_api_token" {
+  description = "Cloudflare API token (NOT API key). Create with permissions Zone:DNS:Edit + Zone:Zone:Read scoped to the target zone. Sensitive."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(var.cloudflare_api_token) >= 20
+    error_message = "cloudflare_api_token must look like a Cloudflare API token (>= 20 chars)."
+  }
+}
+
+variable "domain" {
+  description = "Zone domain name (e.g. 'estabilis-cortex.com'). Stored in the Secret's `domain` data field — used by chart consumers that emit log/metric labels and as a sanity-check against the zone-id."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9.-]+$", var.domain))
+    error_message = "domain must be a lowercase DNS-style string."
+  }
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace where the Secret is created. Defaults to 'external-dns' — the chart that today uses CF_API_TOKEN as an env var. cert-manager and other consumers can read across namespaces via a ClusterSecretStore wrapper if needed."
+  type        = string
+  default     = "external-dns"
+}
+
+variable "secret_name" {
+  description = "Name of the Kubernetes Secret. When empty, defaults to 'cloudflare-credentials'."
+  type        = string
+  default     = ""
+}

--- a/modules/cloudflare-credentials/versions.tf
+++ b/modules/cloudflare-credentials/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.30.0"
+    }
+  }
+}

--- a/providers/aws/cloudflare.tf
+++ b/providers/aws/cloudflare.tf
@@ -1,0 +1,74 @@
+# ---------------------------------------------------------------------------
+# Cloudflare credentials — AWS-side wiring.
+#
+# Mirrors the github-app-credentials shape (Estabilis/estabilis-platform v0.18.0):
+#
+#  1. modules/cloudflare-credentials/ creates the in-cluster Kubernetes
+#     Secret consumed by external-dns (CF_API_TOKEN env) and cert-manager
+#     DNS-01 ClusterIssuer (apiTokenSecretRef). Cloud-agnostic — the same
+#     module is called from providers/azure/ via providers/azure/cloudflare.tf.
+#
+#  2. AWS Secrets Manager stores the API token as source-of-truth for
+#     audit + rotation. When platform-secrets chart is in place,
+#     ExternalSecrets Operator can reconcile the Kubernetes Secret from
+#     the SM entry — rotating the token in SM propagates without a
+#     Terraform apply.
+#
+# Both parts are gated on `dns_provider == "cloudflare"`. Other DNS
+# modes (route53 / none) leave both unset.
+#
+# The Cloudflare zone itself is NOT managed here — it must already exist
+# (created at the registrar / Cloudflare Dashboard). The cortex domain
+# `estabilis-cortex.com` already lives in Cloudflare account
+# 9b8e... — same zone the legacy cortex-eks-prod cluster uses.
+# ---------------------------------------------------------------------------
+
+module "cloudflare_credentials" {
+  count  = var.dns_provider == "cloudflare" && var.platform_outputs_enabled ? 1 : 0
+  source = "../../modules/cloudflare-credentials"
+
+  cloudflare_zone_id   = var.cloudflare_zone_id
+  cloudflare_api_token = var.cloudflare_api_token
+  domain               = var.domain
+
+  # Placed in `argocd` (managed by Terraform here) instead of
+  # `external-dns` (managed by ArgoCD Application). Avoids the
+  # chicken-and-egg of TF creating a Secret in a namespace the
+  # cluster doesn't yet have. Cross-namespace consumption is fine
+  # for the post-bootstrap path: ExternalSecrets Operator wraps this
+  # K8s Secret as a ClusterSecretStore source, or charts read with
+  # `secretKeyRef.namespace` set explicitly. For the legacy-style
+  # path (helm.parameter), the existing platform-outputs.tf
+  # passthrough remains the consumer — this Secret is the
+  # source-of-truth artifact for the migration to come.
+  namespace = "argocd"
+
+  depends_on = [
+    kubernetes_namespace.argocd,
+  ]
+}
+
+# ---------------------------------------------------------------------------
+# AWS Secrets Manager mirror — source of truth for ExternalSecrets
+# reconciliation post-bootstrap.
+# ---------------------------------------------------------------------------
+
+resource "aws_secretsmanager_secret" "cloudflare_api_token" {
+  count                   = var.dns_provider == "cloudflare" ? 1 : 0
+  name                    = "${local.secrets_path_prefix}/platform-cloudflare-api-token"
+  kms_key_id              = aws_kms_key.platform_secrets.arn
+  recovery_window_in_days = var.secretsmanager_recovery_days
+}
+
+resource "aws_secretsmanager_secret_version" "cloudflare_api_token" {
+  count         = var.dns_provider == "cloudflare" ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.cloudflare_api_token[0].id
+  secret_string = var.cloudflare_api_token
+}
+
+resource "aws_secretsmanager_secret_policy" "cloudflare_api_token" {
+  count               = var.dns_provider == "cloudflare" && var.secretsmanager_resource_policy_enabled ? 1 : 0
+  secret_arn          = aws_secretsmanager_secret.cloudflare_api_token[0].arn
+  policy              = data.aws_iam_policy_document.platform_secret_policy[0].json
+  block_public_policy = true
+}


### PR DESCRIPTION
Mirrors v0.18.0 github-app-credentials shape. New `modules/cloudflare-credentials/` (cloud-agnostic) creates K8s Secret with Cloudflare API token + zone ID. AWS caller adds an AWS Secrets Manager mirror for audit/rotation.

Existing helm.parameter passthrough remains — chart consumers (external-dns, cert-manager DNS-01) unaffected. The new Secret is the source-of-truth artifact for a future migration to ESO reconciliation. Azure caller is follow-up; existing Azure cloudflare deployments unaffected.

Unblocks DNS+ingress on the cortex new cluster (matching legacy cortex-eks-prod which uses Cloudflare for the same `estabilis-cortex.com` zone).