### PR TITLE
fix(aws): empty kubernetes.io/cluster tag on node SG (v0.25.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [0.25.1] - 2026-04-25
+
+### Fixed — Empty `kubernetes.io/cluster/<name>` tag on node SG
+
+Postmortem (immediate follow-on to v0.25.0): once the ACM cert + subnet
+tags landed and the ALB front-door provisioned, ALB Controller still
+refused to register pod targets — every reconcile loop emitted
+`expected exactly one securityGroup tagged with
+kubernetes.io/cluster/<cluster-name> for eni <eni-id>, got:
+[<node-sg> <cluster-sg>]`.
+
+Root cause: `terraform-aws-modules/eks` v20.37 hardcodes
+`kubernetes.io/cluster/<cluster-name> = "owned"` in the node SG's tags
+map (see node_groups.tf). The EKS service ALSO auto-tags the cluster
+primary SG with the same key. The result is two SGs claiming cluster
+membership — ALB Controller's algorithm requires exactly one to know
+where to inject the rule that lets the load balancer reach pod IPs.
+See terraform-aws-modules/terraform-aws-eks#2997.
+
+Fix: pass `node_security_group_tags = { "kubernetes.io/cluster/<name>"
+= "" }` to the EKS module. The module's merge order means our value
+wins; the tag still exists (we can't delete via merge) but its empty
+value falls outside ALB Controller's `["owned", "shared"]` filter, so
+the controller correctly identifies the cluster primary SG as the
+sole cluster-tagged SG and injects the rule there. Standard EKS+ALB
+contract is preserved.
+
+### Migration
+
+For existing AWS clusters bootstrapped at < v0.25.1:
+
+1. `terraform apply` after pulling v0.25.1 — the module re-tags the
+   node SG with empty value.
+2. Restart `aws-load-balancer-controller` deployment to clear its SG
+   cache (the controller polls but a restart skips the wait).
+3. Existing Ingresses with stuck `Target.Timeout` health checks
+   reconcile automatically (~30s) once the SG rule is injected.
+
+Zero impact on Azure clients.
+
 ## [0.25.0] - 2026-04-25
 
 ### Fixed — Close the AWS ALB cert + subnet-discovery gap

--- a/providers/aws/eks.tf
+++ b/providers/aws/eks.tf
@@ -248,11 +248,31 @@ module "eks" {
   # touching the module call. ---------------------------------------------
   node_security_group_additional_rules = {}
 
-  # --- Node SG tags for Karpenter discovery -------------------------------
-  # Applied whenever Karpenter is present (both 'karpenter' and 'hybrid').
-  node_security_group_tags = contains(["karpenter", "hybrid"], var.autoscaler) ? {
-    (var.karpenter_discovery_tag_key) = local.cluster_name
-  } : {}
+  # --- Node SG tags ------------------------------------------------------
+  #
+  # `kubernetes.io/cluster/<name>` is force-emptied to escape AWS Load
+  # Balancer Controller's filter, which only recognises values "owned" /
+  # "shared". The module hardcodes value="owned" on the node SG (see
+  # node_groups.tf in terraform-aws-modules/eks) — without this override
+  # both the EKS-managed cluster primary SG AND this node SG carry the
+  # tag, and ALB Controller fails with "expected exactly one
+  # securityGroup tagged with kubernetes.io/cluster/<name> for ENI ...
+  # got: [<node-sg> <cluster-sg>]" the moment a Service or Ingress
+  # produces a TargetGroupBinding. Empty value keeps the key (we cannot
+  # delete via merge) but breaks the filter — the cluster primary SG
+  # remains the single recognised SG, which is the standard EKS+ALB
+  # contract. See: terraform-aws-modules/terraform-aws-eks#2997.
+  #
+  # `var.karpenter_discovery_tag_key` is also applied whenever Karpenter
+  # is present (both 'karpenter' and 'hybrid').
+  node_security_group_tags = merge(
+    {
+      "kubernetes.io/cluster/${local.cluster_name}" = ""
+    },
+    contains(["karpenter", "hybrid"], var.autoscaler) ? {
+      (var.karpenter_discovery_tag_key) = local.cluster_name
+    } : {},
+  )
 
   tags = {
     # Karpenter uses this to find the cluster when provisioning new nodes.


### PR DESCRIPTION
## Summary

Patch follow-up to v0.25.0. After the ACM cert + subnet tags landed and the ALB front-door provisioned, ALB Controller still refused to register pod targets — every reconcile loop emitted `expected exactly one securityGroup tagged with kubernetes.io/cluster/<name> for eni <eni-id>, got: [<node-sg> <cluster-sg>]`.

## Root cause

`terraform-aws-modules/eks` v20.37 hardcodes `kubernetes.io/cluster/<cluster-name> = "owned"` on the node SG (see node_groups.tf line 220). The EKS service ALSO auto-tags the cluster primary SG with the same key. Two SGs claiming cluster membership = ALB Controller's algorithm rejects (it requires exactly one to inject the rule that lets the LB reach pod IPs).

Tracking issue upstream: terraform-aws-modules/terraform-aws-eks#2997.

## Fix

Pass `node_security_group_tags = { "kubernetes.io/cluster/<name>" = "" }` to the EKS module. The module's merge order means our value wins; the tag still exists (we cannot delete via merge) but its empty value falls outside ALB Controller's `["owned", "shared"]` filter, so the controller correctly identifies the cluster primary SG as the sole cluster-tagged SG and injects the rule there. Standard EKS+ALB contract is preserved.

## Test plan

- [x] terraform plan in cortex shows the node SG tag value flipping `owned` → `""`
- [ ] Live cortex apply: ALB Controller stops emitting the "expected exactly one" error and target health goes Healthy
- [ ] HTTPS probe of `argocd.eks-cortex-platform-prd-us-east-1.estabilis-cortex.com/healthz` returns 200