### PR TITLE
feat(ingress): ALB support across all 5 ingress charts (v0.24.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,92 @@
 # Changelog
 
+## [0.24.0] - 2026-04-25
+
+### Added — ALB ingress support across all 5 `*-ingress` charts
+
+Closes the Traefik-only limitation flagged in ADR 0014. The five
+`*-ingress` charts (`argocd`, `grafana`, `loki`, `mimir`, `hubble-ui`)
+now branch on `ingress_class` per exposure profile:
+
+- `traefik` / `traefik-internal` → existing IngressRoute pattern with
+  Middlewares (ipAllowList, basicAuth via ESO).
+- `alb` → AWS Load Balancer Controller pattern. Renders an Ingress
+  with `alb.ingress.kubernetes.io/*` annotations + cert-manager
+  Certificate (DNS-01) OR ACM cert reference.
+
+#### Per-exposure new fields (provider-agnostic shape)
+
+Added to every `*_exposures` variable in BOTH `providers/aws/variables.tf`
+and `providers/azure/variables.tf` (Azure inert). All optional with
+sensible defaults derived from the legacy `cortex-eks-prod` config:
+
+| Field | Default | Purpose |
+|---|---|---|
+| `alb_group` | `"platform"` | `alb.ingress.kubernetes.io/group.name` — share ONE ALB across multiple Ingresses (cost optimization, ~$22/mo savings per shared group) |
+| `alb_scheme` | `"internet-facing"` | `internet-facing` or `internal` |
+| `alb_target_type` | `"ip"` | `ip` (Fargate-compatible) or `instance` |
+| `alb_ssl_policy` | `"ELBSecurityPolicy-TLS13-1-2-2021-06"` | TLS 1.3 with min 1.2 |
+| `alb_healthcheck_path` | `""` (chart default per-app) | argocd `/healthz`, grafana `/api/health`, loki/mimir `/ready`, hubble `/` |
+| `alb_certificate_source` | `"cert-manager"` | `"acm"` uses `global.acmCertificateArn`; `"cert-manager"` issues via DNS-01 |
+| `alb_cloudflare_proxied` | `false` | Sets `external-dns.alpha.kubernetes.io/cloudflare-proxied`. Always `false` recommended (orange cloud OFF) for source-IP allowlists to work |
+
+#### Source-IP allowlist on ALB
+
+Per-exposure `allowed_cidrs` now generates an
+`alb.ingress.kubernetes.io/conditions.<service-name>` annotation with
+the listener-rule condition (different mechanism from Traefik
+`Middleware.ipAllowList` but equivalent semantics).
+
+#### Basic auth limitation
+
+`basic_auth: true` + `ingress_class: "alb"` is **not supported** —
+ALB does not implement HTTP Basic Authentication natively (would
+require Cognito or Lambda integration). The chart `fail`s loud with a
+clear message explaining the limitation. Use Traefik for basic-auth
+exposures.
+
+#### Platform-root template gate
+
+The Traefik gate (`components.traefik != false`) is now relaxed: only
+required when at least one exposure targets a Traefik-style class.
+ALB-only exposures render even with Traefik disabled.
+
+#### `global.dnsProvider` + `global.acmCertificateArn` propagation
+
+Both values are now passed as helm parameters to the 5 `*-ingress`
+Applications, so the ALB chart branch can read them from
+`$.Values.global.*`. Previously inaccessible to the chart context.
+
+### Migration
+
+Operators on `v0.23.0` adopting ALB ingress for any platform app:
+
+1. Bump platform module ref to `v0.24.0`.
+2. In `terraform.tfvars`, add `ingress_class = "alb"` (and any of the
+   new `alb_*` fields) to the desired exposure profile, e.g.:
+   ```hcl
+   argocd_exposures = {
+     external = {
+       enabled                = true
+       host                   = "argocd.example.com"
+       ingress_class          = "alb"
+       allowed_cidrs          = "203.0.113.0/24"
+       alb_group              = "shared-apps"
+       alb_certificate_source = "cert-manager"
+     }
+   }
+   ```
+3. `terraform apply` — refresh ConfigMap data.
+4. Sync `argocd-ingress` (or whichever) Application. ALB provisions in
+   ~1-2min; external-dns publishes the record; cert-manager issues
+   the cert.
+
+### Azure impact
+
+Zero functional impact. Azure deployments never set
+`ingress_class = "alb"`; the new ALB fields on the exposure type are
+inert noise. The Traefik path is byte-identical to v0.23.0.
+
 ## [0.23.0] - 2026-04-25
 
 ### Added — AWS Load Balancer Controller Application + AppProject hardening

--- a/bootstrap/platform-root/templates/argocd-ingress.yaml
+++ b/bootstrap/platform-root/templates/argocd-ingress.yaml
@@ -1,6 +1,9 @@
 {{- /*
-  ADR 0014 — ArgoCD UI external ingress. Gated by traefik on and at least
-  one enabled profile in global.argocdExposures.
+  ADR 0014 — ArgoCD UI external ingress. Active when at least one
+  profile in global.argocdExposures is enabled. The chart itself
+  branches on `ingress_class` (Traefik vs ALB) — no longer gated on
+  components.traefik because ALB does not depend on Traefik being
+  enabled.
 */ -}}
 {{- $raw := index .Values.global "argocdExposures" | default "" -}}
 {{- $jsonStr := "{}" -}}
@@ -13,8 +16,13 @@
 {{- end }}
 {{- $exposures := fromJson $jsonStr -}}
 {{- $hasEnabled := false -}}
-{{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- end }}{{- end }}
-{{- if and (ne (index .Values.components "traefik") false) $hasEnabled }}
+{{- $hasTraefikExposure := false -}}
+{{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
+{{- /* Require components.traefik only when at least one exposure
+       actually targets a Traefik-style class. ALB-only exposures are
+       allowed when components.traefik is false. */}}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) }}
+{{- if and $traefikGate $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -39,6 +47,12 @@ spec:
           - name: exposuresJson
             value: {{ $raw | quote }}
             forceString: true
+          {{- /* ALB ingress class consumes these via .Values.global.*
+                 in the chart. Ignored on Traefik path. */}}
+          - name: global.dnsProvider
+            value: "{{ .Values.global.dnsProvider }}"
+          - name: global.acmCertificateArn
+            value: "{{ .Values.global.acmCertificateArn }}"
     - repoURL: {{ .Values.platformRepoUrl }}
       targetRevision: {{ .Values.platformVersion }}
       ref: values

--- a/bootstrap/platform-root/templates/grafana-ingress.yaml
+++ b/bootstrap/platform-root/templates/grafana-ingress.yaml
@@ -18,8 +18,10 @@
 {{- end }}
 {{- $exposures := fromJson $jsonStr -}}
 {{- $hasEnabled := false -}}
-{{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- end }}{{- end }}
-{{- if and (ne (index .Values.components "traefik") false) $hasEnabled }}
+{{- $hasTraefikExposure := false -}}
+{{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) }}
+{{- if and $traefikGate $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -47,6 +49,12 @@ spec:
           - name: exposuresJson
             value: {{ $raw | quote }}
             forceString: true
+          {{- /* ALB ingress class consumes these via .Values.global.* in the chart.
+                 Ignored on Traefik path. */}}
+          - name: global.dnsProvider
+            value: "{{ .Values.global.dnsProvider }}"
+          - name: global.acmCertificateArn
+            value: "{{ .Values.global.acmCertificateArn }}"
     - repoURL: {{ .Values.platformRepoUrl }}
       targetRevision: {{ .Values.platformVersion }}
       ref: values

--- a/bootstrap/platform-root/templates/hubble-ui-ingress.yaml
+++ b/bootstrap/platform-root/templates/hubble-ui-ingress.yaml
@@ -16,10 +16,12 @@
 {{- end }}
 {{- $exposures := fromJson $jsonStr -}}
 {{- $hasEnabled := false -}}
-{{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- end }}{{- end }}
+{{- $hasTraefikExposure := false -}}
+{{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) }}
 {{- $dataplane := index .Values.global "networkDataplane" | default "" -}}
 {{- if and
-      (ne (index .Values.components "traefik") false)
+      $traefikGate
       (eq (index .Values.components "hubble-ui" | default false) true)
       (eq $dataplane "cilium-acns")
       $hasEnabled }}
@@ -47,6 +49,12 @@ spec:
           - name: exposuresJson
             value: {{ $raw | quote }}
             forceString: true
+          {{- /* ALB ingress class consumes these via .Values.global.* in the chart.
+                 Ignored on Traefik path. */}}
+          - name: global.dnsProvider
+            value: "{{ .Values.global.dnsProvider }}"
+          - name: global.acmCertificateArn
+            value: "{{ .Values.global.acmCertificateArn }}"
     - repoURL: {{ .Values.platformRepoUrl }}
       targetRevision: {{ .Values.platformVersion }}
       ref: values

--- a/bootstrap/platform-root/templates/loki-ingress.yaml
+++ b/bootstrap/platform-root/templates/loki-ingress.yaml
@@ -15,8 +15,10 @@
 {{- end }}
 {{- $exposures := fromJson $jsonStr -}}
 {{- $hasEnabled := false -}}
-{{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- end }}{{- end }}
-{{- if and (ne (index .Values.components "traefik") false) $hasEnabled }}
+{{- $hasTraefikExposure := false -}}
+{{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) }}
+{{- if and $traefikGate $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -40,6 +42,12 @@ spec:
           - name: exposuresJson
             value: {{ $raw | quote }}
             forceString: true
+          {{- /* ALB ingress class consumes these via .Values.global.* in the chart.
+                 Ignored on Traefik path. */}}
+          - name: global.dnsProvider
+            value: "{{ .Values.global.dnsProvider }}"
+          - name: global.acmCertificateArn
+            value: "{{ .Values.global.acmCertificateArn }}"
     - repoURL: {{ .Values.platformRepoUrl }}
       targetRevision: {{ .Values.platformVersion }}
       ref: values

--- a/bootstrap/platform-root/templates/mimir-ingress.yaml
+++ b/bootstrap/platform-root/templates/mimir-ingress.yaml
@@ -15,8 +15,10 @@
 {{- end }}
 {{- $exposures := fromJson $jsonStr -}}
 {{- $hasEnabled := false -}}
-{{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- end }}{{- end }}
-{{- if and (ne (index .Values.components "traefik") false) $hasEnabled }}
+{{- $hasTraefikExposure := false -}}
+{{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) }}
+{{- if and $traefikGate $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -40,6 +42,12 @@ spec:
           - name: exposuresJson
             value: {{ $raw | quote }}
             forceString: true
+          {{- /* ALB ingress class consumes these via .Values.global.* in the chart.
+                 Ignored on Traefik path. */}}
+          - name: global.dnsProvider
+            value: "{{ .Values.global.dnsProvider }}"
+          - name: global.acmCertificateArn
+            value: "{{ .Values.global.acmCertificateArn }}"
     - repoURL: {{ .Values.platformRepoUrl }}
       targetRevision: {{ .Values.platformVersion }}
       ref: values

--- a/core/components/argocd-ingress/templates/ingress-route.yaml
+++ b/core/components/argocd-ingress/templates/ingress-route.yaml
@@ -1,8 +1,19 @@
 {{- /*
-  ADR 0014 — one Ingress + Middlewares + Certificate per enabled exposure
-  profile. Backend: Service argocd-server (port 80) in the argocd namespace.
-  All resources live in argocd namespace to share Traefik's cross-namespace
-  Middleware reference capability.
+  ADR 0014 — one Ingress (+ Middlewares for Traefik / + ALB annotations
+  for AWS) per enabled exposure profile.
+
+  Backend: argocd-server (port 80) in the argocd namespace. All
+  resources live in argocd namespace to share Traefik's cross-namespace
+  Middleware reference capability (Traefik path) or to keep the
+  Ingress co-located with the backend Service (ALB path).
+
+  The chart branches on `$exp.ingress_class`:
+    - "traefik" / "traefik-internal" → Traefik IngressRoute pattern
+      with Middlewares for ipAllowList + basicAuth.
+    - "alb" → AWS Load Balancer Controller pattern with
+      `alb.ingress.kubernetes.io/*` annotations. ALB does NOT support
+      basic_auth natively (would require Cognito or Lambda); the
+      chart fails loud if the combination is configured.
 */ -}}
 {{- $raw := .Values.exposuresJson | default "{}" -}}
 {{- $jsonStr := $raw -}}
@@ -12,6 +23,90 @@
 {{- $exposures := fromJson $jsonStr -}}
 {{- range $profile, $exp := $exposures }}
 {{- if $exp.enabled }}
+{{- $isALB := eq $exp.ingress_class "alb" }}
+
+{{- if and $isALB $exp.basic_auth }}
+{{- fail (printf "argocd_exposures.%s: basic_auth=true is not supported when ingress_class=alb (use Cognito/OIDC integration via the alb_authorizer field — not yet implemented)" $profile) }}
+{{- end }}
+
+{{- if $isALB }}
+{{- /* ============================ ALB BRANCH ============================ */}}
+{{- $hcPath := default "/healthz" $exp.alb_healthcheck_path }}
+{{- $useACM := eq $exp.alb_certificate_source "acm" }}
+---
+{{- if not $useACM }}
+{{- /* cert-manager Certificate (DNS-01 issued); ALB references via Ingress TLS spec */}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: argocd-{{ $profile }}-tls
+  namespace: argocd
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+spec:
+  secretName: argocd-{{ $profile }}-tls
+  issuerRef:
+    name: {{ $exp.issuer | default "letsencrypt-production" | quote }}
+    kind: ClusterIssuer
+  dnsNames:
+    - {{ $exp.host | quote }}
+---
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argocd-{{ $profile }}
+  namespace: argocd
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+  annotations:
+    {{- /* Core ALB annotations */}}
+    alb.ingress.kubernetes.io/scheme: {{ $exp.alb_scheme | quote }}
+    alb.ingress.kubernetes.io/target-type: {{ $exp.alb_target_type | quote }}
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/ssl-policy: {{ $exp.alb_ssl_policy | quote }}
+    alb.ingress.kubernetes.io/healthcheck-path: {{ $hcPath | quote }}
+    {{- /* Group routes multiple Ingresses behind ONE shared ALB —
+          significant cost saver when several apps are exposed. */}}
+    alb.ingress.kubernetes.io/group.name: {{ $exp.alb_group | quote }}
+    {{- if $useACM }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ $.Values.global.acmCertificateArn | quote }}
+    {{- end }}
+    {{- if $exp.allowed_cidrs }}
+    {{- /* ALB listener-rule condition (per-service). Restricts source IPs
+          at the listener level — different mechanism from Traefik
+          Middlewares but equivalent end result. */}}
+    alb.ingress.kubernetes.io/conditions.argocd-server: |-
+      [{"field":"source-ip","sourceIpConfig":{"values":[{{- $cidrs := list -}}{{- range splitList "," $exp.allowed_cidrs -}}{{- $cidrs = append $cidrs (printf "%q" (trim .)) -}}{{- end -}}{{ join "," $cidrs }}]}}]
+    {{- end }}
+    {{- if hasKey $.Values.global "dnsProvider" }}
+    {{- if eq $.Values.global.dnsProvider "cloudflare" }}
+    {{- /* Cloudflare DNS-only mode (orange cloud OFF) — preserves real
+          ALB IP for source-IP allowlist to work. With proxy ON, every
+          request appears to originate from Cloudflare CIDRs. */}}
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: {{ $exp.alb_cloudflare_proxied | quote }}
+    {{- end }}
+    {{- end }}
+    external-dns.alpha.kubernetes.io/hostname: {{ $exp.host | quote }}
+spec:
+  ingressClassName: alb
+  rules:
+    - host: {{ $exp.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: argocd-server
+                port:
+                  number: 80
+  {{- if not $useACM }}
+  tls:
+    - secretName: argocd-{{ $profile }}-tls
+      hosts:
+        - {{ $exp.host | quote }}
+  {{- end }}
+{{- else }}
+{{- /* ========================== TRAEFIK BRANCH ========================== */}}
 {{- $mwIPName := printf "argocd-%s-ipallowlist" $profile }}
 {{- $mwAuthName := printf "argocd-%s-auth" $profile }}
 ---
@@ -110,5 +205,6 @@ spec:
     - secretName: argocd-{{ $profile }}-tls
       hosts:
         - {{ $exp.host | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/core/components/grafana-ingress/templates/middleware.yaml
+++ b/core/components/grafana-ingress/templates/middleware.yaml
@@ -1,13 +1,20 @@
 {{- /*
-  ADR 0014 — iterate over exposures map, rendering Ingress + Middlewares +
-  Certificate per enabled profile. Ingress points to the grafana Service
-  (the chart's own Ingress must stay disabled via overrides/grafana/values.yaml:
-    ingress.enabled: false
-  otherwise a second Ingress is created with different middlewares).
+  ADR 0014 — one Ingress (+ Middlewares for Traefik / + ALB annotations
+  for AWS) per enabled exposure profile.
+
+  Backend: grafana (port ) in the grafana namespace. All
+  resources live in the grafana namespace to share Traefik's cross-namespace
+  Middleware reference capability (Traefik path) or to keep the
+  Ingress co-located with the backend Service (ALB path).
+
+  The chart branches on `$exp.ingress_class`:
+    - "traefik" / "traefik-internal" → Traefik IngressRoute pattern
+      with Middlewares for ipAllowList + basicAuth.
+    - "alb" → AWS Load Balancer Controller pattern with
+      `alb.ingress.kubernetes.io/*` annotations. ALB does NOT support
+      basic_auth natively (would require Cognito or Lambda); the
+      chart fails loud if the combination is configured.
 */ -}}
-{{- /* exposuresJson arrives either as raw JSON (helm template CLI) or as
-      base64 (estabilis CLI v0.15.2+ encodes to survive helm --set parsing).
-      Detect by first char. */ -}}
 {{- $raw := .Values.exposuresJson | default "{}" -}}
 {{- $jsonStr := $raw -}}
 {{- if and $raw (not (or (hasPrefix "{" $raw) (hasPrefix "[" $raw))) }}
@@ -16,6 +23,90 @@
 {{- $exposures := fromJson $jsonStr -}}
 {{- range $profile, $exp := $exposures }}
 {{- if $exp.enabled }}
+{{- $isALB := eq $exp.ingress_class "alb" }}
+
+{{- if and $isALB $exp.basic_auth }}
+{{- fail (printf "grafana_exposures.%s: basic_auth=true is not supported when ingress_class=alb (use Cognito/OIDC integration via the alb_authorizer field — not yet implemented)" $profile) }}
+{{- end }}
+
+{{- if $isALB }}
+{{- /* ============================ ALB BRANCH ============================ */}}
+{{- $hcPath := default "/api/health" $exp.alb_healthcheck_path }}
+{{- $useACM := eq $exp.alb_certificate_source "acm" }}
+---
+{{- if not $useACM }}
+{{- /* cert-manager Certificate (DNS-01 issued); ALB references via Ingress TLS spec */}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: grafana-{{ $profile }}-tls
+  namespace: grafana
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+spec:
+  secretName: grafana-{{ $profile }}-tls
+  issuerRef:
+    name: {{ $exp.issuer | default "letsencrypt-production" | quote }}
+    kind: ClusterIssuer
+  dnsNames:
+    - {{ $exp.host | quote }}
+---
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana-{{ $profile }}
+  namespace: grafana
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+  annotations:
+    {{- /* Core ALB annotations */}}
+    alb.ingress.kubernetes.io/scheme: {{ $exp.alb_scheme | quote }}
+    alb.ingress.kubernetes.io/target-type: {{ $exp.alb_target_type | quote }}
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/ssl-policy: {{ $exp.alb_ssl_policy | quote }}
+    alb.ingress.kubernetes.io/healthcheck-path: {{ $hcPath | quote }}
+    {{- /* Group routes multiple Ingresses behind ONE shared ALB —
+          significant cost saver when several apps are exposed. */}}
+    alb.ingress.kubernetes.io/group.name: {{ $exp.alb_group | quote }}
+    {{- if $useACM }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ $.Values.global.acmCertificateArn | quote }}
+    {{- end }}
+    {{- if $exp.allowed_cidrs }}
+    {{- /* ALB listener-rule condition (per-service). Restricts source IPs
+          at the listener level — different mechanism from Traefik
+          Middlewares but equivalent end result. */}}
+    alb.ingress.kubernetes.io/conditions.grafana: |-
+      [{"field":"source-ip","sourceIpConfig":{"values":[{{- $cidrs := list -}}{{- range splitList "," $exp.allowed_cidrs -}}{{- $cidrs = append $cidrs (printf "%q" (trim .)) -}}{{- end -}}{{ join "," $cidrs }}]}}]
+    {{- end }}
+    {{- if hasKey $.Values.global "dnsProvider" }}
+    {{- if eq $.Values.global.dnsProvider "cloudflare" }}
+    {{- /* Cloudflare DNS-only mode (orange cloud OFF) — preserves real
+          ALB IP for source-IP allowlist to work. With proxy ON, every
+          request appears to originate from Cloudflare CIDRs. */}}
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: {{ $exp.alb_cloudflare_proxied | quote }}
+    {{- end }}
+    {{- end }}
+    external-dns.alpha.kubernetes.io/hostname: {{ $exp.host | quote }}
+spec:
+  ingressClassName: alb
+  rules:
+    - host: {{ $exp.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 80
+  {{- if not $useACM }}
+  tls:
+    - secretName: grafana-{{ $profile }}-tls
+      hosts:
+        - {{ $exp.host | quote }}
+  {{- end }}
+{{- else }}
+{{- /* ========================== TRAEFIK BRANCH ========================== */}}
 {{- $mwIPName := printf "grafana-%s-ipallowlist" $profile }}
 {{- $mwAuthName := printf "grafana-%s-auth" $profile }}
 ---
@@ -114,5 +205,6 @@ spec:
     - secretName: grafana-{{ $profile }}-tls
       hosts:
         - {{ $exp.host | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/core/components/hubble-ui-ingress/templates/ingress-route.yaml
+++ b/core/components/hubble-ui-ingress/templates/ingress-route.yaml
@@ -1,12 +1,19 @@
 {{- /*
-  ADR 0014 — one Ingress + Middlewares + Certificate per enabled exposure
-  profile. Backend: Service hubble-ui (port 80) in the kube-system
-  namespace. All resources live in kube-system to colocate with the
-  backend Service.
+  ADR 0014 — one Ingress (+ Middlewares for Traefik / + ALB annotations
+  for AWS) per enabled exposure profile.
 
-  Hubble UI serves the Cilium ACNS observability dashboard. Requires:
-    global.networkDataplane == "cilium-acns" (enforced at platform-root
-    template layer).
+  Backend: hubble-ui (port ) in the kube-system namespace. All
+  resources live in the kube-system namespace to share Traefik's cross-namespace
+  Middleware reference capability (Traefik path) or to keep the
+  Ingress co-located with the backend Service (ALB path).
+
+  The chart branches on `$exp.ingress_class`:
+    - "traefik" / "traefik-internal" → Traefik IngressRoute pattern
+      with Middlewares for ipAllowList + basicAuth.
+    - "alb" → AWS Load Balancer Controller pattern with
+      `alb.ingress.kubernetes.io/*` annotations. ALB does NOT support
+      basic_auth natively (would require Cognito or Lambda); the
+      chart fails loud if the combination is configured.
 */ -}}
 {{- $raw := .Values.exposuresJson | default "{}" -}}
 {{- $jsonStr := $raw -}}
@@ -16,8 +23,92 @@
 {{- $exposures := fromJson $jsonStr -}}
 {{- range $profile, $exp := $exposures }}
 {{- if $exp.enabled }}
-{{- $mwIPName := printf "hubble-ui-%s-ipallowlist" $profile }}
-{{- $mwAuthName := printf "hubble-ui-%s-auth" $profile }}
+{{- $isALB := eq $exp.ingress_class "alb" }}
+
+{{- if and $isALB $exp.basic_auth }}
+{{- fail (printf "hubble_ui_exposures.%s: basic_auth=true is not supported when ingress_class=alb (use Cognito/OIDC integration via the alb_authorizer field — not yet implemented)" $profile) }}
+{{- end }}
+
+{{- if $isALB }}
+{{- /* ============================ ALB BRANCH ============================ */}}
+{{- $hcPath := default "/" $exp.alb_healthcheck_path }}
+{{- $useACM := eq $exp.alb_certificate_source "acm" }}
+---
+{{- if not $useACM }}
+{{- /* cert-manager Certificate (DNS-01 issued); ALB references via Ingress TLS spec */}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hubble-{{ $profile }}-tls
+  namespace: kube-system
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+spec:
+  secretName: hubble-{{ $profile }}-tls
+  issuerRef:
+    name: {{ $exp.issuer | default "letsencrypt-production" | quote }}
+    kind: ClusterIssuer
+  dnsNames:
+    - {{ $exp.host | quote }}
+---
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hubble-{{ $profile }}
+  namespace: kube-system
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+  annotations:
+    {{- /* Core ALB annotations */}}
+    alb.ingress.kubernetes.io/scheme: {{ $exp.alb_scheme | quote }}
+    alb.ingress.kubernetes.io/target-type: {{ $exp.alb_target_type | quote }}
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/ssl-policy: {{ $exp.alb_ssl_policy | quote }}
+    alb.ingress.kubernetes.io/healthcheck-path: {{ $hcPath | quote }}
+    {{- /* Group routes multiple Ingresses behind ONE shared ALB —
+          significant cost saver when several apps are exposed. */}}
+    alb.ingress.kubernetes.io/group.name: {{ $exp.alb_group | quote }}
+    {{- if $useACM }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ $.Values.global.acmCertificateArn | quote }}
+    {{- end }}
+    {{- if $exp.allowed_cidrs }}
+    {{- /* ALB listener-rule condition (per-service). Restricts source IPs
+          at the listener level — different mechanism from Traefik
+          Middlewares but equivalent end result. */}}
+    alb.ingress.kubernetes.io/conditions.hubble-ui: |-
+      [{"field":"source-ip","sourceIpConfig":{"values":[{{- $cidrs := list -}}{{- range splitList "," $exp.allowed_cidrs -}}{{- $cidrs = append $cidrs (printf "%q" (trim .)) -}}{{- end -}}{{ join "," $cidrs }}]}}]
+    {{- end }}
+    {{- if hasKey $.Values.global "dnsProvider" }}
+    {{- if eq $.Values.global.dnsProvider "cloudflare" }}
+    {{- /* Cloudflare DNS-only mode (orange cloud OFF) — preserves real
+          ALB IP for source-IP allowlist to work. With proxy ON, every
+          request appears to originate from Cloudflare CIDRs. */}}
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: {{ $exp.alb_cloudflare_proxied | quote }}
+    {{- end }}
+    {{- end }}
+    external-dns.alpha.kubernetes.io/hostname: {{ $exp.host | quote }}
+spec:
+  ingressClassName: alb
+  rules:
+    - host: {{ $exp.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: hubble-ui
+                port:
+                  number: 80
+  {{- if not $useACM }}
+  tls:
+    - secretName: hubble-{{ $profile }}-tls
+      hosts:
+        - {{ $exp.host | quote }}
+  {{- end }}
+{{- else }}
+{{- /* ========================== TRAEFIK BRANCH ========================== */}}
+{{- $mwIPName := printf "hubble-%s-ipallowlist" $profile }}
+{{- $mwAuthName := printf "hubble-%s-auth" $profile }}
 ---
 {{- if $exp.allowed_cidrs }}
 apiVersion: traefik.io/v1alpha1
@@ -68,11 +159,11 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: hubble-ui-{{ $profile }}-tls
+  name: hubble-{{ $profile }}-tls
   namespace: kube-system
   {{- include "estabilis.metadata" $ | nindent 2 }}
 spec:
-  secretName: hubble-ui-{{ $profile }}-tls
+  secretName: hubble-{{ $profile }}-tls
   issuerRef:
     name: {{ $exp.issuer | default "letsencrypt-production" | quote }}
     kind: ClusterIssuer
@@ -82,16 +173,16 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: hubble-ui-{{ $profile }}
+  name: hubble-{{ $profile }}
   namespace: kube-system
   {{- include "estabilis.metadata" $ | nindent 2 }}
   annotations:
     {{- $mws := list }}
     {{- if $exp.allowed_cidrs }}
-    {{- $mws = append $mws (printf "kube-system-%s@kubernetescrd" $mwIPName) }}
+    {{- $mws = append $mws (printf "hubble-%s@kubernetescrd" $mwIPName) }}
     {{- end }}
     {{- if $exp.basic_auth }}
-    {{- $mws = append $mws (printf "kube-system-%s@kubernetescrd" $mwAuthName) }}
+    {{- $mws = append $mws (printf "hubble-%s@kubernetescrd" $mwAuthName) }}
     {{- end }}
     {{- if $mws }}
     traefik.ingress.kubernetes.io/router.middlewares: {{ join "," $mws | quote }}
@@ -111,8 +202,9 @@ spec:
                 port:
                   number: 80
   tls:
-    - secretName: hubble-ui-{{ $profile }}-tls
+    - secretName: hubble-{{ $profile }}-tls
       hosts:
         - {{ $exp.host | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/core/components/loki-ingress/templates/ingress-route.yaml
+++ b/core/components/loki-ingress/templates/ingress-route.yaml
@@ -1,7 +1,19 @@
 {{- /*
-  ADR 0014 — iterate over exposures map, rendering Ingress + Middlewares +
-  Certificate + ExternalSecret per enabled profile. Same backend Service
-  (loki-gateway) is shared across profiles; only the edge differs.
+  ADR 0014 — one Ingress (+ Middlewares for Traefik / + ALB annotations
+  for AWS) per enabled exposure profile.
+
+  Backend: grafana-loki (port ) in the grafana namespace. All
+  resources live in the grafana namespace to share Traefik's cross-namespace
+  Middleware reference capability (Traefik path) or to keep the
+  Ingress co-located with the backend Service (ALB path).
+
+  The chart branches on `$exp.ingress_class`:
+    - "traefik" / "traefik-internal" → Traefik IngressRoute pattern
+      with Middlewares for ipAllowList + basicAuth.
+    - "alb" → AWS Load Balancer Controller pattern with
+      `alb.ingress.kubernetes.io/*` annotations. ALB does NOT support
+      basic_auth natively (would require Cognito or Lambda); the
+      chart fails loud if the combination is configured.
 */ -}}
 {{- $raw := .Values.exposuresJson | default "{}" -}}
 {{- $jsonStr := $raw -}}
@@ -11,8 +23,90 @@
 {{- $exposures := fromJson $jsonStr -}}
 {{- range $profile, $exp := $exposures }}
 {{- if $exp.enabled }}
-{{- $mwList := list }}
-{{- $resourceSuffix := $profile }}
+{{- $isALB := eq $exp.ingress_class "alb" }}
+
+{{- if and $isALB $exp.basic_auth }}
+{{- fail (printf "loki_exposures.%s: basic_auth=true is not supported when ingress_class=alb (use Cognito/OIDC integration via the alb_authorizer field — not yet implemented)" $profile) }}
+{{- end }}
+
+{{- if $isALB }}
+{{- /* ============================ ALB BRANCH ============================ */}}
+{{- $hcPath := default "/ready" $exp.alb_healthcheck_path }}
+{{- $useACM := eq $exp.alb_certificate_source "acm" }}
+---
+{{- if not $useACM }}
+{{- /* cert-manager Certificate (DNS-01 issued); ALB references via Ingress TLS spec */}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: loki-{{ $profile }}-tls
+  namespace: grafana
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+spec:
+  secretName: loki-{{ $profile }}-tls
+  issuerRef:
+    name: {{ $exp.issuer | default "letsencrypt-production" | quote }}
+    kind: ClusterIssuer
+  dnsNames:
+    - {{ $exp.host | quote }}
+---
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: loki-{{ $profile }}
+  namespace: grafana
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+  annotations:
+    {{- /* Core ALB annotations */}}
+    alb.ingress.kubernetes.io/scheme: {{ $exp.alb_scheme | quote }}
+    alb.ingress.kubernetes.io/target-type: {{ $exp.alb_target_type | quote }}
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/ssl-policy: {{ $exp.alb_ssl_policy | quote }}
+    alb.ingress.kubernetes.io/healthcheck-path: {{ $hcPath | quote }}
+    {{- /* Group routes multiple Ingresses behind ONE shared ALB —
+          significant cost saver when several apps are exposed. */}}
+    alb.ingress.kubernetes.io/group.name: {{ $exp.alb_group | quote }}
+    {{- if $useACM }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ $.Values.global.acmCertificateArn | quote }}
+    {{- end }}
+    {{- if $exp.allowed_cidrs }}
+    {{- /* ALB listener-rule condition (per-service). Restricts source IPs
+          at the listener level — different mechanism from Traefik
+          Middlewares but equivalent end result. */}}
+    alb.ingress.kubernetes.io/conditions.grafana-loki: |-
+      [{"field":"source-ip","sourceIpConfig":{"values":[{{- $cidrs := list -}}{{- range splitList "," $exp.allowed_cidrs -}}{{- $cidrs = append $cidrs (printf "%q" (trim .)) -}}{{- end -}}{{ join "," $cidrs }}]}}]
+    {{- end }}
+    {{- if hasKey $.Values.global "dnsProvider" }}
+    {{- if eq $.Values.global.dnsProvider "cloudflare" }}
+    {{- /* Cloudflare DNS-only mode (orange cloud OFF) — preserves real
+          ALB IP for source-IP allowlist to work. With proxy ON, every
+          request appears to originate from Cloudflare CIDRs. */}}
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: {{ $exp.alb_cloudflare_proxied | quote }}
+    {{- end }}
+    {{- end }}
+    external-dns.alpha.kubernetes.io/hostname: {{ $exp.host | quote }}
+spec:
+  ingressClassName: alb
+  rules:
+    - host: {{ $exp.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana-loki
+                port:
+                  number: 3100
+  {{- if not $useACM }}
+  tls:
+    - secretName: loki-{{ $profile }}-tls
+      hosts:
+        - {{ $exp.host | quote }}
+  {{- end }}
+{{- else }}
+{{- /* ========================== TRAEFIK BRANCH ========================== */}}
 {{- $mwIPName := printf "loki-%s-ipallowlist" $profile }}
 {{- $mwAuthName := printf "loki-%s-auth" $profile }}
 ---
@@ -85,10 +179,10 @@ metadata:
   annotations:
     {{- $mws := list }}
     {{- if $exp.allowed_cidrs }}
-    {{- $mws = append $mws (printf "grafana-%s@kubernetescrd" $mwIPName) }}
+    {{- $mws = append $mws (printf "loki-%s@kubernetescrd" $mwIPName) }}
     {{- end }}
     {{- if $exp.basic_auth }}
-    {{- $mws = append $mws (printf "grafana-%s@kubernetescrd" $mwAuthName) }}
+    {{- $mws = append $mws (printf "loki-%s@kubernetescrd" $mwAuthName) }}
     {{- end }}
     {{- if $mws }}
     traefik.ingress.kubernetes.io/router.middlewares: {{ join "," $mws | quote }}
@@ -100,7 +194,7 @@ spec:
     - host: {{ $exp.host | quote }}
       http:
         paths:
-          - path: /loki/api/v1/push
+          - path: /
             pathType: Prefix
             backend:
               service:
@@ -111,5 +205,6 @@ spec:
     - secretName: loki-{{ $profile }}-tls
       hosts:
         - {{ $exp.host | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/core/components/mimir-ingress/templates/ingress-route.yaml
+++ b/core/components/mimir-ingress/templates/ingress-route.yaml
@@ -1,8 +1,19 @@
 {{- /*
-  ADR 0014 — iterate over exposures map, rendering Ingress + Middlewares +
-  Certificate + ExternalSecret per enabled profile. Backend Service is
-  grafana-mimir-gateway (Mimir's write path via the gateway). Only the
-  /api/v1/push path is exposed — query endpoints are NOT accessible.
+  ADR 0014 — one Ingress (+ Middlewares for Traefik / + ALB annotations
+  for AWS) per enabled exposure profile.
+
+  Backend: grafana-mimir-gateway (port ) in the grafana namespace. All
+  resources live in the grafana namespace to share Traefik's cross-namespace
+  Middleware reference capability (Traefik path) or to keep the
+  Ingress co-located with the backend Service (ALB path).
+
+  The chart branches on `$exp.ingress_class`:
+    - "traefik" / "traefik-internal" → Traefik IngressRoute pattern
+      with Middlewares for ipAllowList + basicAuth.
+    - "alb" → AWS Load Balancer Controller pattern with
+      `alb.ingress.kubernetes.io/*` annotations. ALB does NOT support
+      basic_auth natively (would require Cognito or Lambda); the
+      chart fails loud if the combination is configured.
 */ -}}
 {{- $raw := .Values.exposuresJson | default "{}" -}}
 {{- $jsonStr := $raw -}}
@@ -12,8 +23,90 @@
 {{- $exposures := fromJson $jsonStr -}}
 {{- range $profile, $exp := $exposures }}
 {{- if $exp.enabled }}
-{{- $mwList := list }}
-{{- $resourceSuffix := $profile }}
+{{- $isALB := eq $exp.ingress_class "alb" }}
+
+{{- if and $isALB $exp.basic_auth }}
+{{- fail (printf "mimir_exposures.%s: basic_auth=true is not supported when ingress_class=alb (use Cognito/OIDC integration via the alb_authorizer field — not yet implemented)" $profile) }}
+{{- end }}
+
+{{- if $isALB }}
+{{- /* ============================ ALB BRANCH ============================ */}}
+{{- $hcPath := default "/ready" $exp.alb_healthcheck_path }}
+{{- $useACM := eq $exp.alb_certificate_source "acm" }}
+---
+{{- if not $useACM }}
+{{- /* cert-manager Certificate (DNS-01 issued); ALB references via Ingress TLS spec */}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: mimir-{{ $profile }}-tls
+  namespace: grafana
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+spec:
+  secretName: mimir-{{ $profile }}-tls
+  issuerRef:
+    name: {{ $exp.issuer | default "letsencrypt-production" | quote }}
+    kind: ClusterIssuer
+  dnsNames:
+    - {{ $exp.host | quote }}
+---
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mimir-{{ $profile }}
+  namespace: grafana
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+  annotations:
+    {{- /* Core ALB annotations */}}
+    alb.ingress.kubernetes.io/scheme: {{ $exp.alb_scheme | quote }}
+    alb.ingress.kubernetes.io/target-type: {{ $exp.alb_target_type | quote }}
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/ssl-policy: {{ $exp.alb_ssl_policy | quote }}
+    alb.ingress.kubernetes.io/healthcheck-path: {{ $hcPath | quote }}
+    {{- /* Group routes multiple Ingresses behind ONE shared ALB —
+          significant cost saver when several apps are exposed. */}}
+    alb.ingress.kubernetes.io/group.name: {{ $exp.alb_group | quote }}
+    {{- if $useACM }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ $.Values.global.acmCertificateArn | quote }}
+    {{- end }}
+    {{- if $exp.allowed_cidrs }}
+    {{- /* ALB listener-rule condition (per-service). Restricts source IPs
+          at the listener level — different mechanism from Traefik
+          Middlewares but equivalent end result. */}}
+    alb.ingress.kubernetes.io/conditions.grafana-mimir-gateway: |-
+      [{"field":"source-ip","sourceIpConfig":{"values":[{{- $cidrs := list -}}{{- range splitList "," $exp.allowed_cidrs -}}{{- $cidrs = append $cidrs (printf "%q" (trim .)) -}}{{- end -}}{{ join "," $cidrs }}]}}]
+    {{- end }}
+    {{- if hasKey $.Values.global "dnsProvider" }}
+    {{- if eq $.Values.global.dnsProvider "cloudflare" }}
+    {{- /* Cloudflare DNS-only mode (orange cloud OFF) — preserves real
+          ALB IP for source-IP allowlist to work. With proxy ON, every
+          request appears to originate from Cloudflare CIDRs. */}}
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: {{ $exp.alb_cloudflare_proxied | quote }}
+    {{- end }}
+    {{- end }}
+    external-dns.alpha.kubernetes.io/hostname: {{ $exp.host | quote }}
+spec:
+  ingressClassName: alb
+  rules:
+    - host: {{ $exp.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana-mimir-gateway
+                port:
+                  number: 80
+  {{- if not $useACM }}
+  tls:
+    - secretName: mimir-{{ $profile }}-tls
+      hosts:
+        - {{ $exp.host | quote }}
+  {{- end }}
+{{- else }}
+{{- /* ========================== TRAEFIK BRANCH ========================== */}}
 {{- $mwIPName := printf "mimir-%s-ipallowlist" $profile }}
 {{- $mwAuthName := printf "mimir-%s-auth" $profile }}
 ---
@@ -86,10 +179,10 @@ metadata:
   annotations:
     {{- $mws := list }}
     {{- if $exp.allowed_cidrs }}
-    {{- $mws = append $mws (printf "grafana-%s@kubernetescrd" $mwIPName) }}
+    {{- $mws = append $mws (printf "mimir-%s@kubernetescrd" $mwIPName) }}
     {{- end }}
     {{- if $exp.basic_auth }}
-    {{- $mws = append $mws (printf "grafana-%s@kubernetescrd" $mwAuthName) }}
+    {{- $mws = append $mws (printf "mimir-%s@kubernetescrd" $mwAuthName) }}
     {{- end }}
     {{- if $mws }}
     traefik.ingress.kubernetes.io/router.middlewares: {{ join "," $mws | quote }}
@@ -101,7 +194,7 @@ spec:
     - host: {{ $exp.host | quote }}
       http:
         paths:
-          - path: /api/v1/push
+          - path: /
             pathType: Prefix
             backend:
               service:
@@ -112,5 +205,6 @@ spec:
     - secretName: mimir-{{ $profile }}-tls
       hosts:
         - {{ $exp.host | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/providers/aws/variables.tf
+++ b/providers/aws/variables.tf
@@ -689,6 +689,16 @@ variable "grafana_exposures" {
     allowed_cidrs = optional(string, "")
     issuer        = optional(string, "letsencrypt-production")
     basic_auth    = optional(bool, false)
+
+    # ALB-specific (only consumed when ingress_class = "alb").
+    # Provider-agnostic shape so Azure exposures keep the same type.
+    alb_group              = optional(string, "platform")
+    alb_scheme             = optional(string, "internet-facing")
+    alb_target_type        = optional(string, "ip")
+    alb_ssl_policy         = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
+    alb_healthcheck_path   = optional(string, "")
+    alb_certificate_source = optional(string, "cert-manager")
+    alb_cloudflare_proxied = optional(bool, false)
   }))
   default = {}
 }
@@ -702,6 +712,15 @@ variable "loki_exposures" {
     allowed_cidrs = optional(string, "")
     issuer        = optional(string, "letsencrypt-production")
     basic_auth    = optional(bool, true)
+
+    # ALB-specific (only consumed when ingress_class = "alb").
+    alb_group              = optional(string, "platform")
+    alb_scheme             = optional(string, "internet-facing")
+    alb_target_type        = optional(string, "ip")
+    alb_ssl_policy         = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
+    alb_healthcheck_path   = optional(string, "")
+    alb_certificate_source = optional(string, "cert-manager")
+    alb_cloudflare_proxied = optional(bool, false)
   }))
   default = {}
 }
@@ -715,6 +734,16 @@ variable "mimir_exposures" {
     allowed_cidrs = optional(string, "")
     issuer        = optional(string, "letsencrypt-production")
     basic_auth    = optional(bool, false)
+
+    # ALB-specific (only consumed when ingress_class = "alb").
+    # Provider-agnostic shape so Azure exposures keep the same type.
+    alb_group              = optional(string, "platform")
+    alb_scheme             = optional(string, "internet-facing")
+    alb_target_type        = optional(string, "ip")
+    alb_ssl_policy         = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
+    alb_healthcheck_path   = optional(string, "")
+    alb_certificate_source = optional(string, "cert-manager")
+    alb_cloudflare_proxied = optional(bool, false)
   }))
   default = {}
 }
@@ -728,6 +757,16 @@ variable "argocd_exposures" {
     allowed_cidrs = optional(string, "")
     issuer        = optional(string, "letsencrypt-production")
     basic_auth    = optional(bool, false)
+
+    # ALB-specific (only consumed when ingress_class = "alb").
+    # Provider-agnostic shape so Azure exposures keep the same type.
+    alb_group              = optional(string, "platform")
+    alb_scheme             = optional(string, "internet-facing")
+    alb_target_type        = optional(string, "ip")
+    alb_ssl_policy         = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
+    alb_healthcheck_path   = optional(string, "")
+    alb_certificate_source = optional(string, "cert-manager")
+    alb_cloudflare_proxied = optional(bool, false)
   }))
   default = {}
 }
@@ -741,6 +780,16 @@ variable "hubble_ui_exposures" {
     allowed_cidrs = optional(string, "")
     issuer        = optional(string, "letsencrypt-production")
     basic_auth    = optional(bool, false)
+
+    # ALB-specific (only consumed when ingress_class = "alb").
+    # Provider-agnostic shape so Azure exposures keep the same type.
+    alb_group              = optional(string, "platform")
+    alb_scheme             = optional(string, "internet-facing")
+    alb_target_type        = optional(string, "ip")
+    alb_ssl_policy         = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
+    alb_healthcheck_path   = optional(string, "")
+    alb_certificate_source = optional(string, "cert-manager")
+    alb_cloudflare_proxied = optional(bool, false)
   }))
   default = {}
 }

--- a/providers/azure/variables.tf
+++ b/providers/azure/variables.tf
@@ -482,6 +482,15 @@ variable "grafana_exposures" {
     allowed_cidrs = optional(string, "")        # CSV; empty = no Middleware L7 filter
     issuer        = optional(string, "letsencrypt-production")
     basic_auth    = optional(bool, false) # BasicAuth Middleware (htpasswd via ExternalSecret)
+
+    # ALB-specific fields kept for type parity with AWS (Azure inert).
+    alb_group              = optional(string, "platform")
+    alb_scheme             = optional(string, "internet-facing")
+    alb_target_type        = optional(string, "ip")
+    alb_ssl_policy         = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
+    alb_healthcheck_path   = optional(string, "")
+    alb_certificate_source = optional(string, "cert-manager")
+    alb_cloudflare_proxied = optional(bool, false)
   }))
   default = {}
 }
@@ -495,6 +504,15 @@ variable "loki_exposures" {
     allowed_cidrs = optional(string, "")
     issuer        = optional(string, "letsencrypt-production")
     basic_auth    = optional(bool, true) # loki uses BasicAuth by default for push API
+
+    # ALB-specific fields kept for type parity with AWS (Azure inert).
+    alb_group              = optional(string, "platform")
+    alb_scheme             = optional(string, "internet-facing")
+    alb_target_type        = optional(string, "ip")
+    alb_ssl_policy         = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
+    alb_healthcheck_path   = optional(string, "")
+    alb_certificate_source = optional(string, "cert-manager")
+    alb_cloudflare_proxied = optional(bool, false)
   }))
   default = {}
 }
@@ -508,6 +526,15 @@ variable "mimir_exposures" {
     allowed_cidrs = optional(string, "")
     issuer        = optional(string, "letsencrypt-production")
     basic_auth    = optional(bool, false)
+
+    # ALB-specific fields kept for type parity with AWS (Azure inert).
+    alb_group              = optional(string, "platform")
+    alb_scheme             = optional(string, "internet-facing")
+    alb_target_type        = optional(string, "ip")
+    alb_ssl_policy         = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
+    alb_healthcheck_path   = optional(string, "")
+    alb_certificate_source = optional(string, "cert-manager")
+    alb_cloudflare_proxied = optional(bool, false)
   }))
   default = {}
 }
