### PR TITLE
fix(platform-root): provider-aware filter on components forwarding (v0.27.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,75 @@
 # Changelog
 
+## [0.27.0] - 2026-04-25
+
+### Fixed — `network-policies` and `resource-quotas` forward AWS-only components on Azure
+
+`bootstrap/platform-root/templates/network-policies.yaml` and
+`resource-quotas.yaml` (introduced in v0.26.0 to fix phantom drift on
+disabled components) forwarded **all** entries of `.Values.components`
+to the gitops-side child charts via `valuesObject.components`,
+regardless of the active provider.
+
+This is correct for components that are always potentially active on
+either provider (`opencost`, `traefik`, etc.) but creates a latent
+drift on Azure for AWS-only components — `aws-load-balancer-controller`,
+`karpenter`, `karpenter-resources`, `metrics-server`. The Application
+templates that install these components are gated on
+`global.provider == "aws"`, so the namespaces never come into
+existence on Azure. But the `components.{ns}: true` defaults in
+`bootstrap/platform-root/values.yaml` still propagated to the
+`network-policies` and `resource-quotas` charts, which would render
+NetworkPolicies and ResourceQuotas for non-existent namespaces →
+permanent OutOfSync.
+
+Today no Azure cluster is using these charts to cover ALB / karpenter
+namespaces (the gitops `components/network-policies/values.yaml`
+historically didn't list them), so the bug was inert. Pairs with
+`estabilis-platform-gitops v0.37.0` which DOES add coverage —
+without this filter, that gitops bump would generate Azure regression.
+
+#### Fix
+
+New helper `platform-root.componentsForwarding` in
+`bootstrap/platform-root/templates/_helpers.tpl` filters the AWS-only
+set out of the forwarded map when `global.provider != "aws"`. Used
+identically by both `network-policies.yaml` and `resource-quotas.yaml`
+templates (replacing the previous inline `range $k, $v` loop).
+
+The AWS-only set:
+```
+- aws-load-balancer-controller
+- karpenter
+- karpenter-resources
+- metrics-server
+```
+must stay synchronized with the `global.provider == "aws"` gating
+clauses in the corresponding `bootstrap/platform-root/templates/*.yaml`
+Application templates.
+
+### Bumped — `platformGitopsVersion: v0.33.0 → v0.37.0`
+
+`estabilis-platform-gitops v0.37.0` lands the corresponding ALB +
+karpenter coverage in `components/network-policies` and
+`components/resource-quotas`. The two releases pair: v0.27.0
+introduces the provider filter, v0.37.0 introduces the new
+allow-* policies and quotas. Either alone is correct (no regression);
+both together close the gap fully.
+
+### Migration
+
+For all v0.26.x clusters:
+1. Bump `ref=` and `platform_revision` to `v0.27.0` in client
+   `providers/<cloud>/main.tf` + `terraform.tfvars`.
+2. `terraform init -upgrade && terraform apply`.
+3. `estabilis promote <client> -d <deployment> --force-refresh`
+   (re-renders the `network-policies` and `resource-quotas`
+   Applications with the filtered components map).
+
+Behaviour unchanged on existing AWS clusters; no-op on existing Azure
+clusters until the gitops chart starts declaring ALB / karpenter
+coverage (v0.37.0).
+
 ## [0.26.2] - 2026-04-25
 
 ### Fixed — Persistent OutOfSync exposed by `platform-root` recovery on AWS

--- a/bootstrap/platform-root/templates/_helpers.tpl
+++ b/bootstrap/platform-root/templates/_helpers.tpl
@@ -376,3 +376,34 @@ affinity:
 tolerations:
   {{- include "platform-root.schedulingTolerations" . | nindent 2 }}
 {{- end -}}
+
+{{- /*
+  componentsForwarding — emit `.Values.components` filtered by provider,
+  skipping AWS-only entries when global.provider != "aws". Used by the
+  network-policies and resource-quotas Application templates that hand
+  the components map to their gitops-side child charts.
+
+  Without this filter, AWS-only namespaces (which never come into
+  existence on Azure because their Application templates are gated on
+  global.provider == "aws") still get forwarded as components.{ns}=true,
+  causing the gitops charts to render NetworkPolicies / ResourceQuotas
+  for non-existent namespaces and producing permanent OutOfSync drift.
+
+  AWS-only set must match the gating clauses in:
+    - bootstrap/platform-root/templates/aws-load-balancer-controller.yaml
+    - bootstrap/platform-root/templates/karpenter.yaml (also gates karpenter-resources)
+    - bootstrap/platform-root/templates/metrics-server.yaml
+
+  Output: a `components:` block ready to nest under valuesObject.
+*/ -}}
+{{- define "platform-root.componentsForwarding" -}}
+{{- $awsOnly := list "aws-load-balancer-controller" "karpenter" "karpenter-resources" "metrics-server" -}}
+components:
+  {{- range $k, $v := .Values.components }}
+  {{- if and (has $k $awsOnly) (ne $.Values.global.provider "aws") }}
+  {{- /* skip AWS-only component on non-AWS provider — namespace doesn't exist */ -}}
+  {{- else }}
+  {{ $k | quote }}: {{ $v }}
+  {{- end }}
+  {{- end }}
+{{- end -}}

--- a/bootstrap/platform-root/templates/network-policies.yaml
+++ b/bootstrap/platform-root/templates/network-policies.yaml
@@ -24,12 +24,16 @@ spec:
               NetworkPolicies for namespaces whose component is actually
               deployed. Without this, disabled components (opencost=false,
               traefik=false, etc.) still produce NPs targeting their
-              non-existent namespaces and the App stays OutOfSync. */}}
+              non-existent namespaces and the App stays OutOfSync.
+
+              AWS-only entries (aws-load-balancer-controller, karpenter,
+              karpenter-resources, metrics-server) are dropped from the
+              forwarded map when global.provider != "aws" — the Apps
+              themselves are gated on provider, so the namespaces never
+              come into existence on Azure. See
+              `platform-root.componentsForwarding` in _helpers.tpl. */}}
         valuesObject:
