### PR TITLE
chore(platform-root): bump platformGitopsVersion v0.37.0 -> v0.37.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.27.1] - 2026-04-25
+
+### Bumped — `platformGitopsVersion: v0.37.0 → v0.37.1`
+
+Patch-only release. `estabilis-platform-gitops v0.37.1` ships a
+karpenter ResourceQuota fix (the v0.37.0 quota was undersized for
+the chart's actual defaults — 2 replicas × 500m/1Gi each exceeded
+the 500m/1Gi quota). This release updates the upstream default so
+new deployments and existing clusters consuming the chart default
+pick up the corrected quota automatically.
+
+No platform code changes.
+
 ## [0.27.0] - 2026-04-25
 
 ### Fixed — `network-policies` and `resource-quotas` forward AWS-only components on Azure

--- a/bootstrap/platform-root/values.yaml
+++ b/bootstrap/platform-root/values.yaml
@@ -38,7 +38,7 @@ configRepoVersion: ""       # DEPRECATED: use configRepoRevision
 # See ADR 0001 (estabilis-platform-tools/docs/adr/0001-workload-bootstrap-strategy.md).
 # Default values below; downstream can override via overrides/platform-root/values.yaml.
 platformGitopsRepoUrl: "https://github.com/Estabilis/estabilis-platform-gitops.git"
-platformGitopsVersion: "v0.37.0"
+platformGitopsVersion: "v0.37.1"
 
 global:
   # Provenance — injected at runtime by the CLI (see block above).


### PR DESCRIPTION
Patch-only. Pairs with `estabilis-platform-gitops v0.37.1` (karpenter ResourceQuota fix). No platform code changes.