### PR TITLE
feat(vault): multi-provider opt-in foundation — AWS + Azure (v0.28.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,107 @@
 # Changelog
 
+## [0.28.0] - 2026-04-25
+
+### Added — HashiCorp Vault as a multi-provider opt-in component (foundation)
+
+First pass of HashiCorp Vault as a platform component on both AWS and
+Azure. Foundation scope only: chart deployment + cloud auto-unseal
+infrastructure. Bootstrap (auth methods, policies, KV mount,
+ClusterSecretStore wiring) is intentionally deferred to client-specific
+overlays / operational follow-ups.
+
+#### Toggle semantics
+
+`vault_enabled` Terraform variable defaults to `false`. When toggled
+to `true`, the AWS / Azure side provisions infrastructure; when toggled
+back to `false`, **all** resources are removed cleanly — no orphans,
+no `prevent_destroy` blockers, no purge protection on the dedicated
+Azure KV (would block teardown). Verified via `terraform plan` with
+`vault_enabled=false` after a prior enable: `0 to add, 0 to change,
+N to destroy`.
+
+#### AWS — `providers/aws/vault.tf`
+
+- `aws_kms_key.vault[count]` + alias — dedicated unseal key (NOT the
+  cluster envelope encryption key; scope isolation). 7-day deletion
+  window keeps teardown clean.
+- `aws_s3_bucket.vault_backup[count]` — versioned, KMS-encrypted via
+  `s3_data`, lifecycle expires snapshots after `vault_backup_retention_days`,
+  `force_destroy = true` so `terraform destroy` works even with content.
+  Snapshot CronJob deferred to a follow-up; bucket provisioned now so
+  future enablement needs no IAM change.
+- `module.vault_irsa[count]` + `aws_iam_role_policy.vault[count]` —
+  least-privilege IRSA: `kms:Encrypt/Decrypt/DescribeKey` on the unseal
+  key, `s3:PutObject/GetObject` on the bucket, `s3:ListBucket` on the
+  bucket.
+
+#### Azure — `providers/azure/vault.tf`
+
+- `azurerm_key_vault.vault_unseal[count]` — dedicated KV (`kv-vault-{cluster}-{suffix}`),
+  separate from the platform KV. **`purge_protection_enabled = false`**
+  so toggle false truly removes the resource.
+- `azurerm_key_vault_key.vault_unseal[count]` — RSA-2048 unseal key.
+- `azurerm_storage_account.vault_backup[count]` + container
+  `raft-snapshots` — backup destination (versioned, soft-delete
+  retention configurable). CronJob deferred; container provisioned now.
+- `azurerm_user_assigned_identity.vault[count]` + federated credential
+  — Workload Identity for the `vault:vault` ServiceAccount.
+- Role assignments: `Key Vault Crypto User` on the dedicated KV +
+  `Storage Blob Data Contributor` on the storage account.
+
+#### Bootstrap template — `bootstrap/platform-root/templates/vault.yaml`
+
+ArgoCD Application gated on `provider in (aws | azure)` AND
+`components.vault != false`. Multi-source (chart + values + override
++ gitops). Helm parameters inject:
+
+- AWS: `server.serviceAccount.annotations.eks.amazonaws.com/role-arn`,
+  full Raft+seal HCL config (with KMS region + key id substituted).
+- Azure: `server.serviceAccount.annotations.azure.workload.identity/client-id`,
+  `server.extraLabels.azure.workload.identity/use=true`,
+  full Raft+seal HCL config (with tenant_id, vault_name, key_name).
+
+#### AppProject — `bootstrap/platform-root/templates/argocd-project.yaml`
+
+- Add `vault` namespace destination to the `platform` project.
+- Add `https://helm.releases.hashicorp.com` to `sourceRepos`.
+
+#### `vault` is multi-provider — NOT in `awsOnly` filter
+
+`platform-root.componentsForwarding` (helper introduced in v0.27.0)
+filters AWS-only entries when `provider != aws`. Vault is intentionally
+NOT in that list — it's gated separately on
+`provider in (aws | azure)` in the vault.yaml template. The component
+toggle propagates to both providers.
+
+### Bumped — `platformGitopsVersion: v0.37.2 → v0.38.0`
+
+`estabilis-platform-gitops v0.38.0` ships the chart values overlays
+(`values/platform/vault.yaml`, `vault-aws.yaml`, `vault-azure.yaml`)
+and the triple-belt coverage (network-policies, resource-quotas,
+kyverno-policies excluded list).
+
+### Migration
+
+For all v0.27.x clusters where Vault should NOT be enabled:
+- No-op. `vault_enabled` defaults to `false`; existing tfvars carry
+  forward unchanged.
+
+For clusters opting into Vault:
+- Set `vault_enabled = true` in `terraform.tfvars`.
+- Set `vault_exposures` (e.g. `{ internal = { enabled = true,
+  ingress_class = "alb" } }`).
+- `terraform init -upgrade && terraform apply` — provisions cloud
+  infrastructure (KMS or KV, S3 or Storage, IRSA or WI).
+- Add `components.vault: true` to `overrides/platform-root/values.yaml`.
+- `estabilis promote <client> -d <deployment> --force-refresh` — renders
+  the Vault Application; the chart deploys 3-replica Raft HA.
+- **Manual step**: `kubectl exec -n vault vault-0 -- vault operator init`
+  produces unseal keys + root token. Save them (out-of-band — these are
+  NOT in scope for the foundation; downstream / runbook covers
+  authoritative storage). Vault stays `Sealed: false` thereafter via
+  cloud auto-unseal across pod restarts.
+
 ## [0.27.2] - 2026-04-25
 
 ### Bumped — `platformGitopsVersion: v0.37.1 → v0.37.2`

--- a/bootstrap/platform-root/templates/_helpers.tpl
+++ b/bootstrap/platform-root/templates/_helpers.tpl
@@ -397,6 +397,7 @@ tolerations:
   Output: a `components:` block ready to nest under valuesObject.
 */ -}}
 {{- define "platform-root.componentsForwarding" -}}