-          components:
-            {{- range $k, $v := .Values.components }}
-            {{ $k | quote }}: {{ $v }}
-            {{- end }}
+          {{- include "platform-root.componentsForwarding" . | nindent 10 }}
         parameters:
           {{- include "platform-root.provenanceParameters" $ | nindent 10 }}
     - repoURL: {{ .Values.platformGitopsRepoUrl }}

--- a/bootstrap/platform-root/templates/resource-quotas.yaml
+++ b/bootstrap/platform-root/templates/resource-quotas.yaml
@@ -24,12 +24,16 @@ spec:
               actually deployed. Without this, disabled components
               (opencost=false, traefik=false, etc.) still produce quotas
               targeting their non-existent namespaces and the App stays
-              OutOfSync. */}}
+              OutOfSync.
+
+              AWS-only entries (aws-load-balancer-controller, karpenter,
+              karpenter-resources, metrics-server) are dropped from the
+              forwarded map when global.provider != "aws" — the Apps
+              themselves are gated on provider, so the namespaces never
+              come into existence on Azure. See
+              `platform-root.componentsForwarding` in _helpers.tpl. */}}
         valuesObject:
-          components:
-            {{- range $k, $v := .Values.components }}
-            {{ $k | quote }}: {{ $v }}
-            {{- end }}
+          {{- include "platform-root.componentsForwarding" . | nindent 10 }}
         parameters:
           {{- include "platform-root.provenanceParameters" $ | nindent 10 }}
     - repoURL: {{ .Values.platformGitopsRepoUrl }}

--- a/bootstrap/platform-root/values.yaml
+++ b/bootstrap/platform-root/values.yaml
@@ -38,7 +38,7 @@ configRepoVersion: ""       # DEPRECATED: use configRepoRevision
 # See ADR 0001 (estabilis-platform-tools/docs/adr/0001-workload-bootstrap-strategy.md).
 # Default values below; downstream can override via overrides/platform-root/values.yaml.
 platformGitopsRepoUrl: "https://github.com/Estabilis/estabilis-platform-gitops.git"
