### PR TITLE
feat(aws): aws-load-balancer-controller + AppProject hardening (v0.23.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,76 @@
 # Changelog
 
+## [0.23.0] - 2026-04-25
+
+### Added — AWS Load Balancer Controller Application + AppProject hardening
+
+Closes the last AWS-only Application gap that was missing from
+estabilis-platform vs the legacy cortex-eks-prod configuration. The
+controller chart was deferred from Phase 2 (TF was provisioning the
+IRSA role since v0.16.0 but no ArgoCD Application existed). This
+release ships it on the same chart version (1.17.1, controller v2.17.1)
+that legacy runs in production.
+
+#### `bootstrap/platform-root/templates/aws-load-balancer-controller.yaml`
+
+New Application gated on:
+- `provider == "aws"`
+- `components.aws-load-balancer-controller != false`
+- `ingress_controller == "alb"`
+
+Helm parameters:
+- `clusterName` ← `global.clusterName`
+- `vpcId` ← `global.vpcId`
+- `serviceAccount.annotations.eks.amazonaws.com/role-arn` ←
+  `identity.albController.roleArn`
+
+Values from `estabilis-platform-gitops v0.36.0`:
+`values/platform/aws-load-balancer-controller.yaml` (resources, SA,
+PDB — mirrors legacy).
+
+#### `bootstrap/platform-root/templates/argocd-project.yaml`
+
+- `sourceRepos`: added `https://aws.github.io/eks-charts`.
+- `destinations`: added `aws-load-balancer-controller` namespace.
+- `clusterResourceWhitelist`: added `apiregistration.k8s.io/APIService`
+  (bake of an in-place patch from v0.21.0 — required by metrics-server
+  and historically missing).
+
+#### `bootstrap/platform-root/values.yaml`
+
+`components.aws-load-balancer-controller: true` default.
+
+### Dependency
+
+Requires `estabilis-platform-gitops >= v0.36.0`.
+
+### Migration
+
+Operators on AWS at `v0.22.0` adopting `alb` ingress:
+
+1. Bump `platformGitopsVersion` to `v0.36.0` in
+   `overrides/platform-root/values.yaml`.
+2. Bump platform module ref to `v0.23.0`.
+3. Set in `terraform.tfvars`:
+   ```hcl
+   ingress_controller = "alb"
+   ```
+4. `terraform apply` — provisions:
+   - `module.alb_controller_irsa` (IAM role + AWS-managed policy)
+   - ConfigMap data update (`global.ingressController = alb`,
+     `identity.albController.roleArn`)
+5. Refresh + sync `platform-root`. Three new Applications appear
+   automatically when `ingress_controller = "alb"`:
+   - `aws-load-balancer-controller`
+6. Test by creating an Ingress with `ingressClassName: alb` and a
+   host under the configured domain — external-dns should publish the
+   record to Cloudflare (or Route53), cert-manager should issue a
+   certificate, ALB should provision.
+
+### Azure impact
+
+Zero. All gates require `provider == "aws"`.
+
 ## [0.22.0] - 2026-04-25
 
 ### Added — `modules/cloudflare-credentials/` (cloud-agnostic) + AWS caller

--- a/bootstrap/platform-root/templates/argocd-project.yaml
+++ b/bootstrap/platform-root/templates/argocd-project.yaml
@@ -34,6 +34,7 @@ spec:
     - "https://prometheus-community.github.io/helm-charts"
     - "https://kubernetes-sigs.github.io/metrics-server/"
     - "public.ecr.aws/karpenter"
+    - "https://aws.github.io/eks-charts"
     {{- /*
     Platform add-on repos: must match the repoURL emitted by
     platform-addons.yaml. ArgoCD 3.x requires OCI Helm repoURL WITHOUT
@@ -96,6 +97,8 @@ spec:
       namespace: metrics-server
     - server: https://kubernetes.default.svc
       namespace: karpenter
+    - server: https://kubernetes.default.svc
+      namespace: aws-load-balancer-controller
     {{- range $name, $addon := .Values.platformAddons }}
     {{- if $addon.namespace }}
     - server: https://kubernetes.default.svc
@@ -131,6 +134,8 @@ spec:
       kind: "*"
     - group: karpenter.k8s.aws
       kind: "*"
+    - group: apiregistration.k8s.io
+      kind: APIService
 ---
 # Workload-baseline project — for platform baseline components deployed
 # to workload clusters via the workload-bootstrap ApplicationSets.

--- a/bootstrap/platform-root/templates/aws-load-balancer-controller.yaml
+++ b/bootstrap/platform-root/templates/aws-load-balancer-controller.yaml
@@ -1,0 +1,77 @@
+{{- /*
+  AWS Load Balancer Controller — manages ALB/NLB resources from
+  Kubernetes Ingress / Service objects on EKS clusters.
+
+  AWS-only. Gated on:
+    - provider == "aws"
+    - components.aws-load-balancer-controller != false
+    - ingress_controller == "alb" (passed as global.ingressController
+      from Terraform)
+
+  IAM role for the controller's ServiceAccount is provisioned by
+  `providers/aws/alb-controller.tf` (the IRSA module attaches the
+  AWS-managed `AWSLoadBalancerControllerIAMPolicy`). Role ARN flows
+  in via the `platform-infrastructure-sensitive` Secret as
+  `identity.albController.roleArn`.
+
+  Chart pinned to 1.17.1 (controller v2.17.1) — same version validated
+  in production on the legacy cortex-eks-prod cluster. The 3.x chart
+  family (controller v3) ships breaking changes vs v2 (new
+  IngressClassParams shape, annotation rename); not bumped here without
+  explicit release-notes review.
+*/ -}}
+{{- if and (eq .Values.global.provider "aws") (eq .Values.global.ingressController "alb") }}
+{{- if ne (index .Values.components "aws-load-balancer-controller") false }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: aws-load-balancer-controller
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: platform
+  sources:
+    - repoURL: https://aws.github.io/eks-charts
+      chart: aws-load-balancer-controller
+      targetRevision: "1.17.1"
+      helm:
+        valueFiles:
+          - $values/values/platform/aws-load-balancer-controller.yaml
+          {{- include "platform-root.overrideValueFile" (dict "component" "aws-load-balancer-controller" "root" $) | nindent 10 }}
+          {{- include "platform-root.gitopsValueFile" (dict "component" "aws-load-balancer-controller" "root" $) | nindent 10 }}
+        {{- include "platform-root.ignoreMissingValueFiles" $ | nindent 8 }}
+        parameters:
+          {{- include "platform-root.provenanceParameters" $ | nindent 10 }}
+          - name: clusterName
+            value: "{{ .Values.global.clusterName }}"
+          - name: vpcId
+            value: "{{ .Values.global.vpcId }}"
+          - name: serviceAccount.annotations.eks\.amazonaws\.com/role-arn
+            value: "{{ .Values.identity.albController.roleArn }}"
+        valuesObject:
+          {{- /* Scheduling (ADR 0012 — issue #97) */}}
+          {{- include "platform-root.schedulingValuesTopLevel" (dict
+                "mode" (default "auto" (index .Values.scheduling "aws-load-balancer-controller"))
+             ) | nindent 10 }}
+    - repoURL: {{ .Values.platformGitopsRepoUrl }}
+      targetRevision: {{ .Values.platformGitopsVersion }}
+      ref: values
+    {{- include "platform-root.overrideSource" . | nindent 4 }}
+    {{- include "platform-root.gitopsSource" . | nindent 4 }}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: aws-load-balancer-controller
+  syncPolicy:
+    {{- include "platform-root.managedNamespaceMetadataExcluded" . | nindent 4 }}
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+{{- end }}
+{{- end }}

--- a/bootstrap/platform-root/values.yaml
+++ b/bootstrap/platform-root/values.yaml
@@ -151,6 +151,7 @@ components:
   metrics-server: true       # optional: AWS-only — Resource Metrics API server (kubectl top, HPA). Azure AKS provides natively
   karpenter: true            # optional: AWS-only — node autoscaler. Activates when global.autoscaler is `karpenter` or `hybrid`
   karpenter-resources: true  # optional: AWS-only — default NodePool + EC2NodeClass. Same activation as karpenter
+  aws-load-balancer-controller: true  # optional: AWS-only — provisions ALB/NLB from Ingress/Service. Activates when global.ingressController == "alb"
 
   # --- observability (disable individually or set all to false) ---
   grafana: true              # observability: dashboards and visualization


### PR DESCRIPTION
Adds the AWS Load Balancer Controller Application gated on `ingress_controller == "alb"`. Chart pinned to 1.17.1 (controller v2.17.1) — same as legacy cortex-eks-prod.

Also bakes `apiregistration.k8s.io/APIService` into AppProject clusterResourceWhitelist (was a v0.21.0 in-place patch).

Requires gitops v0.36.1+. Azure: zero impact.