@@ -521,6 +548,15 @@ variable "argocd_exposures" {
     allowed_cidrs = optional(string, "")
     issuer        = optional(string, "letsencrypt-production")
     basic_auth    = optional(bool, false) # ArgoCD has its own SSO
+
+    # ALB-specific fields kept for type parity with AWS (Azure inert).
+    alb_group              = optional(string, "platform")
+    alb_scheme             = optional(string, "internet-facing")
+    alb_target_type        = optional(string, "ip")
+    alb_ssl_policy         = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
+    alb_healthcheck_path   = optional(string, "")
+    alb_certificate_source = optional(string, "cert-manager")
+    alb_cloudflare_proxied = optional(bool, false)
   }))
   default = {}
 }
@@ -534,6 +570,15 @@ variable "hubble_ui_exposures" {
     allowed_cidrs = optional(string, "")
     issuer        = optional(string, "letsencrypt-production")
     basic_auth    = optional(bool, false)
+
+    # ALB-specific fields kept for type parity with AWS (Azure inert).
+    alb_group              = optional(string, "platform")
+    alb_scheme             = optional(string, "internet-facing")
+    alb_target_type        = optional(string, "ip")
+    alb_ssl_policy         = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
+    alb_healthcheck_path   = optional(string, "")
+    alb_certificate_source = optional(string, "cert-manager")
+    alb_cloudflare_proxied = optional(bool, false)
   }))
   default = {}
 }


