### PR TITLE
chore(platform-root): bump platformGitopsVersion v0.37.1 -> v0.37.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.27.2] - 2026-04-25
+
+### Bumped — `platformGitopsVersion: v0.37.1 → v0.37.2`
+
+Patch-only release. `estabilis-platform-gitops v0.37.2` adds
+`metrics-server` namespace to the three policy/quota coverage layers
+(same pattern as ALB/karpenter in v0.37.0). The `awsOnly` list in
+`platform-root.componentsForwarding` (introduced v0.27.0) already
+covers `metrics-server`, so no platform code change is needed beyond
+the upstream default bump.
+
+No platform code changes.
+
 ## [0.27.1] - 2026-04-25
 
 ### Bumped — `platformGitopsVersion: v0.37.0 → v0.37.1`

--- a/bootstrap/platform-root/values.yaml
+++ b/bootstrap/platform-root/values.yaml
@@ -38,7 +38,7 @@ configRepoVersion: ""       # DEPRECATED: use configRepoRevision
 # See ADR 0001 (estabilis-platform-tools/docs/adr/0001-workload-bootstrap-strategy.md).
 # Default values below; downstream can override via overrides/platform-root/values.yaml.
 platformGitopsRepoUrl: "https://github.com/Estabilis/estabilis-platform-gitops.git"
-platformGitopsVersion: "v0.37.1"
+platformGitopsVersion: "v0.37.2"
 
 global:
   # Provenance — injected at runtime by the CLI (see block above).


### PR DESCRIPTION
Patch-only. Pairs with `estabilis-platform-gitops v0.37.2` (metrics-server namespace coverage). No platform code changes.