### PR TITLE
fix(platform-root): clear persistent OutOfSync on policies, quotas, ALB controller (v0.26.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog
 
+## [0.26.0] - 2026-04-25
+
+### Fixed — Persistent OutOfSync on `network-policies`, `resource-quotas`, `aws-load-balancer-controller`
+
+Cortex post-mortem (validated with `argocd-ingress`, `external-secrets`,
+`platform-root`):
+
+#### `network-policies` and `resource-quotas` — phantom drift on disabled components
+
+Both charts have a `components.<ns>` map that defaults every entry to
+`true`, so they unconditionally rendered `NetworkPolicy` /
+`ResourceQuota` / `LimitRange` resources for namespaces of components
+that an operator had disabled (e.g. `components.opencost = false`,
+`components.traefik = false` on AWS clusters). The target namespaces
+never exist, so the resources stay in `OutOfSync` forever.
+
+The fix: `bootstrap/platform-root/templates/network-policies.yaml` and
+`resource-quotas.yaml` now forward `.Values.components` into the child
+Application via `valuesObject.components`. The chart-level gating
+(`if hasKey $.Values.components $ns`) immediately starts honoring the
+operator's intent.
+
+Also added `policy-reporter: false` to platform-root `values.yaml`
+defaults — every cluster carried this in `components` only via the
+chart's default-true behaviour, even though policy-reporter is opt-in.
+
+Mismatches between platform-root key naming and chart key naming
+(e.g. platform's `cnpg` vs `resource-quotas` chart's `cnpg-system`,
+platform's `trivy` vs `trivy-system`) are tolerated: the chart's
+`hasKey` check falls through to default-true, which is correct for the
+clusters that DO deploy those components. A follow-up PR will rename
+the chart keys for full consistency.
+
+#### `aws-load-balancer-controller` — phantom drift on webhook caBundle and TLS
+
+The chart's webhook-self-signing init container patches the
+`MutatingWebhookConfiguration` / `ValidatingWebhookConfiguration`
+caBundle and the `aws-load-balancer-tls` Secret data at install time.
+ArgoCD then sees the resulting in-cluster fields as drift against the
+unpopulated chart manifest and reports `OutOfSync` permanently. Same
+issue on the `IngressClassParams alb` body which the chart leaves empty
+for the operator to fill in.
+
+The fix: scoped `ignoreDifferences` entries on the `aws-load-balancer-
+controller` Application:
+- caBundle in both webhook configurations (jqPathExpression
+  `.webhooks[]?.clientConfig.caBundle`)
+- entire `data` of the TLS Secret
+- entire `spec` of the `IngressClassParams alb` (body is not chart-managed)
+
+The pattern follows the AKS `admissionsenforcer` precedent (Estabilis
+memory `reference_aks_admissionsenforcer_webhook_drift`).
+
+### Migration
+
+For all clusters running v0.25.x:
+
+1. `terraform apply` after pulling v0.26.0 — only the platform-root
+   Application's `targetRevision` bumps; no infrastructure change.
+2. `estabilis promote <client>` (or sync `platform-root` then
+   downstream Apps directly) — the new `valuesObject` and
+   `ignoreDifferences` propagate; existing OutOfSync states clear
+   within the next reconcile loop.
+3. NetworkPolicies / Quotas for disabled components are pruned
+   automatically (their parent App auto-syncs with `prune: true`).
+
+Zero impact on Azure-only clusters that have all components enabled.
+
 ## [0.25.2] - 2026-04-25
 
 ### Fixed — Properly delete node SG cluster-membership tag (v0.25.1 was a no-op)

--- a/bootstrap/platform-root/templates/aws-load-balancer-controller.yaml
+++ b/bootstrap/platform-root/templates/aws-load-balancer-controller.yaml
@@ -62,6 +62,32 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: aws-load-balancer-controller
+  {{- /* Ignore drift on fields the chart's webhook self-signing logic
+        populates at install time (caBundle / TLS Secret data) and on
+        the IngressClassParams body which the chart leaves empty for the
+        operator to fill in. Without this, the App reports OutOfSync on
+        every reconcile despite the controller working correctly. */}}
+  ignoreDifferences:
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      name: aws-load-balancer-webhook
+      jqPathExpressions:
+        - .webhooks[]?.clientConfig.caBundle
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      name: aws-load-balancer-webhook
+      jqPathExpressions:
+        - .webhooks[]?.clientConfig.caBundle
+    - group: ""
+      kind: Secret
+      name: aws-load-balancer-tls
+      jsonPointers:
+        - /data
+    - group: elbv2.k8s.aws
+      kind: IngressClassParams
+      name: alb
+      jsonPointers:
+        - /spec
   syncPolicy:
     {{- include "platform-root.managedNamespaceMetadataExcluded" . | nindent 4 }}
     retry:

--- a/bootstrap/platform-root/templates/network-policies.yaml
+++ b/bootstrap/platform-root/templates/network-policies.yaml
@@ -20,7 +20,18 @@ spec:
           {{- include "platform-root.overrideValueFile" (dict "component" "network-policies" "root" $) | nindent 10 }}
           {{- include "platform-root.gitopsValueFile" (dict "component" "network-policies" "root" $) | nindent 10 }}
         ignoreMissingValueFiles: true
-        {{- include "platform-root.provenanceParametersBlock" $ | nindent 8 }}
+        {{- /* Forward platform-root components map so the chart only renders
+              NetworkPolicies for namespaces whose component is actually
+              deployed. Without this, disabled components (opencost=false,
+              traefik=false, etc.) still produce NPs targeting their
+              non-existent namespaces and the App stays OutOfSync. */}}
+        valuesObject:
+          components:
+            {{- range $k, $v := .Values.components }}
+            {{ $k | quote }}: {{ $v }}
+            {{- end }}
+        parameters:
+          {{- include "platform-root.provenanceParameters" $ | nindent 10 }}
     - repoURL: {{ .Values.platformGitopsRepoUrl }}
       targetRevision: {{ .Values.platformGitopsVersion }}
       ref: values

--- a/bootstrap/platform-root/templates/resource-quotas.yaml
+++ b/bootstrap/platform-root/templates/resource-quotas.yaml
@@ -19,7 +19,19 @@ spec:
           {{- include "platform-root.overrideValueFile" (dict "component" "resource-quotas" "root" $) | nindent 10 }}
           {{- include "platform-root.gitopsValueFile" (dict "component" "resource-quotas" "root" $) | nindent 10 }}
         ignoreMissingValueFiles: true
-        {{- include "platform-root.provenanceParametersBlock" $ | nindent 8 }}
+        {{- /* Forward platform-root components map so the chart only renders
+              ResourceQuotas/LimitRanges for namespaces whose component is
+              actually deployed. Without this, disabled components
+              (opencost=false, traefik=false, etc.) still produce quotas
+              targeting their non-existent namespaces and the App stays
+              OutOfSync. */}}
+        valuesObject:
+          components:
+            {{- range $k, $v := .Values.components }}
+            {{ $k | quote }}: {{ $v }}
+            {{- end }}
+        parameters:
+          {{- include "platform-root.provenanceParameters" $ | nindent 10 }}
     - repoURL: {{ .Values.platformGitopsRepoUrl }}
       targetRevision: {{ .Values.platformGitopsVersion }}
       ref: values

--- a/bootstrap/platform-root/values.yaml
+++ b/bootstrap/platform-root/values.yaml
@@ -148,6 +148,7 @@ components:
   velero: true               # optional: backup/restore (disable if handled externally)
   external-dns: true         # optional: DNS record management (disable if manual DNS)
   argocd-image-updater: false # optional: auto-update container images via registry polling (opt-in)
+  policy-reporter: false     # optional: kubernetes policy report dashboards (disabled by default — opt-in)
   metrics-server: true       # optional: AWS-only — Resource Metrics API server (kubectl top, HPA). Azure AKS provides natively
   karpenter: true            # optional: AWS-only — node autoscaler. Activates when global.autoscaler is `karpenter` or `hybrid`
   karpenter-resources: true  # optional: AWS-only — default NodePool + EC2NodeClass. Same activation as karpenter


### PR DESCRIPTION
## Summary

Cortex post-mortem after enabling Grafana exposure: 4 Applications stuck OutOfSync forever despite working correctly.

## Findings + Fixes

### `network-policies` and `resource-quotas` — phantom drift on disabled components

Both charts render `NetworkPolicy` / `ResourceQuota` / `LimitRange` per-namespace gated on `components.<ns>`. Defaults to true. Platform-root never forwarded `.Values.components`, so disabled components (`opencost=false`, `traefik=false`, `policy-reporter=false`) still produced resources for namespaces that don't exist → permanent OutOfSync.

Fix: forward `.Values.components` to both Apps via `valuesObject.components`. Added `policy-reporter: false` to platform-root values (was implicitly true via chart default).

### `aws-load-balancer-controller` — webhook caBundle drift

Chart's self-signing init container patches `MutatingWebhookConfiguration` + `ValidatingWebhookConfiguration` caBundle and the TLS Secret at install time → ArgoCD sees these as permanent drift. Same for `IngressClassParams alb` (chart leaves the body empty for operator to fill).

Fix: scoped `ignoreDifferences` on the App for caBundle (jqPathExpressions), TLS Secret data, and IngressClassParams spec.

## Test plan

- [x] `helm template` of platform-root with `components.opencost=false` shows `valuesObject.components` propagated to network-policies + resource-quotas
- [x] `helm template` shows `ignoreDifferences` on aws-load-balancer-controller App with the 4 entries
- [ ] Cortex E2E: bump to v0.26.0, sync platform-root, verify the 4 OutOfSync Apps clear without manual intervention