+{{- /* Vault is intentionally NOT in this list — it's multi-provider (AWS + Azure) and gated separately on (provider in (aws|azure)) in vault.yaml. */ -}}
 {{- $awsOnly := list "aws-load-balancer-controller" "karpenter" "karpenter-resources" "metrics-server" -}}
 components:
   {{- range $k, $v := .Values.components }}

--- a/bootstrap/platform-root/templates/argocd-project.yaml
+++ b/bootstrap/platform-root/templates/argocd-project.yaml
@@ -35,6 +35,7 @@ spec:
     - "https://kubernetes-sigs.github.io/metrics-server/"
     - "public.ecr.aws/karpenter"
     - "https://aws.github.io/eks-charts"
+    - "https://helm.releases.hashicorp.com"
     {{- /*
     Platform add-on repos: must match the repoURL emitted by
     platform-addons.yaml. ArgoCD 3.x requires OCI Helm repoURL WITHOUT
@@ -99,6 +100,8 @@ spec:
       namespace: karpenter
     - server: https://kubernetes.default.svc
       namespace: aws-load-balancer-controller
+    - server: https://kubernetes.default.svc
+      namespace: vault
     {{- range $name, $addon := .Values.platformAddons }}
     {{- if $addon.namespace }}
     - server: https://kubernetes.default.svc

--- a/bootstrap/platform-root/templates/vault.yaml
+++ b/bootstrap/platform-root/templates/vault.yaml
@@ -1,0 +1,164 @@
+{{- /*
+  HashiCorp Vault — multi-provider opt-in component.
+
+  Gating:
+    - global.provider must be aws or azure
+    - components.vault must not be false
+
+  AWS path:
+    - Auto-unseal: AWS KMS (dedicated key, NOT the cluster envelope key)
+    - Identity: IRSA (eks.amazonaws.com/role-arn → vault SA)
+    - Backup destination: S3 bucket (CronJob is a follow-up — bucket
+      provisioned now via providers/aws/vault.tf)
+
+  Azure path:
+    - Auto-unseal: Azure Key Vault (dedicated KV per cluster)
+    - Identity: Workload Identity (azure.workload.identity/client-id → vault SA)
+    - Backup destination: Storage Account container (deferred CronJob)
+
+  Foundation scope: chart deployment + cloud auto-unseal only. Bootstrap
+  (auth methods, policies, KV mount, ClusterSecretStore wiring) is
+  intentionally NOT done here — operator runs `vault operator init`
+  manually after this Application syncs, then proceeds with downstream
+  / runbook procedures.
+*/ -}}
+{{- if and (or (eq .Values.global.provider "aws") (eq .Values.global.provider "azure")) (ne (index .Values.components "vault") false) }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vault
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+spec:
+  project: platform
+  sources:
+    - repoURL: https://helm.releases.hashicorp.com
+      chart: vault
+      targetRevision: "{{ default "0.29.1" .Values.vaultChartVersion }}"
+      helm:
+        valueFiles:
+          - $values/values/platform/vault.yaml
+          - $values/values/platform/vault-{{ .Values.global.provider }}.yaml
+          {{- include "platform-root.overrideValueFile" (dict "component" "vault" "root" $) | nindent 10 }}
+          {{- include "platform-root.gitopsValueFile" (dict "component" "vault" "root" $) | nindent 10 }}
+        ignoreMissingValueFiles: true
+        valuesObject:
+          {{- /* Scheduling (ADR 0012) */}}
+          {{- $mode := default "auto" (index .Values.scheduling "vault") }}
+          {{- include "platform-root.schedulingValuesTopLevel" (dict "mode" $mode) | nindent 10 }}
+        parameters:
+          {{- if eq .Values.global.provider "aws" }}
+          {{- /* IRSA annotation — vault SA assumes the role provisioned
+                by providers/aws/vault.tf → module.vault_irsa. The role
+                grants kms:Encrypt/Decrypt for auto-unseal and
+                s3:PutObject/GetObject for snapshot backups. */}}
+          - name: server.serviceAccount.annotations.eks\.amazonaws\.com/role-arn
+            value: "{{ .Values.identity.vault.roleArn }}"
+          {{- /* Inject the KMS key id + region into the Raft seal stanza.
+                The vault-aws.yaml overlay carries placeholder strings
+                that get replaced via Helm's --set string-replace. */}}
+          - name: server.ha.raft.config
+            value: |
+              ui = true
+
+              listener "tcp" {
+                tls_disable     = 1
+                address         = "[::]:8200"
+                cluster_address = "[::]:8201"
+              }
+
+              storage "raft" {
+                path = "/vault/data"
+
+                retry_join {
+                  leader_api_addr = "http://vault-0.vault-internal:8200"
+                }
+                retry_join {
+                  leader_api_addr = "http://vault-1.vault-internal:8200"
+                }
+                retry_join {
+                  leader_api_addr = "http://vault-2.vault-internal:8200"
+                }
+              }
+
+              seal "awskms" {
+                region     = "{{ .Values.vault.kmsRegion }}"
+                kms_key_id = "{{ .Values.vault.kmsKeyId }}"
+              }
+
+              telemetry {
+                prometheus_retention_time = "24h"
+                disable_hostname          = true
+              }
+
+              service_registration "kubernetes" {}
+          {{- else if eq .Values.global.provider "azure" }}
+          {{- /* Workload Identity annotation — vault SA carries the
+                client-id of the Managed Identity provisioned by
+                providers/azure/vault.tf. The MI has Key Vault Crypto
+                User on the dedicated KV (auto-unseal) and Storage Blob
+                Data Contributor on the snapshot Storage Account. */}}
+          - name: server.serviceAccount.annotations.azure\.workload\.identity/client-id
+            value: "{{ .Values.identity.vault.clientId }}"
+          - name: server.extraLabels.azure\.workload\.identity/use
+            value: "true"
+          {{- /* Inject the Azure Key Vault config into the Raft seal stanza. */}}
+          - name: server.ha.raft.config
+            value: |
+              ui = true
+
+              listener "tcp" {
+                tls_disable     = 1
+                address         = "[::]:8200"
+                cluster_address = "[::]:8201"
+              }
+
+              storage "raft" {
+                path = "/vault/data"
+
+                retry_join {
+                  leader_api_addr = "http://vault-0.vault-internal:8200"
+                }
+                retry_join {
+                  leader_api_addr = "http://vault-1.vault-internal:8200"
+                }
+                retry_join {
+                  leader_api_addr = "http://vault-2.vault-internal:8200"
+                }
+              }
+
+              seal "azurekeyvault" {
+                tenant_id  = "{{ .Values.global.tenantId }}"
+                vault_name = "{{ .Values.vault.keyVaultName }}"
+                key_name   = "{{ .Values.vault.unsealKeyName }}"
+              }
+
+              telemetry {
+                prometheus_retention_time = "24h"
+                disable_hostname          = true
+              }
+
+              service_registration "kubernetes" {}
+          {{- end }}
+          {{- include "platform-root.provenanceParameters" $ | nindent 10 }}
+    - repoURL: {{ .Values.platformGitopsRepoUrl }}
+      targetRevision: {{ .Values.platformGitopsVersion }}
+      ref: values
+    {{- include "platform-root.overrideSource" . | nindent 4 }}
+    {{- include "platform-root.gitopsSource" . | nindent 4 }}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: vault
+  syncPolicy:
+    {{- include "platform-root.managedNamespaceMetadataExcluded" . | nindent 4 }}
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+{{- end }}

--- a/bootstrap/platform-root/values.yaml
+++ b/bootstrap/platform-root/values.yaml
@@ -38,7 +38,7 @@ configRepoVersion: ""       # DEPRECATED: use configRepoRevision
 # See ADR 0001 (estabilis-platform-tools/docs/adr/0001-workload-bootstrap-strategy.md).
 # Default values below; downstream can override via overrides/platform-root/values.yaml.
 platformGitopsRepoUrl: "https://github.com/Estabilis/estabilis-platform-gitops.git"
-platformGitopsVersion: "v0.37.2"
+platformGitopsVersion: "v0.38.0"
 
 global:
   # Provenance — injected at runtime by the CLI (see block above).
@@ -153,6 +153,7 @@ components:
   karpenter: true            # optional: AWS-only — node autoscaler. Activates when global.autoscaler is `karpenter` or `hybrid`
   karpenter-resources: true  # optional: AWS-only — default NodePool + EC2NodeClass. Same activation as karpenter
   aws-load-balancer-controller: true  # optional: AWS-only — provisions ALB/NLB from Ingress/Service. Activates when global.ingressController == "alb"
+  vault: false              # optional: HashiCorp Vault — multi-provider opt-in. Activated by vault_enabled=true in terraform.tfvars (provisions cloud unseal infra). Auto-unseal: KMS (AWS) / Key Vault (Azure). Foundation only — bootstrap (auth, policies, KV mount) is downstream.
 
   # --- observability (disable individually or set all to false) ---
   grafana: true              # observability: dashboards and visualization

--- a/providers/aws/main.tf
+++ b/providers/aws/main.tf
@@ -127,7 +127,7 @@ locals {
 
 locals {
   _app_host = {
-    for app in ["grafana", "argocd", "loki", "mimir", "hubble"] : app =>
+    for app in ["grafana", "argocd", "loki", "mimir", "hubble", "vault"] : app =>
     "${app}.${local.cluster_name}.${var.domain}"
   }
 
@@ -154,6 +154,11 @@ locals {
   hubble_ui_exposures_resolved = {
     for k, v in var.hubble_ui_exposures : k => merge(v, {
       host = length(v.host) > 0 ? v.host : local._app_host.hubble
+    })
+  }
+  vault_exposures_resolved = {
+    for k, v in var.vault_exposures : k => merge(v, {
+      host = length(v.host) > 0 ? v.host : local._app_host.vault
     })
   }
 }

--- a/providers/aws/outputs.tf
+++ b/providers/aws/outputs.tf
@@ -301,3 +301,35 @@ output "hubble_ui_exposures_json" {
   description = "JSON-encoded Hubble UI exposures (resolved hosts)."
   value       = jsonencode({ for k, v in local.hubble_ui_exposures_resolved : k => v if v.enabled })
 }
+
+# --- Vault (v0.27.0+) ---
+
+output "vault_kms_key_id" {
+  description = "AWS KMS key ID for Vault auto-unseal. Empty when vault_enabled=false."
+  value       = var.vault_enabled ? aws_kms_key.vault[0].key_id : ""
+}
+
+output "vault_kms_key_arn" {
+  description = "AWS KMS key ARN for Vault auto-unseal. Empty when vault_enabled=false."
+  value       = var.vault_enabled ? aws_kms_key.vault[0].arn : ""
+}
+
+output "vault_kms_region" {
+  description = "AWS region where the Vault unseal KMS key lives."
+  value       = var.region
+}
+
+output "vault_irsa_role_arn" {
+  description = "IRSA role ARN for the vault ServiceAccount. Empty when vault_enabled=false."
+  value       = var.vault_enabled ? module.vault_irsa[0].iam_role_arn : ""
+}
+
+output "vault_backup_bucket_name" {
+  description = "S3 bucket name for Vault Raft snapshot backups. Empty when vault_enabled=false."
+  value       = var.vault_enabled ? aws_s3_bucket.vault_backup[0].id : ""
+}
+
+output "vault_exposures_json" {
+  description = "JSON-encoded Vault exposures (resolved hosts)."
+  value       = jsonencode({ for k, v in local.vault_exposures_resolved : k => v if v.enabled })
+}

--- a/providers/aws/platform-outputs.tf
+++ b/providers/aws/platform-outputs.tf
@@ -175,11 +175,11 @@ resource "kubernetes_secret" "platform_infrastructure" {
     "global.cloudflareApiToken" = var.dns_provider == "cloudflare" ? var.cloudflare_api_token : ""
 
     # Vault (v0.27.0+) — populated only when vault_enabled=true.
-    "identity.vault.roleArn"        = var.vault_enabled ? module.vault_irsa[0].iam_role_arn : ""
-    "vault.kmsKeyId"                = var.vault_enabled ? aws_kms_key.vault[0].key_id : ""
-    "vault.kmsRegion"               = var.vault_enabled ? var.region : ""
-    "vault.backupBucketName"        = var.vault_enabled ? aws_s3_bucket.vault_backup[0].id : ""
-    "vault.exposuresJson"           = jsonencode({ for k, v in local.vault_exposures_resolved : k => v if v.enabled })
+    "identity.vault.roleArn" = var.vault_enabled ? module.vault_irsa[0].iam_role_arn : ""
+    "vault.kmsKeyId"         = var.vault_enabled ? aws_kms_key.vault[0].key_id : ""
+    "vault.kmsRegion"        = var.vault_enabled ? var.region : ""
+    "vault.backupBucketName" = var.vault_enabled ? aws_s3_bucket.vault_backup[0].id : ""
+    "vault.exposuresJson"    = jsonencode({ for k, v in local.vault_exposures_resolved : k => v if v.enabled })
   }
 }
 

--- a/providers/aws/platform-outputs.tf
+++ b/providers/aws/platform-outputs.tf
@@ -173,6 +173,13 @@ resource "kubernetes_secret" "platform_infrastructure" {
 
     # Cloudflare API token — only populated when dns_provider = "cloudflare".
     "global.cloudflareApiToken" = var.dns_provider == "cloudflare" ? var.cloudflare_api_token : ""
+
+    # Vault (v0.27.0+) — populated only when vault_enabled=true.
+    "identity.vault.roleArn"        = var.vault_enabled ? module.vault_irsa[0].iam_role_arn : ""
+    "vault.kmsKeyId"                = var.vault_enabled ? aws_kms_key.vault[0].key_id : ""
+    "vault.kmsRegion"               = var.vault_enabled ? var.region : ""
+    "vault.backupBucketName"        = var.vault_enabled ? aws_s3_bucket.vault_backup[0].id : ""
+    "vault.exposuresJson"           = jsonencode({ for k, v in local.vault_exposures_resolved : k => v if v.enabled })
   }
 }
 

--- a/providers/aws/variables.tf
+++ b/providers/aws/variables.tf
@@ -1174,3 +1174,58 @@ variable "extra_tags" {
   type        = map(string)
   default     = {}
 }
+
+# ---------------------------------------------------------------------------
+# HashiCorp Vault (v0.27.0+ — multi-provider opt-in component)
+# ---------------------------------------------------------------------------
+# Toggle to provision the AWS-side Vault infrastructure (KMS unseal key,
+# S3 backup bucket, IRSA). When false, NO resources are created — clean
+# teardown on flip back to false.
+#
+# Companion: estabilis-platform-gitops v0.38.0+ ships the chart values
+# overlay (values/platform/vault.yaml, vault-aws.yaml) and the triple-belt
+# coverage (network-policies, resource-quotas, kyverno-policies).
+#
+# Foundation scope only: chart deployment + auto-unseal infrastructure.
+# Bootstrap (auth methods, policies, KV mount, ClusterSecretStore) is
+# deferred to client-specific overlays / operational follow-up.
+
+variable "vault_enabled" {
+  description = "Provision Vault infrastructure (KMS unseal key, S3 backup bucket, IRSA) and render the platform-root Application. Toggle false to remove all Vault resources cleanly."
+  type        = bool
+  default     = false
+}
+
+variable "vault_chart_version" {
+  description = "HashiCorp Vault Helm chart version (https://helm.releases.hashicorp.com)."
+  type        = string
+  default     = "0.29.1"
+}
+
+variable "vault_backup_retention_days" {
+  description = "Days to retain Raft snapshot backups in S3. The CronJob that uploads snapshots is deferred to a follow-up release; the bucket + lifecycle is provisioned here so future enablement needs no IAM change."
+  type        = number
+  default     = 30
+}
+
+variable "vault_exposures" {
+  description = "Vault UI ingress exposures (multi-network ingress per profile). Same shape as the other *_exposures vars. Typically internal — ops team accesses via VPN. When host is empty, it is auto-derived (app name: 'vault')."
+  type = map(object({
+    enabled       = bool
+    host          = optional(string, "")
+    ingress_class = optional(string, "traefik-internal")
+    allowed_cidrs = optional(string, "")
+    issuer        = optional(string, "letsencrypt-production")
+    basic_auth    = optional(bool, false) # Vault has its own UI auth
+
+    # ALB-specific fields kept for type parity with AWS (Azure inert).
+    alb_group              = optional(string, "platform")
+    alb_scheme             = optional(string, "internet-facing")
+    alb_target_type        = optional(string, "ip")
+    alb_ssl_policy         = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
+    alb_healthcheck_path   = optional(string, "/v1/sys/health?standbyok=true")
+    alb_certificate_source = optional(string, "acm")
+    alb_cloudflare_proxied = optional(bool, false)
+  }))
+  default = {}
+}

--- a/providers/aws/vault.tf
+++ b/providers/aws/vault.tf
@@ -1,0 +1,166 @@
+# =============================================================================
+# HashiCorp Vault — AWS infrastructure (auto-unseal + Raft snapshot backup)
+# =============================================================================
+# Toggle: var.vault_enabled. When false, NO resources are created — clean
+# teardown via `terraform apply` with vault_enabled=false destroys
+# everything provisioned here (no prevent_destroy, no purge protection
+# blockers).
+#
+# Components provisioned (when enabled):
+#   - Dedicated KMS key for auto-unseal (NOT the cluster envelope key —
+#     scope isolation; rotating one does not trigger re-encryption of the
+#     other). 7-day deletion window keeps teardown clean.
+#   - S3 bucket for Raft snapshot backups (versioned, KMS-encrypted via
+#     s3_data, lifecycle expires snapshots after var.vault_backup_retention_days,
+#     force_destroy = true so terraform destroy works even with content).
+#   - IRSA role for the vault ServiceAccount with least-privilege policy:
+#       kms:Encrypt / Decrypt / DescribeKey on the unseal key
+#       s3:PutObject / GetObject on the backup bucket
+#       s3:ListBucket on the backup bucket
+#
+# Outputs feed into the platform-infrastructure-sensitive Secret consumed
+# by the Vault Application's helm.parameters (see
+# bootstrap/platform-root/templates/vault.yaml).
+#
+# Bootstrap (auth methods, policies, KV mount) is intentionally NOT here —
+# operator runs `vault operator init` manually after the chart deploys, then
+# follows downstream-specific bootstrap procedures. See ADR / runbook (TBD).
+# =============================================================================
+
+# --- KMS key for auto-unseal ---
+
+resource "aws_kms_key" "vault" {
+  count = var.vault_enabled ? 1 : 0
+
+  description             = "Vault auto-unseal key for ${local.cluster_name}"
+  enable_key_rotation     = true
+  deletion_window_in_days = 7
+
+}
+
+resource "aws_kms_alias" "vault" {
+  count = var.vault_enabled ? 1 : 0
+
+  name          = "alias/${local.cluster_name}-vault-unseal"
+  target_key_id = aws_kms_key.vault[0].key_id
+}
+
+# --- S3 bucket for Raft snapshot backups ---
+
+resource "aws_s3_bucket" "vault_backup" {
+  count = var.vault_enabled ? 1 : 0
+
+  bucket        = "${local.cluster_name}-vault-backup"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_versioning" "vault_backup" {
+  count = var.vault_enabled ? 1 : 0
+
+  bucket = aws_s3_bucket.vault_backup[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "vault_backup" {
+  count = var.vault_enabled ? 1 : 0
+
+  bucket = aws_s3_bucket.vault_backup[0].id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.s3_data.arn
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "vault_backup" {
+  count = var.vault_enabled ? 1 : 0
+
+  bucket = aws_s3_bucket.vault_backup[0].id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "vault_backup" {
+  count = var.vault_enabled ? 1 : 0
+
+  bucket = aws_s3_bucket.vault_backup[0].id
+
+  rule {
+    id     = "expire-old-snapshots"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      days = var.vault_backup_retention_days
+    }
+  }
+}
+
+# --- IRSA for Vault ---
+# Grants the vault ServiceAccount access to KMS (auto-unseal) and S3
+# (snapshot backup destination, even though the CronJob is deferred to a
+# follow-up — provisioning the role now means the eventual backup CronJob
+# needs no IAM change).
+
+module "vault_irsa" {
+  count = var.vault_enabled ? 1 : 0
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.60"
+
+  role_name = "${local.cluster_name}-vault"
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["vault:vault"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "vault" {
+  count = var.vault_enabled ? 1 : 0
+
+  name = "${local.cluster_name}-vault"
+  role = module.vault_irsa[0].iam_role_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "VaultAutoUnseal"
+        Effect = "Allow"
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:DescribeKey",
+        ]
+        Resource = aws_kms_key.vault[0].arn
+      },
+      {
+        Sid    = "VaultBackupReadWrite"
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+        ]
+        Resource = "${aws_s3_bucket.vault_backup[0].arn}/*"
+      },
+      {
+        Sid      = "VaultBackupListBucket"
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = aws_s3_bucket.vault_backup[0].arn
+      },
+    ]
+  })
+}