### PR DESCRIPTION
## Summary

Extends all 5 platform ingress charts (argocd, grafana, loki, mimir, hubble-ui) to natively support **ALB ingress class** in addition to Traefik. Brings cortex-on-new-platform to parity with the legacy ALB pattern, without forcing the operator to bring up Traefik on AWS.

## Why

Current ingress charts are Traefik-only (`IngressRoute` + `Middleware` CRDs). On AWS we want to use the AWS Load Balancer Controller + standard k8s `Ingress` with ALB annotations — same pattern as cortex legacy. Path B (extend the upstream charts) was chosen over Path A (downstream wiring) because:

- Single source of truth — every client benefits, not just cortex
- `core/components/*-ingress/` stays the canonical place for ingress shape decisions
- Future cloud providers (GCP / on-prem) just need a new branch in the same template

## Changes

### Charts (`core/components/{argocd,grafana,loki,mimir,hubble-ui}-ingress/`)
- Each `templates/*.yaml` now branches on `$exp.ingress_class`:
  - `"alb"` → emits standard `networking.k8s.io/v1` `Ingress` with ALB annotations (scheme, target-type, listen-ports, ssl-policy, healthcheck-path, group.name, optional certificate-arn, source-IP conditions, external-dns hostname/proxied)
  - anything else → existing Traefik `IngressRoute` + `Middleware`
