### PR TITLE
fix(aws): properly delete node SG cluster-membership tag (v0.25.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,64 @@
 # Changelog
 
+## [0.25.2] - 2026-04-25
+
+### Fixed — Properly delete node SG cluster-membership tag (v0.25.1 was a no-op)
+
+The v0.25.1 fix was based on a wrong assumption about ALB Controller's
+filter logic. We thought the controller filtered SGs by tag VALUE
+(matching `["owned", "shared"]` only); empirically it filters by tag
+KEY only. Setting `node_security_group_tags = { ... = "" }` produced a
+tag with empty value but the same key — controller still found two
+cluster-tagged SGs per ENI and continued to reject target rule
+injection. Validated end-to-end on cortex by enabling
+`grafana_exposures` after v0.25.1 apply: `Target.Timeout` returned
+immediately.
+
+Real fix: a `null_resource` with `provisioner "local-exec"` that calls
+`aws ec2 delete-tags` on the node SG, with `triggers = { always =
+timestamp() }` so it re-runs on every apply. The EKS module will
+re-assert the tag every plan/apply (its tags map is hardcoded — see
+node_groups.tf in terraform-aws-modules/eks), but this resource
+re-deletes it immediately afterward. The cluster steady state has the
+tag absent from the node SG, satisfying ALB Controller's "exactly one"
+constraint.
+
+Trade-off: terraform plan will show a small recurring drift in the
+node SG's `tags` attribute (the cluster-membership key being added
+back). This is expected; the apply restores the deleted state via the
+null_resource. We deliberately did NOT use a provider-level
+`ignore_tags` to suppress this drift, because it would also disable
+drift detection on the `aws_ec2_tag.existing_subnets_cluster_membership`
+resources from v0.25.0 (same key) — silently breaking subnet
+auto-discovery if the tag were ever removed externally. Tracking
+upstream: terraform-aws-modules/terraform-aws-eks#2997.
+
+### Migration
+
+For clusters that applied v0.25.1:
+
+1. `terraform apply` after pulling v0.25.2 — the null_resource runs
+   the delete-tags call. The empty-value `node_security_group_tags`
+   override is removed automatically.
+2. The `aws-load-balancer-controller` reconcile loop picks up within
+   ~30 s; no restart needed (the SG state changes invalidate its
+   filter result).
+
+For Azure clients: zero impact.
+
+### Removed (was never useful)
+
+- `node_security_group_tags = { "kubernetes.io/cluster/<name>" = "" }`
+  pseudo-fix from v0.25.1.
+
 ## [0.25.1] - 2026-04-25
 
-### Fixed — Empty `kubernetes.io/cluster/<name>` tag on node SG
+### Fixed — Empty `kubernetes.io/cluster/<name>` tag on node SG (NO-OP, see v0.25.2)
+
+> **Superseded by v0.25.2.** This release's approach (override the tag
+> value to `""`) does not actually fix the ALB Controller bug because
+> the controller filters by tag KEY, not value. Upgrade directly from
+> v0.25.0 → v0.25.2.
 
 Postmortem (immediate follow-on to v0.25.0): once the ACM cert + subnet
 tags landed and the ALB front-door provisioned, ALB Controller still