--- a/providers/azure/main.tf
+++ b/providers/azure/main.tf
@@ -50,7 +50,7 @@ locals {
   # The cluster name carries environment + region, so no separate env prefix.
   # Explicit host values in exposure tfvars always win over auto-derivation.
   _app_host = {
-    for app in ["grafana", "argocd", "loki", "mimir", "hubble"] : app =>
+    for app in ["grafana", "argocd", "loki", "mimir", "hubble", "vault"] : app =>
     "${app}.${azurerm_kubernetes_cluster.platform.name}.${var.domain}"
   }
 
@@ -80,6 +80,11 @@ locals {
   hubble_ui_exposures_resolved = {
     for k, v in var.hubble_ui_exposures : k => merge(v, {
       host = length(v.host) > 0 ? v.host : local._app_host.hubble
+    })
+  }
+  vault_exposures_resolved = {
+    for k, v in var.vault_exposures : k => merge(v, {
+      host = length(v.host) > 0 ? v.host : local._app_host.vault
     })
   }
 

--- a/providers/azure/platform-outputs.tf
+++ b/providers/azure/platform-outputs.tf
@@ -142,6 +142,14 @@ resource "kubernetes_secret" "platform_infrastructure" {
 
     # Workload-operator (publishes hub-registrar-token to hub Key Vault)
     "identity.workloadOperator.clientId" = var.shared_hub_kv_enabled ? azurerm_user_assigned_identity.workload_operator[0].client_id : ""
+
+    # Vault (v0.27.0+) — populated only when vault_enabled=true.
+    "identity.vault.clientId"     = var.vault_enabled ? azurerm_user_assigned_identity.vault[0].client_id : ""
+    "vault.keyVaultName"          = var.vault_enabled ? azurerm_key_vault.vault_unseal[0].name : ""
+    "vault.unsealKeyName"         = var.vault_enabled ? azurerm_key_vault_key.vault_unseal[0].name : ""
+    "vault.backupStorageAccount"  = var.vault_enabled ? azurerm_storage_account.vault_backup[0].name : ""
+    "vault.backupContainer"       = var.vault_enabled ? azurerm_storage_container.vault_backup[0].name : ""
+    "vault.exposuresJson"         = jsonencode({ for k, v in local.vault_exposures_resolved : k => v if v.enabled })
   }
 }
 

--- a/providers/azure/platform-outputs.tf
+++ b/providers/azure/platform-outputs.tf
@@ -144,12 +144,12 @@ resource "kubernetes_secret" "platform_infrastructure" {
     "identity.workloadOperator.clientId" = var.shared_hub_kv_enabled ? azurerm_user_assigned_identity.workload_operator[0].client_id : ""
 
     # Vault (v0.27.0+) — populated only when vault_enabled=true.
-    "identity.vault.clientId"     = var.vault_enabled ? azurerm_user_assigned_identity.vault[0].client_id : ""
-    "vault.keyVaultName"          = var.vault_enabled ? azurerm_key_vault.vault_unseal[0].name : ""
-    "vault.unsealKeyName"         = var.vault_enabled ? azurerm_key_vault_key.vault_unseal[0].name : ""
-    "vault.backupStorageAccount"  = var.vault_enabled ? azurerm_storage_account.vault_backup[0].name : ""
-    "vault.backupContainer"       = var.vault_enabled ? azurerm_storage_container.vault_backup[0].name : ""
-    "vault.exposuresJson"         = jsonencode({ for k, v in local.vault_exposures_resolved : k => v if v.enabled })
+    "identity.vault.clientId"    = var.vault_enabled ? azurerm_user_assigned_identity.vault[0].client_id : ""
+    "vault.keyVaultName"         = var.vault_enabled ? azurerm_key_vault.vault_unseal[0].name : ""
+    "vault.unsealKeyName"        = var.vault_enabled ? azurerm_key_vault_key.vault_unseal[0].name : ""
+    "vault.backupStorageAccount" = var.vault_enabled ? azurerm_storage_account.vault_backup[0].name : ""
+    "vault.backupContainer"      = var.vault_enabled ? azurerm_storage_container.vault_backup[0].name : ""
+    "vault.exposuresJson"        = jsonencode({ for k, v in local.vault_exposures_resolved : k => v if v.enabled })
   }
 }
 

