### PR TITLE
feat(aws): close ALB cert + subnet-discovery gap (v0.25.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,90 @@
 # Changelog
 
+## [0.25.0] - 2026-04-25
+
+### Fixed — Close the AWS ALB cert + subnet-discovery gap
+
+Postmortem from cortex E2E validation: v0.24.0's chart support for
+`ingress_class = "alb"` rendered the right Ingress, but two missing
+pieces of glue prevented ALB Controller from actually provisioning the
+load balancer. Both pieces were operator-side workarounds in legacy
+deployments — v0.25.0 closes both inside the platform module.
+
+#### Cloudflare-validated ACM cert (was Route53-only)
+
+`providers/aws/acm.tf` now creates the validation CNAME records via
+the `cloudflare/cloudflare` provider when `dns_provider =
+"cloudflare"`, using the same Cloudflare API token already required
+for external-dns + cert-manager DNS-01 issuance. Previously the
+module only auto-validated for Route53; Cloudflare clients had to
+place CNAMEs by hand and the apply hung indefinitely on
+`aws_acm_certificate_validation`.
+
+- New: `cloudflare_record.acm_validation` (one per validation entry)
+- Updated: `aws_acm_certificate_validation.wildcard` count gate +
+  validation_record_fqdns now branches on dns_provider
+- New required provider: `cloudflare/cloudflare ~> 4.0` in `versions.tf`
+
+#### Subnet cluster-membership tag (vpc_mode = existing)
+
+`providers/aws/eks.tf` now tags each subnet (public + private) with
+`kubernetes.io/cluster/<cluster-name> = shared` when the platform
+runs against a pre-existing VPC. Without this, ALB Controller fails
+with "couldn't auto-discover subnets: tagged for other clusters" any
+time the same VPC hosts more than one EKS cluster (typical during
+legacy → new migration). `shared` (vs `owned`) is correct because the
+platform module does NOT own the subnet lifecycle in this mode.
+
+- New: `aws_ec2_tag.existing_subnets_cluster_membership` (one tag per
+  subnet — `for_each = concat(public, private)`)
+
+#### `alb_certificate_source` default flipped to `"acm"`
+
+The v0.24.0 default of `"cert-manager"` was unworkable: AWS Load
+Balancer Controller only consumes ACM certificates — it cannot read
+k8s Secrets directly (no built-in `Secret → ALB cert` path). All five
+AWS `*_exposures` variables now default to `"acm"`. Azure provider
+defaults are unchanged (Azure path doesn't use ALB).
+
+The `"cert-manager"` value is still accepted for forward compatibility
+with future cert-manager → ACM syncer integrations, but rendering an
+ALB Ingress with `alb_certificate_source = "cert-manager"` and no
+syncer in place will produce a non-functional Ingress.
+
+#### Cross-variable validation guards (fail fast at plan time)
+
+Three new guards prevent silent footguns:
+
+- `null_resource.alb_requires_acm_validation`: `ingress_controller =
+  "alb"` requires `acm_enabled = true` (the chart cannot render an
+  ALB without an ACM ARN).
+- `null_resource.acm_requires_managed_dns`: `acm_enabled = true`
+  requires `dns_provider = "route53"` or `"cloudflare"` (with
+  `"none"` the validation CNAME never appears and apply hangs).
+- Chart-level `fail` blocks: each `*-ingress` template now hard-fails
+  if `alb_certificate_source = "acm"` but `global.acmCertificateArn`
+  is empty, OR if `alb_certificate_source` is an unrecognized value.
+  The error message points the operator at exactly which knob to
+  flip.
+
+### Migration
+
+For existing AWS-on-ALB clusters provisioned with v0.24.0:
+
+1. `terraform init -upgrade` (picks up the new `cloudflare/cloudflare`
+   provider).
+2. Set `acm_enabled = true` in the platform downstream `tfvars` (and
+   verify `dns_provider = "cloudflare"` or `"route53"`).
+3. `terraform apply` — provisions the ACM cert + validation CNAMEs +
+   subnet cluster-membership tags. The cert ARN flows automatically to
+   ingress charts via `global.acmCertificateArn`.
+4. `estabilis promote` to refresh platform-root with the new ARN.
+5. Existing ALB Ingresses that were stuck on "no certificate found"
+   will reconcile automatically once the ACM cert is ISSUED. No
+   manual `kubectl annotate` needed.
+
+For Azure clients: zero impact (all changes are AWS-only).
+
 ## [0.24.0] - 2026-04-25
 
 ### Added — ALB ingress support across all 5 `*-ingress` charts

--- a/core/components/argocd-ingress/templates/ingress-route.yaml
+++ b/core/components/argocd-ingress/templates/ingress-route.yaml
@@ -29,6 +29,14 @@
 {{- fail (printf "argocd_exposures.%s: basic_auth=true is not supported when ingress_class=alb (use Cognito/OIDC integration via the alb_authorizer field — not yet implemented)" $profile) }}
 {{- end }}
 
+{{- if and $isALB (eq $exp.alb_certificate_source "acm") (eq (default "" $.Values.global.acmCertificateArn) "") }}
+{{- fail (printf "argocd_exposures.%s: alb_certificate_source=acm but global.acmCertificateArn is empty. Set acm_enabled=true on the platform Terraform module so an ACM cert is provisioned and its ARN auto-flows to this chart, or pick a different alb_certificate_source." $profile) }}
+{{- end }}
+
+{{- if and $isALB (not (has $exp.alb_certificate_source (list "acm" "cert-manager"))) }}
+{{- fail (printf "argocd_exposures.%s: alb_certificate_source=%q is not recognized. Valid values: 'acm' (recommended — ALB Controller consumes ACM cert directly), 'cert-manager' (NOT supported by stock ALB Controller — kept for forward compatibility with future syncer integrations)." $profile $exp.alb_certificate_source) }}
+{{- end }}
+
 {{- if $isALB }}
 {{- /* ============================ ALB BRANCH ============================ */}}
 {{- $hcPath := default "/healthz" $exp.alb_healthcheck_path }}

--- a/core/components/grafana-ingress/templates/middleware.yaml
+++ b/core/components/grafana-ingress/templates/middleware.yaml
@@ -29,6 +29,14 @@
 {{- fail (printf "grafana_exposures.%s: basic_auth=true is not supported when ingress_class=alb (use Cognito/OIDC integration via the alb_authorizer field — not yet implemented)" $profile) }}
 {{- end }}
 
+{{- if and $isALB (eq $exp.alb_certificate_source "acm") (eq (default "" $.Values.global.acmCertificateArn) "") }}
+{{- fail (printf "grafana_exposures.%s: alb_certificate_source=acm but global.acmCertificateArn is empty. Set acm_enabled=true on the platform Terraform module so an ACM cert is provisioned and its ARN auto-flows to this chart, or pick a different alb_certificate_source." $profile) }}
+{{- end }}
+
+{{- if and $isALB (not (has $exp.alb_certificate_source (list "acm" "cert-manager"))) }}
+{{- fail (printf "grafana_exposures.%s: alb_certificate_source=%q is not recognized. Valid values: 'acm' (recommended — ALB Controller consumes ACM cert directly), 'cert-manager' (NOT supported by stock ALB Controller — kept for forward compatibility with future syncer integrations)." $profile $exp.alb_certificate_source) }}
+{{- end }}
+
 {{- if $isALB }}
 {{- /* ============================ ALB BRANCH ============================ */}}
 {{- $hcPath := default "/api/health" $exp.alb_healthcheck_path }}

--- a/core/components/hubble-ui-ingress/templates/ingress-route.yaml
+++ b/core/components/hubble-ui-ingress/templates/ingress-route.yaml
@@ -29,6 +29,14 @@
 {{- fail (printf "hubble_ui_exposures.%s: basic_auth=true is not supported when ingress_class=alb (use Cognito/OIDC integration via the alb_authorizer field — not yet implemented)" $profile) }}
 {{- end }}
 
+{{- if and $isALB (eq $exp.alb_certificate_source "acm") (eq (default "" $.Values.global.acmCertificateArn) "") }}
+{{- fail (printf "hubble_ui_exposures.%s: alb_certificate_source=acm but global.acmCertificateArn is empty. Set acm_enabled=true on the platform Terraform module so an ACM cert is provisioned and its ARN auto-flows to this chart, or pick a different alb_certificate_source." $profile) }}
+{{- end }}
+
+{{- if and $isALB (not (has $exp.alb_certificate_source (list "acm" "cert-manager"))) }}
+{{- fail (printf "hubble_ui_exposures.%s: alb_certificate_source=%q is not recognized. Valid values: 'acm' (recommended — ALB Controller consumes ACM cert directly), 'cert-manager' (NOT supported by stock ALB Controller — kept for forward compatibility with future syncer integrations)." $profile $exp.alb_certificate_source) }}
+{{- end }}
+
 {{- if $isALB }}
 {{- /* ============================ ALB BRANCH ============================ */}}
 {{- $hcPath := default "/" $exp.alb_healthcheck_path }}

--- a/core/components/loki-ingress/templates/ingress-route.yaml
+++ b/core/components/loki-ingress/templates/ingress-route.yaml
@@ -29,6 +29,14 @@
 {{- fail (printf "loki_exposures.%s: basic_auth=true is not supported when ingress_class=alb (use Cognito/OIDC integration via the alb_authorizer field — not yet implemented)" $profile) }}
 {{- end }}
 
+{{- if and $isALB (eq $exp.alb_certificate_source "acm") (eq (default "" $.Values.global.acmCertificateArn) "") }}
+{{- fail (printf "loki_exposures.%s: alb_certificate_source=acm but global.acmCertificateArn is empty. Set acm_enabled=true on the platform Terraform module so an ACM cert is provisioned and its ARN auto-flows to this chart, or pick a different alb_certificate_source." $profile) }}
+{{- end }}
+
+{{- if and $isALB (not (has $exp.alb_certificate_source (list "acm" "cert-manager"))) }}
+{{- fail (printf "loki_exposures.%s: alb_certificate_source=%q is not recognized. Valid values: 'acm' (recommended — ALB Controller consumes ACM cert directly), 'cert-manager' (NOT supported by stock ALB Controller — kept for forward compatibility with future syncer integrations)." $profile $exp.alb_certificate_source) }}
+{{- end }}
+
 {{- if $isALB }}
 {{- /* ============================ ALB BRANCH ============================ */}}
 {{- $hcPath := default "/ready" $exp.alb_healthcheck_path }}

--- a/core/components/mimir-ingress/templates/ingress-route.yaml
+++ b/core/components/mimir-ingress/templates/ingress-route.yaml
@@ -29,6 +29,14 @@
 {{- fail (printf "mimir_exposures.%s: basic_auth=true is not supported when ingress_class=alb (use Cognito/OIDC integration via the alb_authorizer field — not yet implemented)" $profile) }}
 {{- end }}
 
+{{- if and $isALB (eq $exp.alb_certificate_source "acm") (eq (default "" $.Values.global.acmCertificateArn) "") }}
+{{- fail (printf "mimir_exposures.%s: alb_certificate_source=acm but global.acmCertificateArn is empty. Set acm_enabled=true on the platform Terraform module so an ACM cert is provisioned and its ARN auto-flows to this chart, or pick a different alb_certificate_source." $profile) }}
+{{- end }}
+
+{{- if and $isALB (not (has $exp.alb_certificate_source (list "acm" "cert-manager"))) }}
+{{- fail (printf "mimir_exposures.%s: alb_certificate_source=%q is not recognized. Valid values: 'acm' (recommended — ALB Controller consumes ACM cert directly), 'cert-manager' (NOT supported by stock ALB Controller — kept for forward compatibility with future syncer integrations)." $profile $exp.alb_certificate_source) }}
+{{- end }}
+
 {{- if $isALB }}
 {{- /* ============================ ALB BRANCH ============================ */}}
 {{- $hcPath := default "/ready" $exp.alb_healthcheck_path }}

--- a/providers/aws/acm.tf
+++ b/providers/aws/acm.tf
@@ -1,15 +1,46 @@
 # ---------------------------------------------------------------------------
 # ACM wildcard certificate (opt-in)
 #
-# Used when ingress_controller = 'alb' and the operator wants TLS terminated
-# at the ALB with an AWS-native certificate (no cert-manager on the public
-# path). DNS-01 validation is automatic when dns_provider = 'route53'; for
-# Cloudflare the caller must create the _acme-challenge CNAMEs manually
-# (the certificate waits up to 90 minutes, so this path is discouraged).
+# Used when ingress_controller = 'alb'. ALB Controller only consumes ACM
+# certificates (it cannot read k8s Secrets — cert-manager-issued certs
+# do NOT work on ALB). DNS-01 validation is automatic for both
+# 'route53' and 'cloudflare' providers — the latter writes the
+# _acme-challenge CNAME via the Cloudflare API token already required
+# by external-dns / cert-manager DNS-01 issuer.
 #
 # Domain: *.{cluster_name}.{domain}
 # Extra SANs: var.acm_extra_domain_names
 # ---------------------------------------------------------------------------
+
+# Cross-variable validation: ALB Controller only consumes ACM certificates —
+# cert-manager-issued k8s Secrets do NOT work. If the operator picks
+# ingress_controller = "alb" but forgets acm_enabled, fail at plan time
+# instead of after a successful apply that produces broken Ingresses.
+resource "null_resource" "alb_requires_acm_validation" {
+  count = var.ingress_controller == "alb" ? 1 : 0
+
+  lifecycle {
+    precondition {
+      condition     = var.acm_enabled
+      error_message = "ingress_controller = \"alb\" requires acm_enabled = true. AWS Load Balancer Controller cannot consume cert-manager-issued k8s Secrets — only ACM certificates are supported. Set acm_enabled = true to provision a wildcard ACM cert validated automatically via the configured dns_provider (route53 or cloudflare)."
+    }
+  }
+}
+
+# Cross-variable validation: ACM DNS validation only automated for
+# 'route53' and 'cloudflare'. With dns_provider = "none" the operator
+# would have to place CNAMEs by hand and the certificate_validation
+# resource would block forever — fail loud upfront.
+resource "null_resource" "acm_requires_managed_dns" {
+  count = var.acm_enabled ? 1 : 0
+
+  lifecycle {
+    precondition {
+      condition     = contains(["route53", "cloudflare"], var.dns_provider)
+      error_message = "acm_enabled = true requires dns_provider = \"route53\" or \"cloudflare\" so Terraform can place the validation CNAMEs automatically. With dns_provider = \"none\" you would have to validate by hand and the apply would block — disable acm_enabled or pick a managed DNS provider."
+    }
+  }
+}
 
 resource "aws_acm_certificate" "wildcard" {
   count = var.acm_enabled ? 1 : 0
@@ -24,8 +55,7 @@ resource "aws_acm_certificate" "wildcard" {
 }
 
 # ---------------------------------------------------------------------------
-# DNS validation records (only when dns_provider = route53 — we can create
-# them automatically; Cloudflare requires manual CNAME creation).
+# DNS validation records — Route53 path.
 # ---------------------------------------------------------------------------
 
 resource "aws_route53_record" "acm_validation" {
@@ -45,9 +75,40 @@ resource "aws_route53_record" "acm_validation" {
   allow_overwrite = true
 }
 
-resource "aws_acm_certificate_validation" "wildcard" {
-  count = var.acm_enabled && var.dns_provider == "route53" ? 1 : 0
+# ---------------------------------------------------------------------------
+# DNS validation records — Cloudflare path.
+#
+# ACM emits validation records as fully-qualified CNAMEs ending with
+# `.${var.domain}.` — Cloudflare's API expects relative names, so we
+# trimsuffix the zone to keep the record under the right zone without
+# duplicating the apex.
+# ---------------------------------------------------------------------------
 
-  certificate_arn         = aws_acm_certificate.wildcard[0].arn
-  validation_record_fqdns = [for r in aws_route53_record.acm_validation : r.fqdn]
+resource "cloudflare_record" "acm_validation" {
+  for_each = var.acm_enabled && var.dns_provider == "cloudflare" ? {
+    for dvo in aws_acm_certificate.wildcard[0].domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  } : {}
+
+  zone_id = var.cloudflare_zone_id
+  name    = trimsuffix(each.value.name, ".${var.domain}.")
+  value   = trimsuffix(each.value.record, ".")
+  type    = each.value.type
+  ttl     = 60
+  proxied = false
+  comment = "ACM cert validation for ${local.cluster_name} (managed by estabilis-platform)"
+}
+
+resource "aws_acm_certificate_validation" "wildcard" {
+  count = var.acm_enabled && contains(["route53", "cloudflare"], var.dns_provider) ? 1 : 0
+
+  certificate_arn = aws_acm_certificate.wildcard[0].arn
+  validation_record_fqdns = var.dns_provider == "route53" ? (
+    [for r in aws_route53_record.acm_validation : r.fqdn]
+    ) : (
+    [for r in cloudflare_record.acm_validation : r.hostname]
+  )
 }

--- a/providers/aws/cloudflare.tf
+++ b/providers/aws/cloudflare.tf
@@ -1,4 +1,16 @@
 # ---------------------------------------------------------------------------
+# Cloudflare provider — only effective when dns_provider = "cloudflare".
+# When dns_provider != "cloudflare", api_token is empty and any
+# cloudflare_* resource that gets created (none should — they are
+# count-gated) will fail with an obvious "Authentication error" rather
+# than silently succeeding.
+# ---------------------------------------------------------------------------
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}
+
+# ---------------------------------------------------------------------------
 # Cloudflare credentials — AWS-side wiring.
 #
 # Mirrors the github-app-credentials shape (Estabilis/estabilis-platform v0.18.0):

--- a/providers/aws/eks.tf
+++ b/providers/aws/eks.tf
@@ -292,3 +292,19 @@ resource "aws_ec2_tag" "existing_public_elb" {
   key         = "kubernetes.io/role/elb"
   value       = "1"
 }
+
+# Cluster-membership tag. ALB Controller filters subnets by
+# `kubernetes.io/cluster/<cluster-name>` to determine which subnets belong
+# to this cluster — without it, public ALB provisioning fails with
+# "couldn't auto-discover subnets: tagged for other clusters" when the VPC
+# is shared with another EKS cluster (e.g. legacy + new running side by
+# side during a migration). `shared` (vs `owned`) is appropriate because
+# the platform module does NOT own the subnet lifecycle in vpc_mode =
+# existing — it only annotates membership.
+resource "aws_ec2_tag" "existing_subnets_cluster_membership" {
+  for_each = var.vpc_mode == "existing" ? toset(concat(var.public_subnet_ids, var.private_subnet_ids)) : []
+
+  resource_id = each.value
+  key         = "kubernetes.io/cluster/${local.cluster_name}"
+  value       = "shared"
+}

--- a/providers/aws/variables.tf
+++ b/providers/aws/variables.tf
@@ -663,7 +663,7 @@ variable "letsencrypt_email" {
 # ---------------------------------------------------------------------------
 
 variable "acm_enabled" {
-  description = "Provision a wildcard ACM certificate for *.{cluster_name}.{domain}. Useful with ALB + ACM integration (avoids cert-manager for public endpoints). Terraform runs the DNS-01 validation automatically when dns_provider = 'route53'."
+  description = "Provision a wildcard ACM certificate for *.{cluster_name}.{domain}. Required when ingress_controller = 'alb' (ALB Controller only consumes ACM certificates — k8s Secrets are not supported). DNS validation is automatic for both 'route53' and 'cloudflare' DNS providers."
   type        = bool
   default     = false
 }
@@ -697,7 +697,7 @@ variable "grafana_exposures" {
     alb_target_type        = optional(string, "ip")
     alb_ssl_policy         = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
     alb_healthcheck_path   = optional(string, "")
-    alb_certificate_source = optional(string, "cert-manager")
+    alb_certificate_source = optional(string, "acm")
     alb_cloudflare_proxied = optional(bool, false)
   }))
   default = {}
@@ -719,7 +719,7 @@ variable "loki_exposures" {
     alb_target_type        = optional(string, "ip")
     alb_ssl_policy         = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
     alb_healthcheck_path   = optional(string, "")
-    alb_certificate_source = optional(string, "cert-manager")
+    alb_certificate_source = optional(string, "acm")
     alb_cloudflare_proxied = optional(bool, false)
   }))
   default = {}
@@ -742,7 +742,7 @@ variable "mimir_exposures" {
     alb_target_type        = optional(string, "ip")
     alb_ssl_policy         = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
     alb_healthcheck_path   = optional(string, "")
-    alb_certificate_source = optional(string, "cert-manager")
+    alb_certificate_source = optional(string, "acm")
     alb_cloudflare_proxied = optional(bool, false)
   }))
   default = {}