--- a/providers/aws/eks.tf
+++ b/providers/aws/eks.tf
@@ -248,31 +248,15 @@ module "eks" {
   # touching the module call. ---------------------------------------------
   node_security_group_additional_rules = {}
 
-  # --- Node SG tags ------------------------------------------------------
-  #
-  # `kubernetes.io/cluster/<name>` is force-emptied to escape AWS Load
-  # Balancer Controller's filter, which only recognises values "owned" /
-  # "shared". The module hardcodes value="owned" on the node SG (see
-  # node_groups.tf in terraform-aws-modules/eks) — without this override
-  # both the EKS-managed cluster primary SG AND this node SG carry the
-  # tag, and ALB Controller fails with "expected exactly one
-  # securityGroup tagged with kubernetes.io/cluster/<name> for ENI ...
-  # got: [<node-sg> <cluster-sg>]" the moment a Service or Ingress
-  # produces a TargetGroupBinding. Empty value keeps the key (we cannot
-  # delete via merge) but breaks the filter — the cluster primary SG
-  # remains the single recognised SG, which is the standard EKS+ALB
-  # contract. See: terraform-aws-modules/terraform-aws-eks#2997.
-  #
-  # `var.karpenter_discovery_tag_key` is also applied whenever Karpenter
-  # is present (both 'karpenter' and 'hybrid').
-  node_security_group_tags = merge(
-    {
-      "kubernetes.io/cluster/${local.cluster_name}" = ""
-    },
-    contains(["karpenter", "hybrid"], var.autoscaler) ? {
-      (var.karpenter_discovery_tag_key) = local.cluster_name
-    } : {},
-  )
+  # --- Node SG tags for Karpenter discovery -------------------------------
+  # Applied whenever Karpenter is present (both 'karpenter' and 'hybrid').
+  # The cluster-membership tag (kubernetes.io/cluster/<name>) is deliberately
+  # NOT set here — see null_resource.untag_node_sg_cluster_membership below
+  # for the deletion logic and main.tf provider's ignore_tags for the
+  # drift-suppression pair.
+  node_security_group_tags = contains(["karpenter", "hybrid"], var.autoscaler) ? {
+    (var.karpenter_discovery_tag_key) = local.cluster_name
+  } : {}
 
   tags = {
     # Karpenter uses this to find the cluster when provisioning new nodes.
@@ -327,4 +311,53 @@ resource "aws_ec2_tag" "existing_subnets_cluster_membership" {
   resource_id = each.value
   key         = "kubernetes.io/cluster/${local.cluster_name}"
   value       = "shared"
+}
+
+# ---------------------------------------------------------------------------
+# Node SG cluster-tag deletion.
+#
+# `terraform-aws-modules/eks` v20 hardcodes
+# `kubernetes.io/cluster/<name>=owned` in the node SG's tags map; combined
+# with the EKS-managed cluster primary SG (auto-tagged by AWS), this gives
+# every node ENI TWO cluster-tagged SGs. ALB Controller's algorithm rejects
+# this state with:
+#
+#     "expected exactly one securityGroup tagged with
+#      kubernetes.io/cluster/<name> for eni <id>, got: [<node-sg> <cluster-sg>]"
+#
+# blocking target rule injection on every Ingress/Service. Module exposes no
+# knob to suppress; setting the value via `node_security_group_tags = { ...
+# = "" }` keeps the tag KEY (which is what the controller filters on),
+# making that workaround a no-op. The only effective fix is an actual
+# delete-tags API call after every apply.
+#
+# `triggers = { always = timestamp() }` re-runs the local-exec on every
+# apply, so even when the EKS module re-asserts the tag (which it will,
+# every plan/apply, since terraform's drift detection sees the tag missing
+# from AWS but present in the module's tags map), this resource immediately
+# re-deletes it. Operators will see a small drift in plan output for the
+# node SG `tags` attribute — that is the expected steady state and tracks
+# the upstream module bug:
+#   https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2997
+#
+# Provider-level `ignore_tags` would suppress the plan-output drift but
+# would also disable drift detection on `aws_ec2_tag.existing_subnets_*`
+# (which uses the same key), creating a silent failure mode for the subnet
+# tagging fix in v0.25.0. Trading clean plan output for safer subnet drift
+# detection — the local-exec idempotency keeps the cluster healthy in
+# between any actual applies.
+# ---------------------------------------------------------------------------
+resource "null_resource" "untag_node_sg_cluster_membership" {
+  triggers = {
+    sg_id        = module.eks.node_security_group_id
+    cluster_name = local.cluster_name
+    region       = var.region
+    always_run   = timestamp()
+  }
+
+  provisioner "local-exec" {
+    command = "aws ec2 delete-tags --resources ${self.triggers.sg_id} --tags Key=kubernetes.io/cluster/${self.triggers.cluster_name} --region ${self.triggers.region}"
+  }
+
+  depends_on = [module.eks]
 }


### PR DESCRIPTION
## Summary

v0.25.1's empty-value override was a **no-op**. ALB Controller filters SGs by tag KEY, not value, so an empty value still hits the 'expected exactly one securityGroup' guard. Validated end-to-end on cortex by enabling `grafana_exposures` after v0.25.1: `Target.Timeout` returned immediately.

## Real fix

`null_resource` with `provisioner "local-exec"` calling `aws ec2 delete-tags`, triggered on every apply via `timestamp()`. The EKS module re-asserts the tag during apply (its tags map is hardcoded — see `node_groups.tf` upstream); this resource immediately re-deletes it. Cluster steady state has the tag absent from the node SG, satisfying ALB Controller's "exactly one" constraint.

## Why no provider ignore_tags

Using `provider.ignore_tags { keys = ["kubernetes.io/cluster/<name>"] }` would suppress the plan-output drift but would also disable drift detection on the `aws_ec2_tag.existing_subnets_cluster_membership` resources from v0.25.0 (same key). That would silently break subnet auto-discovery if the tag were ever removed externally. Trade clean plan output for safe drift detection — the local-exec idempotency keeps the cluster healthy between any actual applies.

Operators will see a small recurring drift in plan output for the node SG `tags` attribute. This is expected.

Tracking upstream: terraform-aws-modules/terraform-aws-eks#2997.

## Test plan

- [x] cortex E2E: with v0.25.1, enabling `grafana_exposures.external` produced an Ingress that synced but Target was unhealthy with `Target.Timeout`. Manual `aws ec2 delete-tags` resolved it. Same expected behavior with v0.25.2 but automatic.
- [ ] cortex `terraform apply` v0.25.2 — null_resource runs delete-tags, target heals
- [ ] HTTPS probe of `grafana.eks-cortex-platform-prd-us-east-1.estabilis-cortex.com/api/health` returns 200 without manual intervention