### PR TITLE
fix(aws): cloudflare_record.value -> content (v4 deprecation, v0.26.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.26.1] - 2026-04-25
+
+### Fixed — `cloudflare_record.value` deprecation warning
+
+Cloudflare Terraform provider v4 deprecated the `value` argument in
+favor of `content`. Every `terraform plan/apply` against an
+`acm_enabled = true` cluster on the Cloudflare path emitted:
+
+```
+Warning: Argument is deprecated
+  with module.estabilis_platform.cloudflare_record.acm_validation[...]:
+  98:   value   = trimsuffix(each.value.record, ".")
+  `value` is deprecated in favour of `content` and will be removed in
+  the next major release.
+```
+
+The argument was added in v0.25.0 as part of the Cloudflare-validated
+ACM path. Fixed: `value` → `content` in
+`providers/aws/acm.tf:cloudflare_record.acm_validation`.
+
+Behaviour identical, no resource recreate.
+
 ## [0.26.0] - 2026-04-25
 
 ### Fixed — Persistent OutOfSync on `network-policies`, `resource-quotas`, `aws-load-balancer-controller`

--- a/providers/aws/acm.tf
+++ b/providers/aws/acm.tf
@@ -95,7 +95,7 @@ resource "cloudflare_record" "acm_validation" {
 
   zone_id = var.cloudflare_zone_id
   name    = trimsuffix(each.value.name, ".${var.domain}.")
-  value   = trimsuffix(each.value.record, ".")
+  content = trimsuffix(each.value.record, ".")
   type    = each.value.type
   ttl     = 60
   proxied = false


### PR DESCRIPTION
Cloudflare provider v4 deprecated `value` in favor of `content`. Every terraform plan/apply against `acm_enabled=true` + `dns_provider=cloudflare` emitted a deprecation warning since v0.25.0. Drop-in rename, no behaviour change, no resource recreate.