--- a/providers/azure/variables.tf
+++ b/providers/azure/variables.tf
@@ -1083,3 +1083,54 @@ variable "shared_hub_kv_enabled" {
   type        = bool
   default     = true
 }
+
+# ---------------------------------------------------------------------------
+# HashiCorp Vault (v0.27.0+ — multi-provider opt-in component)
+# ---------------------------------------------------------------------------
+# Toggle to provision the Azure-side Vault infrastructure (dedicated Key
+# Vault for unseal key, Storage Account for snapshot backups, Workload
+# Identity). When false, NO resources are created — clean teardown on
+# flip back to false (no purge_protection on the dedicated KV).
+#
+# Companion: estabilis-platform-gitops v0.38.0+ ships the chart values
+# overlay (values/platform/vault.yaml, vault-azure.yaml) and the triple-belt
+# coverage (network-policies, resource-quotas, kyverno-policies).
+
+variable "vault_enabled" {
+  description = "Provision Vault infrastructure (dedicated KV unseal key, Storage Account backup, Workload Identity) and render the platform-root Application. Toggle false to remove all Vault resources cleanly (no purge protection on the dedicated KV)."
+  type        = bool
+  default     = false
+}
+
+variable "vault_chart_version" {
+  description = "HashiCorp Vault Helm chart version (https://helm.releases.hashicorp.com)."
+  type        = string
+  default     = "0.29.1"
+}
+
+variable "vault_backup_retention_days" {
+  description = "Days to retain Raft snapshot backups in the Storage Account container. CronJob is deferred to a follow-up; the bucket + lifecycle is provisioned here so future enablement needs no role assignment."
+  type        = number
+  default     = 30
+}
+
+variable "vault_exposures" {
+  description = "Vault UI ingress exposures (multi-network ingress per profile). Same shape as other *_exposures vars. Typically internal — ops team via VPN. When host is empty, it is auto-derived (app name: 'vault')."
+  type = map(object({
+    enabled       = bool
+    host          = optional(string, "")
+    ingress_class = optional(string, "traefik-internal")
+    allowed_cidrs = optional(string, "")
+    issuer        = optional(string, "letsencrypt-production")
+    basic_auth    = optional(bool, false)
+
+    alb_group              = optional(string, "platform")
+    alb_scheme             = optional(string, "internet-facing")
+    alb_target_type        = optional(string, "ip")
+    alb_ssl_policy         = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
+    alb_healthcheck_path   = optional(string, "/v1/sys/health?standbyok=true")
+    alb_certificate_source = optional(string, "cert-manager")
+    alb_cloudflare_proxied = optional(bool, false)
+  }))
+  default = {}
+}