-platformGitopsVersion: "v0.33.0"
+platformGitopsVersion: "v0.37.0"
 
 global:
   # Provenance — injected at runtime by the CLI (see block above).


### PR DESCRIPTION
## Summary

The `network-policies` and `resource-quotas` Application templates (introduced in v0.26.0 to fix phantom drift on disabled components) forward `.Values.components` verbatim to the gitops-side child charts. This is correct for components active on either provider but creates latent drift on Azure for **AWS-only** components: `aws-load-balancer-controller`, `karpenter`, `karpenter-resources`, `metrics-server`.

The Application templates that install these components are already gated on `global.provider == "aws"`, so the namespaces never come into existence on Azure. But the `components.{ns}: true` defaults in `bootstrap/platform-root/values.yaml` still propagated to the gitops charts. With the gitops chart in `estabilis-platform-gitops v0.37.0` (paired) starting to declare coverage for ALB / karpenter, the unfiltered forwarding would render `NetworkPolicy` and `ResourceQuota` for non-existent namespaces on Azure → permanent OutOfSync.

## Fix

New helper `platform-root.componentsForwarding` in `bootstrap/platform-root/templates/_helpers.tpl`:

```yaml
{{- $awsOnly := list "aws-load-balancer-controller" "karpenter" "karpenter-resources" "metrics-server" -}}
components:
  {{- range $k, $v := .Values.components }}
  {{- if and (has $k $awsOnly) (ne $.Values.global.provider "aws") }}
  {{- /* skip AWS-only on non-AWS provider */ -}}
  {{- else }}
  {{ $k | quote }}: {{ $v }}
  {{- end }}
  {{- end }}
{{- end -}}
```

Both `network-policies.yaml` and `resource-quotas.yaml` now `include` the helper instead of inlining the previous forward-everything range loop.

The AWS-only set in the helper is hardcoded — must stay synchronized with the `global.provider == "aws"` gating clauses in the corresponding Application templates (`aws-load-balancer-controller.yaml`, `karpenter.yaml`, `metrics-server.yaml`).

## Bumped — `platformGitopsVersion: v0.33.0 → v0.37.0`

`estabilis-platform-gitops v0.37.0` lands the corresponding ALB + karpenter coverage in `components/network-policies` and `components/resource-quotas`. The two releases pair: this PR adds the provider filter, the gitops PR adds the new policies/quotas. **Either alone is correct (no regression); both together close the gap fully.**

## Pairing matrix

| platform | gitops | AWS outcome | Azure outcome |
|---|---|---|---|
| v0.26.x | v0.36.1 (current) | gap stays | gap stays |
| v0.26.x | v0.37.0 (gitops PR) | new policies render | new policies render for non-existent ns → drift unless override |
| **v0.27.0 (this)** | v0.36.1 | provider filter active but no new ALB/karpenter coverage in chart | filter is no-op (no AWS-only key currently forwarded) |
| **v0.27.0** | **v0.37.0** | new policies render correctly | filter blocks forwarding → namespaces stay default-false → no rendering ✅ |

## Test plan

- [x] Helper renders correctly via `helm template` against the AWS provider on cortex (verifies components map unchanged)
- [ ] After v0.27.0 merge + tag + cortex bump, `kubectl -n aws-load-balancer-controller get networkpolicy,resourcequota` shows the new resources from gitops v0.37.0
- [ ] On a separate Azure HML deployment (Estabilis HML), `helm template` of `network-policies.yaml` / `resource-quotas.yaml` Applications shows the AWS-only keys filtered out of valuesObject.components
- [ ] No regression on existing components (cert-manager, external-secrets, etc.) — same forwarded values

## Migration

For all v0.26.x clusters:
1. Bump `ref=` and `platform_revision` to `v0.27.0` in client `providers/<cloud>/main.tf` + `terraform.tfvars`
2. `terraform init -upgrade && terraform apply`
3. `estabilis promote <client> -d <deployment> --force-refresh` (re-renders the `network-policies` and `resource-quotas` Applications with the filtered components map)