@@ -765,7 +765,7 @@ variable "argocd_exposures" {
     alb_target_type        = optional(string, "ip")
     alb_ssl_policy         = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
     alb_healthcheck_path   = optional(string, "")
-    alb_certificate_source = optional(string, "cert-manager")
+    alb_certificate_source = optional(string, "acm")
     alb_cloudflare_proxied = optional(bool, false)
   }))
   default = {}
@@ -788,7 +788,7 @@ variable "hubble_ui_exposures" {
     alb_target_type        = optional(string, "ip")
     alb_ssl_policy         = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
     alb_healthcheck_path   = optional(string, "")
-    alb_certificate_source = optional(string, "cert-manager")
+    alb_certificate_source = optional(string, "acm")
     alb_cloudflare_proxied = optional(bool, false)
   }))
   default = {}

--- a/providers/aws/versions.tf
+++ b/providers/aws/versions.tf
@@ -30,5 +30,9 @@ terraform {
       source  = "hashicorp/helm"
       version = "~> 2.17"
     }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Postmortem from cortex E2E validation: v0.24.0's chart support for `ingress_class = "alb"` rendered the right Ingress, but two missing pieces of glue prevented ALB Controller from actually provisioning the load balancer. Both pieces were operator-side workarounds in legacy deployments — v0.25.0 closes both inside the platform module.

