### PR TITLE
fix(platform-root): permit elbv2.k8s.aws + ignore external-secrets webhook caBundle drift (v0.26.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Changelog
 
+## [0.26.2] - 2026-04-25
+
+### Fixed — Persistent OutOfSync exposed by `platform-root` recovery on AWS
+
+Two upstream gaps surfaced after the `application-controller` was
+restored on a v0.26.1 AWS cluster (cortex-eks postmortem). Both were
+present since v0.26.0 but were masked by a stuck controller cache that
+prevented fresh diffs against the v0.26.1 manifest set.
+
+#### `aws-load-balancer-controller` — `IngressClassParams alb` rejected by AppProject
+
+`bootstrap/platform-root/templates/aws-load-balancer-controller.yaml`
+ships an `ignoreDifferences` entry for the `IngressClassParams alb`
+spec (added in v0.26.0), but the platform AppProject's
+`clusterResourceWhitelist` never permitted the `elbv2.k8s.aws` API
+group. Sync failed with:
+
+```
+resource elbv2.k8s.aws:IngressClassParams is not permitted in project platform
+```
+
+The fix: add `elbv2.k8s.aws/*` to the platform project's
+`clusterResourceWhitelist` in
+`bootstrap/platform-root/templates/argocd-project.yaml`. Pattern
+matches the existing `karpenter.sh/*` and `karpenter.k8s.aws/*`
+entries — wildcard because the AWS Load Balancer Controller may
+introduce additional kinds (e.g. `TargetGroupBinding`) in future
+chart versions.
+
+#### `external-secrets` — caBundle drift on `ValidatingWebhookConfiguration`
+
+`externalsecret-validate` and `secretstore-validate` are populated
+with a `caBundle` after install (chart-rendered manifest leaves it
+empty). Same pattern that `argocd`, `aws-load-balancer-controller`,
+and `cert-manager` already address with `ignoreDifferences`.
+
+The fix: add scoped `ignoreDifferences` entries on the
+`external-secrets` Application
+(`bootstrap/platform-root/templates/external-secrets.yaml`):
+- `ValidatingWebhookConfiguration .webhooks[]?.clientConfig.caBundle`
+- `MutatingWebhookConfiguration .webhooks[]?.clientConfig.caBundle`
+
+The `MutatingWebhookConfiguration` entry is defensive — current
+chart only registers a `ValidatingWebhookConfiguration`, but the
+upstream pattern across the platform always covers both kinds.
+
+### Migration
+
+For all clusters running v0.26.x:
+
+1. Bump platform `ref=` to `v0.26.2` in client `providers/<cloud>/main.tf`
+2. Bump `platform_version = "v0.26.2"` in client `terraform.tfvars`
+3. `terraform init -upgrade && terraform plan && terraform apply`
+4. `estabilis promote <client> -d <deployment> --force-refresh`
+5. Force-sync `aws-load-balancer-controller` and `external-secrets` (manual sync apps)
+
+Behaviour identical, no resource recreate, no data path impact.
+
 ## [0.26.1] - 2026-04-25
 
 ### Fixed — `cloudflare_record.value` deprecation warning

--- a/bootstrap/platform-root/templates/argocd-project.yaml
+++ b/bootstrap/platform-root/templates/argocd-project.yaml
@@ -134,6 +134,8 @@ spec:
       kind: "*"
     - group: karpenter.k8s.aws
       kind: "*"
+    - group: elbv2.k8s.aws
+      kind: "*"
     - group: apiregistration.k8s.io
       kind: APIService
 ---

--- a/bootstrap/platform-root/templates/external-secrets.yaml
+++ b/bootstrap/platform-root/templates/external-secrets.yaml
@@ -51,6 +51,21 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: external-secrets
+  ignoreDifferences:
+    {{- /*
+        cert-manager (or the chart's webhook-self-signing init) injects
+        the caBundle into both webhook configurations after install.
+        Same pattern as argocd, aws-load-balancer-controller, cert-manager —
+        see Estabilis memory `reference_aks_admissionsenforcer_webhook_drift`.
+    */}}
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      jqPathExpressions:
+        - .webhooks[]?.clientConfig.caBundle
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      jqPathExpressions:
+        - .webhooks[]?.clientConfig.caBundle
   syncPolicy:
     {{- include "platform-root.managedNamespaceMetadataExcluded" . | nindent 4 }}
     retry:


### PR DESCRIPTION
## Summary

Two upstream gaps surfaced after the `application-controller` was restored on a v0.26.1 AWS cluster — both present since v0.26.0 but masked by a stuck controller cache.

### 1. `aws-load-balancer-controller` blocked at AppProject gate

`bootstrap/platform-root/templates/aws-load-balancer-controller.yaml` already declares `ignoreDifferences` for `IngressClassParams alb` (added in v0.26.0). But the platform project's `clusterResourceWhitelist` never permitted `elbv2.k8s.aws`, so sync failed with:

```
resource elbv2.k8s.aws:IngressClassParams is not permitted in project platform
```

**Fix:** add `elbv2.k8s.aws/*` to the platform project's whitelist (`bootstrap/platform-root/templates/argocd-project.yaml`). Wildcard, matching the existing `karpenter.sh/*` and `karpenter.k8s.aws/*` lines — covers `IngressClassParams` today and any future kinds in the same group (e.g. `TargetGroupBinding`).

### 2. `external-secrets` permanent webhook caBundle drift

`externalsecret-validate` and `secretstore-validate` get a `caBundle` injected after install (chart manifest leaves it empty). Same pattern that `argocd`, `aws-load-balancer-controller` and `cert-manager` already address.

**Fix:** add scoped `ignoreDifferences` on the `external-secrets` Application for both `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` `.webhooks[]?.clientConfig.caBundle`. Both kinds defensively — current chart only ships Validating but platform pattern always covers both.

## Test plan

- [x] Live cluster reproduction confirmed: `kubectl -n argocd get application aws-load-balancer-controller` → `SyncFailed` with `elbv2.k8s.aws:IngressClassParams is not permitted`
- [x] Live cluster reproduction confirmed: `external-secrets` → `OutOfSync Healthy`, with the 2 webhook configurations as the only diffs
- [ ] After v0.26.2 ships and cluster is bumped, both Apps reach `Synced + Healthy` without manual intervention
- [ ] No resource recreate (additive changes only)

## Migration

For all v0.26.x clusters: bump `ref=` and `platform_version` to `v0.26.2`, run `terraform apply`, then force-sync `aws-load-balancer-controller` and `external-secrets` (both manual-sync apps). No data path impact.