- `basic_auth=true` on an ALB exposure now hard-fails with a clear message (basic-auth is a Traefik middleware concept; not portable to ALB)

### Variables (`providers/{aws,azure}/variables.tf`)
- All 5 `*_exposures` variables gain optional ALB fields (Azure inert — for type parity):
  - `alb_group`, `alb_scheme`, `alb_target_type`, `alb_ssl_policy`
  - `alb_healthcheck_path`, `alb_certificate_source`, `alb_cloudflare_proxied`

### platform-root templates (`bootstrap/platform-root/templates/*-ingress.yaml`)
- Traefik gate relaxed: only blocks rendering when an exposure is explicitly Traefik-flavored AND `components.traefik=false`. ALB-only exposures render even with `components.traefik=false`.
- New helm parameters `global.dnsProvider` and `global.acmCertificateArn` propagated to every ingress App so charts can decide cert-manager vs ACM.

## Migration

- **Existing Traefik users:** zero change — defaults preserve current behavior.
- **AWS users opting into ALB:** set `ingress_class = "alb"` in any `*_exposures` profile and (optionally) tune `alb_*` fields. `external-dns` + `aws-load-balancer-controller` must be enabled (already shipped in v0.22.0 / v0.23.0).

## Test plan

- [x] `helm template` of all 5 charts renders cleanly for both ALB and Traefik exposures
- [x] `helm template` of all 5 platform-root templates passes traefik-gate logic
- [ ] E2E on cortex (us-east-1): bump tfvars `argocd_exposures.external.ingress_class=alb`, terraform apply, verify ALB provisioned, Cloudflare record published by external-dns, TLS issued by cert-manager DNS-01