## Changes

### Cloudflare-validated ACM cert (was Route53-only)

`providers/aws/acm.tf` now creates validation CNAMEs via `cloudflare/cloudflare ~> 4.0` when `dns_provider = "cloudflare"`. Previously only Route53 was auto-validated; Cloudflare clients had to place CNAMEs by hand and `aws_acm_certificate_validation` would hang.

### Subnet cluster-membership tag (vpc_mode = existing)

`providers/aws/eks.tf` now adds `kubernetes.io/cluster/<cluster-name> = shared` to each subnet (public + private) when `vpc_mode = "existing"`. Without this, ALB Controller fails with "couldn't auto-discover subnets: tagged for other clusters" any time a VPC hosts > 1 EKS cluster (legacy → new migration).

### `alb_certificate_source` default flipped to `"acm"`

The v0.24.0 default of `"cert-manager"` was unworkable: AWS Load Balancer Controller cannot read k8s Secrets — only ACM certs. Flipped for all 5 AWS `*_exposures`. Azure unchanged.

### Cross-variable validation guards

Three guards at plan time prevent silent footguns:
- `ingress_controller = "alb"` requires `acm_enabled = true`
- `acm_enabled = true` requires `dns_provider = "route53"` or `"cloudflare"`
- Chart-level `fail` when `alb_certificate_source = "acm"` + empty `global.acmCertificateArn`, or unknown value

## Test plan

- [x] `helm template` of all 5 charts renders correctly with ALB+ACM
- [x] `helm template` fails clearly when `alb_certificate_source = "acm"` but ARN empty
- [x] `helm template` fails clearly when `alb_certificate_source` is unrecognized
- [ ] E2E on cortex: `terraform apply` provisions ACM cert + Cloudflare CNAMEs + subnet tags; ALB picks up cert via auto-discovery; argocd Ingress healthy without manual intervention