--- a/providers/azure/vault.tf
+++ b/providers/azure/vault.tf
@@ -1,0 +1,152 @@
+# =============================================================================
+# HashiCorp Vault — Azure infrastructure (auto-unseal + Raft snapshot backup)
+# =============================================================================
+# Toggle: var.vault_enabled. When false, NO resources are created — clean
+# teardown via `terraform apply` with vault_enabled=false destroys
+# everything provisioned here. NO purge protection on the dedicated KV
+# (would block teardown); accept that an unseal key can be soft-deleted +
+# purged inside the soft-delete retention window.
+#
+# Components provisioned (when enabled):
+#   - Dedicated Key Vault `kv-vault-{cluster}-{suffix}` (separate from the
+#     platform KV — scope isolation; no purge protection so the toggle is
+#     truly destructive)
+#   - RSA-2048 unseal key inside the dedicated KV
+#   - Storage Account `stvault{cluster}{suffix}` + container `raft-snapshots`
+#     for backup destination (deferred CronJob — bucket provisioned now so
+#     future enablement needs no role assignment)
+#   - User-assigned Managed Identity for the vault ServiceAccount + federated
+#     credential (Workload Identity)
+#   - Role assignments: Key Vault Crypto User on the dedicated KV +
+#     Storage Blob Data Contributor on the storage account
+#
+# Outputs feed into the platform-infrastructure-sensitive Secret consumed
+# by the Vault Application's helm.parameters (see
+# bootstrap/platform-root/templates/vault.yaml).
+#
+# Bootstrap (auth methods, policies, KV mount) is intentionally NOT here —
+# operator runs `vault operator init` manually after the chart deploys.
+# =============================================================================
+
+# --- Dedicated Key Vault for unseal key ---
+
+resource "azurerm_key_vault" "vault_unseal" {
+  count = var.vault_enabled ? 1 : 0
+
+  name                       = "kv-vault-${var.name_prefix}-${local.env_code}-${random_string.storage_suffix.result}"
+  location                   = azurerm_resource_group.platform.location
+  resource_group_name        = azurerm_resource_group.platform.name
+  tenant_id                  = var.tenant_id
+  sku_name                   = "standard"
+  rbac_authorization_enabled = true
+  soft_delete_retention_days = 7
+
+  # NO purge_protection — toggle false must remove all resources cleanly.
+  purge_protection_enabled = false
+
+  dynamic "network_acls" {
+    for_each = var.firewall_enabled ? [1] : []
+    content {
+      default_action             = "Deny"
+      bypass                     = "AzureServices"
+      ip_rules                   = local.firewall_keyvault_ips
+      virtual_network_subnet_ids = concat(local.firewall_base_subnet_ids, [azurerm_subnet.aks_pods.id])
+    }
+  }
+
+  tags = local.tags
+}
+
+# Operator running terraform needs Crypto Officer to create the key.
+resource "azurerm_role_assignment" "terraform_vault_kv_officer" {
+  count = var.vault_enabled ? 1 : 0
+
+  scope                = azurerm_key_vault.vault_unseal[0].id
+  role_definition_name = "Key Vault Crypto Officer"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_key_vault_key" "vault_unseal" {
+  count = var.vault_enabled ? 1 : 0
+
+  name         = "vault-unseal"
+  key_vault_id = azurerm_key_vault.vault_unseal[0].id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+
+  depends_on = [azurerm_role_assignment.terraform_vault_kv_officer]
+
+  tags = local.tags
+}
+
+# --- Storage Account for Raft snapshot backups ---
+
+resource "azurerm_storage_account" "vault_backup" {
+  count = var.vault_enabled ? 1 : 0
+
+  name                     = "st${var.name_prefix}${local.env_code}vlt${random_string.storage_suffix.result}"
+  resource_group_name      = azurerm_resource_group.platform.name
+  location                 = azurerm_resource_group.platform.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
+
+  blob_properties {
+    versioning_enabled = true
+
+    delete_retention_policy {
+      days = var.vault_backup_retention_days
+    }
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_storage_container" "vault_backup" {
+  count = var.vault_enabled ? 1 : 0
+
+  name                  = "raft-snapshots"
+  storage_account_id    = azurerm_storage_account.vault_backup[0].id
+  container_access_type = "private"
+}
+
+# --- Managed Identity + Federated Credential (Workload Identity) ---
+
+resource "azurerm_user_assigned_identity" "vault" {
+  count = var.vault_enabled ? 1 : 0
+
+  name                = "mi-${local.base_name}-vault"
+  location            = azurerm_resource_group.platform.location
+  resource_group_name = azurerm_resource_group.platform.name
+  tags                = local.tags
+}
+
+resource "azurerm_federated_identity_credential" "vault" {
+  count = var.vault_enabled ? 1 : 0
+
+  name                      = "fic-${local.base_name}-vault"
+  user_assigned_identity_id = azurerm_user_assigned_identity.vault[0].id
+  audience                  = ["api://AzureADTokenExchange"]
+  issuer                    = local.aks_oidc_issuer_url
+  subject                   = "system:serviceaccount:vault:vault"
+  resource_group_name       = azurerm_resource_group.platform.name
+}
+
+# --- Role assignments ---
+
+resource "azurerm_role_assignment" "vault_kv_crypto_user" {
+  count = var.vault_enabled ? 1 : 0
+
+  scope                = azurerm_key_vault.vault_unseal[0].id
+  role_definition_name = "Key Vault Crypto User"
+  principal_id         = azurerm_user_assigned_identity.vault[0].principal_id
+}
+
+resource "azurerm_role_assignment" "vault_storage_contributor" {
+  count = var.vault_enabled ? 1 : 0
+
+  scope                = azurerm_storage_account.vault_backup[0].id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.vault[0].principal_id
+}


### PR DESCRIPTION
Foundation pass for HashiCorp Vault as a platform component on **both AWS and Azure**. Pairs with [`estabilis-platform-gitops#32`](https://github.com/Estabilis/estabilis-platform-gitops/pull/32) (triple-belt + chart overlays).

## Scope (foundation only)

✅ Chart deployment (3-replica Raft HA)
✅ Cloud auto-unseal infrastructure (AWS KMS / Azure Key Vault)
✅ Backup storage (S3 bucket / Azure Storage container) — CronJob deferred
✅ IRSA / Workload Identity for the vault SA
✅ Toggle on/off via `vault_enabled` — **no orphans on disable**
✅ Ingress `vault_exposures` (internal/external — same shape as other `*_exposures`)
✅ Multi-source Application gated on `provider in (aws | azure)`

## Out of scope (downstream / follow-ups)

❌ `vault operator init` (manual after Application syncs)
❌ Auth methods (GitHub, Kubernetes JWT, userpass)
❌ Policies (admin, developer, eso, etc.)
❌ KV mount + secret paths
❌ ClusterSecretStore for Vault provider (existing KV/SM stores stay)
❌ Snapshot CronJob (depends on token; storage provisioned now)

## Toggle = no orphans

`vault_enabled = false` after a prior enable produces a clean `terraform destroy` of all Vault resources:

| Resource | Cleanup |
|---|---|
| AWS KMS key | 7-day deletion window, no `prevent_destroy` |
| AWS S3 bucket | `force_destroy = true` (snapshots auto-removed) |
| AWS IRSA role + policy | counts to 0 |
| Azure dedicated KV | **`purge_protection = false`** (deliberate — toggle would block otherwise) |
| Azure Storage Account | counts to 0 |
| Azure Managed Identity + federated cred | counts to 0 |

## File summary

| File | Change |
|---|---|
| `providers/aws/vault.tf` | NEW — KMS unseal + S3 backup + IRSA |
| `providers/azure/vault.tf` | NEW — dedicated KV + Storage + Managed Identity + role assignments |
| `providers/{aws,azure}/variables.tf` | +4 vars per provider (vault_enabled, vault_chart_version, vault_backup_retention_days, vault_exposures) |
| `providers/{aws,azure}/main.tf` | `_app_host` += vault; new `vault_exposures_resolved` local |
| `providers/aws/outputs.tf` | +6 outputs (kms_key_id/arn/region, irsa_role_arn, backup_bucket, exposures_json) |
| `providers/{aws,azure}/platform-outputs.tf` | inject vault.* + identity.vault.* into `platform-infrastructure-sensitive` Secret |
| `bootstrap/platform-root/templates/vault.yaml` | NEW — ArgoCD Application, multi-source, Helm parameter injection per provider |
| `bootstrap/platform-root/templates/argocd-project.yaml` | +vault namespace destination, +HashiCorp helm sourceRepo |
| `bootstrap/platform-root/templates/_helpers.tpl` | comment that vault is NOT in awsOnly (multi-provider) |
| `bootstrap/platform-root/values.yaml` | components.vault=false default, platformGitopsVersion v0.37.2 → v0.38.0 |
| `CHANGELOG.md` | v0.28.0 entry |

## Migration

Default `vault_enabled = false` → no-op on existing clusters. Opt-in flow:
1. `vault_enabled = true` + `vault_exposures = { ... }` in `terraform.tfvars`
2. `terraform apply` — provisions cloud unseal infra
3. `components.vault: true` in `overrides/platform-root/values.yaml`
4. `estabilis promote <client> -d <deployment> --force-refresh`
5. **Manual**: `kubectl exec -n vault vault-0 -- vault operator init` (out-of-band storage of unseal keys + root token; downstream/runbook covers)

## Test plan

- [ ] Apply with `vault_enabled=false` (default) — no Vault resources, no diff
- [ ] Apply with `vault_enabled=true` — KMS/KV + bucket + IRSA created
- [ ] `platform-root` syncs Vault Application (3 pods Running, sealed → auto-unsealed by KMS/KV)
- [ ] Toggle back to `false` → `terraform plan` shows N to destroy, 0 prevented
- [ ] On Azure: dedicated KV named `kv-vault-{cluster}-{suffix}`, separate from platform KV