### PR TITLE
feat(vault): vault-ingress chart + dynamic exposures + 3 tunable vars (v0.28.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,84 @@
 # Changelog
 
+## [0.28.2] - 2026-04-25
+
+### Added — `vault-ingress` chart (consumes `vault_exposures` dynamically)
+
+Closes the gap from v0.28.0/v0.28.1 where `vault_exposures` flowed into
+the Secret but had no chart consuming it. Clients had to hardcode an
+Ingress in their `overrides/vault/values.yaml` referencing literal
+ACM ARNs, hostnames, and ALB groups. v0.28.2 ships a proper
+`vault-ingress` chart following the existing `grafana-ingress` /
+`argocd-ingress` pattern.
+
+#### `core/components/vault-ingress/` (NEW)
+
+Mirror of `grafana-ingress`, vault-specific:
+- Backend: `vault-ui` Service, port 8200 (NOT the chart's own ingress)
+- Default healthcheck path: `/v1/sys/health?standbyok=true&sealedcode=200&uninitcode=200`
+  — keeps the LB routing traffic to standby pods (default is 429), to
+  sealed pods (so the operator can reach the API to unseal), and to
+  uninitialized pods (so `vault operator init` works via the LB).
+- Branches on `$exp.ingress_class`:
+  - `alb` → AWS Load Balancer Controller annotations (cert ARN, group,
+    scheme, ssl-policy, healthcheck path) — all consumed from the
+    profile + `global.acmCertificateArn` from the platform Secret.
+  - `traefik` / `traefik-internal` → Traefik IngressRoute with
+    Middlewares for `ipAllowList`.
+- Vault has its own UI auth — `basic_auth = true` is unsupported and
+  the chart fails loud regardless of ingress class (would double-auth).
+
+#### `bootstrap/platform-root/templates/vault-ingress.yaml` (NEW)
+
+ArgoCD Application gated on (`provider in (aws | azure)`) AND
+`components.vault != false` AND at least one enabled exposure profile
+in `global.vaultExposures`. Forwards `exposuresJson` +
+`global.acmCertificateArn` + `global.dnsProvider` to the chart via
+`helm.parameters`. Sync-wave 9 (after the Vault chart at wave 5).
+
+#### `providers/{aws,azure}/platform-outputs.tf` — exposures move
+
+`vault.exposuresJson` (in `platform-infrastructure-sensitive` Secret)
+→ `global.vaultExposures` (in `platform-infrastructure` ConfigMap),
+matching the ADR 0014 convention used by every other `*Exposures`
+field. Exposures are non-sensitive (just hostnames + CIDR allowlists);
+the Secret keeps only the identity and KMS/KV key ID.
+
+### Added — Three tunable variables
+
+`providers/aws/variables.tf`:
+- `vault_kms_deletion_window_days` (default `7`, range 7-30) — AWS
+  KMS deletion window for the dedicated unseal key. Lower = faster
+  destroy on toggle off; higher = bigger window to recover an
+  accidentally-disabled deployment.
+
+`providers/azure/variables.tf`:
+- `vault_kv_soft_delete_days` (default `7`, range 7-90) — Soft-delete
+  retention on the dedicated Vault Key Vault. NO purge_protection
+  (toggle false must remove cleanly).
+- `vault_storage_replication_type` (default `"LRS"`, validated against
+  LRS/ZRS/GRS/RAGRS/GZRS/RAGZRS) — Replication type for the Vault
+  snapshot Storage Account. LRS=cheapest single-region; clients with
+  HA backup needs override to ZRS or GRS.
+
+### Migration
+
+For `vault_enabled = true` deployments running v0.28.0 or v0.28.1:
+
+1. Bump `ref` and `platform_revision` to `v0.28.2`.
+2. `terraform init -upgrade && terraform apply` — `platform-infrastructure`
+   ConfigMap gains `global.vaultExposures`; `platform-infrastructure-sensitive`
+   loses `vault.exposuresJson` (was non-sensitive, ADR 0014 alignment).
+3. `estabilis promote <client> -d <deployment> --force-refresh` — the
+   parameter forwarding picks up the new ConfigMap key; vault-ingress
+   Application renders.
+4. **Drop hardcoded ingress override** in client repo's
+   `overrides/vault/values.yaml` (only the genuine cluster-specific
+   bits like `dataStorage.storageClass` should remain).
+
+For deployments NOT yet using Vault: no-op (`vault_enabled = false`
+default).
+
 ## [0.28.1] - 2026-04-25
 
 ### Fixed — `vault.yaml` template nil-pointer on first render

--- a/bootstrap/platform-root/templates/vault-ingress.yaml
+++ b/bootstrap/platform-root/templates/vault-ingress.yaml
@@ -1,0 +1,75 @@
+{{- /*
+  Vault external ingress Application — multi-provider (AWS + Azure).
+  Renders iff vault is enabled AND at least one exposure is enabled in
+  global.vaultExposures (which terraform's vault.exposuresJson flows into).
+  Mirror of grafana-ingress.yaml — see core/components/vault-ingress for
+  the per-profile Ingress + Middleware rendering.
+*/ -}}
+{{- if and (or (eq .Values.global.provider "aws") (eq .Values.global.provider "azure")) (ne (index .Values.components "vault") false) }}
+{{- /* Source of truth: terraform's `vault.exposuresJson` field on
+      platform-infrastructure-sensitive Secret, surfaced into helm values
+      as global.vaultExposures by the upstart parameter wiring. */ -}}
+{{- $raw := index .Values.global "vaultExposures" | default "" -}}
+{{- $jsonStr := "{}" -}}
+{{- if $raw }}
+  {{- if or (hasPrefix "{" $raw) (hasPrefix "[" $raw) }}
+    {{- $jsonStr = $raw }}
+  {{- else }}
+    {{- $jsonStr = b64dec $raw }}
+  {{- end }}
+{{- end }}
+{{- $exposures := fromJson $jsonStr -}}
+{{- $hasEnabled := false -}}
+{{- $hasTraefikExposure := false -}}
+{{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) }}
+{{- if and $traefikGate $hasEnabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vault-ingress
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "9"
+spec:
+  project: platform
+  sources:
+    - repoURL: {{ .Values.platformRepoUrl }}
+      targetRevision: {{ .Values.platformVersion }}
+      path: core/components/vault-ingress
+      helm:
+        valueFiles:
+          - $values/core/components/vault-ingress/values.yaml
+          {{- include "platform-root.overrideValueFile" (dict "component" "vault-ingress" "root" $) | nindent 10 }}
+          {{- include "platform-root.gitopsValueFile" (dict "component" "vault-ingress" "root" $) | nindent 10 }}
+        ignoreMissingValueFiles: true
+        parameters:
+          {{- include "platform-root.provenanceParameters" $ | nindent 10 }}
+          {{- /* Pass through whatever encoding the source provided
+                (base64 or JSON). The child chart's middleware.yaml
+                inspects first char to decide whether to b64dec. */}}
+          - name: exposuresJson
+            value: {{ $raw | quote }}
+            forceString: true
+          {{- /* ALB branch consumes these via .Values.global.*. Ignored on Traefik. */}}
+          - name: global.dnsProvider
+            value: "{{ .Values.global.dnsProvider }}"
+          - name: global.acmCertificateArn
+            value: "{{ .Values.global.acmCertificateArn }}"
+    - repoURL: {{ .Values.platformRepoUrl }}
+      targetRevision: {{ .Values.platformVersion }}
+      ref: values
+    {{- include "platform-root.overrideSource" . | nindent 4 }}
+    {{- include "platform-root.gitopsSource" . | nindent 4 }}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: vault
+  syncPolicy:
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+{{- end }}
+{{- end }}

--- a/core/components/vault-ingress/Chart.yaml
+++ b/core/components/vault-ingress/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: vault-ingress
+description: HashiCorp Vault external ingress — ADR 0014 multi-exposure model (mirror of grafana-ingress, vault-specific backend + healthcheck)
+version: 0.1.0
+appVersion: "0.1.0"
+type: application

--- a/core/components/vault-ingress/templates/_helpers.tpl
+++ b/core/components/vault-ingress/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+{{/*
+Mirror of the platform-wide estabilis metadata helpers (ADR 0003).
+Duplicated identically across internal charts; keep in sync.
+*/}}
+{{- define "estabilis.labels" -}}
+estabilis.io/component: {{ .Chart.Name }}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: estabilis-platform
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "estabilis.annotations" -}}
+estabilis.io/platform: "Estabilis Platform"
+estabilis.io/chart-version: {{ .Chart.Version | quote }}
+estabilis.io/website: "https://estabilis.com"
+estabilis.io/source: "https://github.com/Estabilis/estabilis-platform"
+estabilis.io/support: "ops@estabilis.com"
+estabilis.io/license: "proprietary"
+{{- if and .Values.global .Values.global.provenance .Values.global.provenance.gitRevision }}
+estabilis.io/git-revision: {{ .Values.global.provenance.gitRevision | quote }}
+estabilis.io/git-source: {{ .Values.global.provenance.gitSource | quote }}
+estabilis.io/built-at: {{ .Values.global.provenance.builtAt | quote }}
+estabilis.io/build-id: {{ .Values.global.provenance.buildId | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "estabilis.metadata" -}}
+labels:
+  {{- include "estabilis.labels" . | nindent 2 }}
+annotations:
+  {{- include "estabilis.annotations" . | nindent 2 }}
+{{- end -}}

--- a/core/components/vault-ingress/templates/middleware.yaml
+++ b/core/components/vault-ingress/templates/middleware.yaml
@@ -1,0 +1,226 @@
+{{- /*
+  ADR 0014 — one Ingress (+ Middlewares for Traefik / + ALB annotations
+  for AWS) per enabled exposure profile.
+
+  Backend: vault-ui (port 8200) in the vault namespace. All
+  resources live in the vault namespace to share Traefik's cross-namespace
+  Middleware reference capability (Traefik path) or to keep the
+  Ingress co-located with the backend Service (ALB path).
+
+  The chart branches on `$exp.ingress_class`:
+    - "traefik" / "traefik-internal" → Traefik IngressRoute pattern
+      with Middlewares for ipAllowList. basic_auth is NOT supported
+      (Vault has its own UI auth — would double-auth) and the chart
+      fails loud if a profile sets it.
+    - "alb" → AWS Load Balancer Controller pattern with
+      `alb.ingress.kubernetes.io/*` annotations.
+
+  Default healthcheck path tuned for Vault: `/v1/sys/health?standbyok=true
+  &sealedcode=200&uninitcode=200`. The flags keep the LB routing traffic
+  to standby pods (default would 429), to sealed pods (so the operator
+  can reach the API to unseal), and to uninitialized pods (so the
+  operator can hit `vault operator init` via the LB).
+*/ -}}
+{{- $raw := .Values.exposuresJson | default "{}" -}}
+{{- $jsonStr := $raw -}}
+{{- if and $raw (not (or (hasPrefix "{" $raw) (hasPrefix "[" $raw))) }}
+  {{- $jsonStr = b64dec $raw }}
+{{- end }}
+{{- $exposures := fromJson $jsonStr -}}
+{{- range $profile, $exp := $exposures }}
+{{- if $exp.enabled }}
+{{- $isALB := eq $exp.ingress_class "alb" }}
+
+{{- /* Vault has its own UI authentication — basic_auth would double-auth.
+       Fail loud regardless of ingress class. */}}
+{{- if $exp.basic_auth }}
+{{- fail (printf "vault_exposures.%s: basic_auth=true is not supported (Vault has its own UI auth — basic_auth would double-auth)." $profile) }}
+{{- end }}
+
+{{- if and $isALB (eq $exp.alb_certificate_source "acm") (eq (default "" $.Values.global.acmCertificateArn) "") }}
+{{- fail (printf "vault_exposures.%s: alb_certificate_source=acm but global.acmCertificateArn is empty. Set acm_enabled=true on the platform Terraform module so an ACM cert is provisioned and its ARN auto-flows to this chart, or pick a different alb_certificate_source." $profile) }}
+{{- end }}
+
+{{- if and $isALB (not (has $exp.alb_certificate_source (list "acm" "cert-manager"))) }}
+{{- fail (printf "vault_exposures.%s: alb_certificate_source=%q is not recognized. Valid values: 'acm' (recommended — ALB Controller consumes ACM cert directly), 'cert-manager' (NOT supported by stock ALB Controller — kept for forward compatibility with future syncer integrations)." $profile $exp.alb_certificate_source) }}
+{{- end }}
+
+{{- if $isALB }}
+{{- /* ============================ ALB BRANCH ============================ */}}
+{{- $hcPath := default "/v1/sys/health?standbyok=true&sealedcode=200&uninitcode=200" $exp.alb_healthcheck_path }}
+{{- $useACM := eq $exp.alb_certificate_source "acm" }}
+---
+{{- if not $useACM }}
+{{- /* cert-manager Certificate (DNS-01 issued); ALB references via Ingress TLS spec */}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: vault-{{ $profile }}-tls
+  namespace: vault
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+spec:
+  secretName: vault-{{ $profile }}-tls
+  issuerRef:
+    name: {{ $exp.issuer | default "letsencrypt-production" | quote }}
+    kind: ClusterIssuer
+  dnsNames:
+    - {{ $exp.host | quote }}
+---
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: vault-{{ $profile }}
+  namespace: vault
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+  annotations:
+    {{- /* Core ALB annotations */}}
+    alb.ingress.kubernetes.io/scheme: {{ $exp.alb_scheme | quote }}
+    alb.ingress.kubernetes.io/target-type: {{ $exp.alb_target_type | quote }}
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/ssl-policy: {{ $exp.alb_ssl_policy | quote }}
+    alb.ingress.kubernetes.io/healthcheck-path: {{ $hcPath | quote }}
+    {{- /* Group routes multiple Ingresses behind ONE shared ALB —
+          significant cost saver when several apps are exposed. */}}
+    alb.ingress.kubernetes.io/group.name: {{ $exp.alb_group | quote }}
+    {{- if $useACM }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ $.Values.global.acmCertificateArn | quote }}
+    {{- end }}
+    {{- if $exp.allowed_cidrs }}
+    {{- /* ALB listener-rule condition (per-service). Restricts source IPs
+          at the listener level — different mechanism from Traefik
+          Middlewares but equivalent end result. */}}
+    alb.ingress.kubernetes.io/conditions.vault-ui: |-
+      [{"field":"source-ip","sourceIpConfig":{"values":[{{- $cidrs := list -}}{{- range splitList "," $exp.allowed_cidrs -}}{{- $cidrs = append $cidrs (printf "%q" (trim .)) -}}{{- end -}}{{ join "," $cidrs }}]}}]
+    {{- end }}
+    {{- if hasKey $.Values.global "dnsProvider" }}
+    {{- if eq $.Values.global.dnsProvider "cloudflare" }}
+    {{- /* Cloudflare DNS-only mode (orange cloud OFF) — preserves real
+          ALB IP for source-IP allowlist to work. With proxy ON, every
+          request appears to originate from Cloudflare CIDRs. */}}
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: {{ $exp.alb_cloudflare_proxied | quote }}
+    {{- end }}
+    {{- end }}
+    external-dns.alpha.kubernetes.io/hostname: {{ $exp.host | quote }}
+spec:
+  ingressClassName: alb
+  rules:
+    - host: {{ $exp.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: vault-ui
+                port:
+                  number: 8200
+  {{- if not $useACM }}
+  tls:
+    - secretName: vault-{{ $profile }}-tls
+      hosts:
+        - {{ $exp.host | quote }}
+  {{- end }}
+{{- else }}
+{{- /* ========================== TRAEFIK BRANCH ========================== */}}
+{{- $mwIPName := printf "vault-%s-ipallowlist" $profile }}
+{{- $mwAuthName := printf "vault-%s-auth" $profile }}
+---
+{{- if $exp.allowed_cidrs }}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $mwIPName }}
+  namespace: vault
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+spec:
+  ipAllowList:
+    sourceRange:
+      {{- range splitList "," $exp.allowed_cidrs }}
+      - {{ trim . | quote }}
+      {{- end }}
+---
+{{- end }}
+{{- if $exp.basic_auth }}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $mwAuthName }}
+  namespace: vault
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+spec:
+  basicAuth:
+    secret: {{ $mwAuthName }}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ $mwAuthName }}
+  namespace: vault
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: platform-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: {{ $mwAuthName }}
+    creationPolicy: Owner
+  data:
+    - secretKey: users
+      remoteRef:
+        key: {{ printf "%s-%s" $.Values.kvSecretPrefix $profile | quote }}
+---
+{{- end }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: vault-{{ $profile }}-tls
+  namespace: vault
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+spec:
+  secretName: vault-{{ $profile }}-tls
+  issuerRef:
+    name: {{ $exp.issuer | default "letsencrypt-production" | quote }}
+    kind: ClusterIssuer
+  dnsNames:
+    - {{ $exp.host | quote }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: vault-{{ $profile }}
+  namespace: vault
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+  annotations:
+    {{- $mws := list }}
+    {{- if $exp.allowed_cidrs }}
+    {{- $mws = append $mws (printf "vault-%s@kubernetescrd" $mwIPName) }}
+    {{- end }}
+    {{- if $exp.basic_auth }}
+    {{- $mws = append $mws (printf "vault-%s@kubernetescrd" $mwAuthName) }}
+    {{- end }}
+    {{- if $mws }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ join "," $mws | quote }}
+    {{- end }}
+    external-dns.alpha.kubernetes.io/hostname: {{ $exp.host | quote }}
+spec:
+  ingressClassName: {{ $exp.ingress_class | default "traefik" | quote }}
+  rules:
+    - host: {{ $exp.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: vault-ui
+                port:
+                  number: 8200
+  tls:
+    - secretName: vault-{{ $profile }}-tls
+      hosts:
+        - {{ $exp.host | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/core/components/vault-ingress/values.yaml
+++ b/core/components/vault-ingress/values.yaml
@@ -1,0 +1,27 @@
+# HashiCorp Vault external ingress — ADR 0014 (multi-exposure model).
+#
+# Mirror of grafana-ingress/values.yaml. Each entry in exposures becomes a
+# K8s Ingress (+ Middlewares for Traefik / + ALB annotations for AWS) +
+# optional cert-manager Certificate. The Ingress points at the `vault-ui`
+# Service on port 8200 (the Vault chart's UI service).
+#
+# Vault has its own UI authentication — `basic_auth` is unsupported
+# (would double-auth) and the chart fails loud if a profile sets it.
+
+# Injected by platform-root as a JSON string parameter from
+# `vault.exposuresJson` in the platform-infrastructure-sensitive Secret.
+# Source of truth: `var.vault_exposures` in providers/{aws,azure}/variables.tf
+# resolved via `local.vault_exposures_resolved` in providers/*/main.tf.
+exposuresJson: "{}"
+
+# Default Vault health-check path consumed when an exposure profile leaves
+# `alb_healthcheck_path` empty. `standbyok=true` returns 200 from standby
+# pods (default would 429); `sealedcode=200` + `uninitcode=200` keep the
+# LB routing traffic to a fresh Vault that hasn't been initialized yet —
+# operator can run `vault operator init` via the LB.
+defaultHealthcheckPath: "/v1/sys/health?standbyok=true&sealedcode=200&uninitcode=200"
+
+# `global` block populated by helm.parameters from platform-root.
+global:
+  acmCertificateArn: ""
+  dnsProvider: ""

--- a/providers/aws/platform-outputs.tf
+++ b/providers/aws/platform-outputs.tf
@@ -105,6 +105,7 @@ resource "kubernetes_config_map" "platform_infrastructure" {
     "global.grafanaExposures"  = jsonencode({ for k, v in local.grafana_exposures_resolved : k => v if v.enabled })
     "global.argocdExposures"   = jsonencode({ for k, v in local.argocd_exposures_resolved : k => v if v.enabled })
     "global.hubbleUiExposures" = jsonencode({ for k, v in local.hubble_ui_exposures_resolved : k => v if v.enabled })
+    "global.vaultExposures"    = jsonencode({ for k, v in local.vault_exposures_resolved : k => v if v.enabled })
 
     # Autoscaler + Karpenter wiring
     "global.autoscaler"               = var.autoscaler
@@ -175,11 +176,13 @@ resource "kubernetes_secret" "platform_infrastructure" {
     "global.cloudflareApiToken" = var.dns_provider == "cloudflare" ? var.cloudflare_api_token : ""
 
     # Vault (v0.27.0+) — populated only when vault_enabled=true.
+    # vault.exposuresJson moved to ConfigMap as global.vaultExposures (ADR 0014
+    # convention; non-sensitive). The Secret keeps the identity + KMS key id
+    # which ARE sensitive.
     "identity.vault.roleArn" = var.vault_enabled ? module.vault_irsa[0].iam_role_arn : ""
     "vault.kmsKeyId"         = var.vault_enabled ? aws_kms_key.vault[0].key_id : ""
     "vault.kmsRegion"        = var.vault_enabled ? var.region : ""
     "vault.backupBucketName" = var.vault_enabled ? aws_s3_bucket.vault_backup[0].id : ""
-    "vault.exposuresJson"    = jsonencode({ for k, v in local.vault_exposures_resolved : k => v if v.enabled })
   }
 }
 

--- a/providers/aws/variables.tf
+++ b/providers/aws/variables.tf
@@ -1208,6 +1208,17 @@ variable "vault_backup_retention_days" {
   default     = 30
 }
 
+variable "vault_kms_deletion_window_days" {
+  description = "AWS KMS deletion window for the dedicated Vault unseal key. Range 7-30 days. Lower = faster destroy on toggle off; higher = bigger window to recover an accidentally-disabled deployment."
+  type        = number
+  default     = 7
+
+  validation {
+    condition     = var.vault_kms_deletion_window_days >= 7 && var.vault_kms_deletion_window_days <= 30
+    error_message = "vault_kms_deletion_window_days must be between 7 and 30."
+  }
+}
+
 variable "vault_exposures" {
   description = "Vault UI ingress exposures (multi-network ingress per profile). Same shape as the other *_exposures vars. Typically internal — ops team accesses via VPN. When host is empty, it is auto-derived (app name: 'vault')."
   type = map(object({

--- a/providers/aws/vault.tf
+++ b/providers/aws/vault.tf
@@ -34,7 +34,7 @@ resource "aws_kms_key" "vault" {
 
   description             = "Vault auto-unseal key for ${local.cluster_name}"
   enable_key_rotation     = true
-  deletion_window_in_days = 7
+  deletion_window_in_days = var.vault_kms_deletion_window_days
 
 }
 

--- a/providers/azure/platform-outputs.tf
+++ b/providers/azure/platform-outputs.tf
@@ -84,6 +84,7 @@ resource "kubernetes_config_map" "platform_infrastructure" {
     "global.grafanaExposures"  = jsonencode({ for k, v in local.grafana_exposures_resolved : k => v if v.enabled })
     "global.argocdExposures"   = jsonencode({ for k, v in local.argocd_exposures_resolved : k => v if v.enabled })
     "global.hubbleUiExposures" = jsonencode({ for k, v in local.hubble_ui_exposures_resolved : k => v if v.enabled })
+    "global.vaultExposures"    = jsonencode({ for k, v in local.vault_exposures_resolved : k => v if v.enabled })
 
     # Gate for hubble-ui-ingress rendering (Hubble UI only exists in ACNS)
     "global.networkDataplane" = var.network_dataplane
@@ -144,12 +145,15 @@ resource "kubernetes_secret" "platform_infrastructure" {
     "identity.workloadOperator.clientId" = var.shared_hub_kv_enabled ? azurerm_user_assigned_identity.workload_operator[0].client_id : ""
 
     # Vault (v0.27.0+) — populated only when vault_enabled=true.
+    # vault.exposuresJson moved to ConfigMap as global.vaultExposures (ADR 0014
+    # convention; non-sensitive). The Secret keeps the identity + KV name + key
+    # name which ARE sensitive (or pseudo-sensitive — KV name is part of the
+    # unseal recovery story).
     "identity.vault.clientId"    = var.vault_enabled ? azurerm_user_assigned_identity.vault[0].client_id : ""
     "vault.keyVaultName"         = var.vault_enabled ? azurerm_key_vault.vault_unseal[0].name : ""
     "vault.unsealKeyName"        = var.vault_enabled ? azurerm_key_vault_key.vault_unseal[0].name : ""
     "vault.backupStorageAccount" = var.vault_enabled ? azurerm_storage_account.vault_backup[0].name : ""
     "vault.backupContainer"      = var.vault_enabled ? azurerm_storage_container.vault_backup[0].name : ""
-    "vault.exposuresJson"        = jsonencode({ for k, v in local.vault_exposures_resolved : k => v if v.enabled })
   }
 }
 

--- a/providers/azure/variables.tf
+++ b/providers/azure/variables.tf
@@ -1114,6 +1114,28 @@ variable "vault_backup_retention_days" {
   default     = 30
 }
 
+variable "vault_kv_soft_delete_days" {
+  description = "Soft-delete retention on the dedicated Vault Key Vault. Range 7-90 days. Set low for cleaner toggle-off; set higher when teams want a wider undelete window. NO purge_protection here — `vault_enabled = false` must remove the resource."
+  type        = number
+  default     = 7
+
+  validation {
+    condition     = var.vault_kv_soft_delete_days >= 7 && var.vault_kv_soft_delete_days <= 90
+    error_message = "vault_kv_soft_delete_days must be between 7 and 90."
+  }
+}
+
+variable "vault_storage_replication_type" {
+  description = "Replication type for the Vault Raft snapshot Storage Account. LRS=cheapest single-region; ZRS=zone-redundant; GRS/RAGRS=geo-redundant. Defaults to LRS for foundation cost; clients with HA backup needs override to ZRS or GRS."
+  type        = string
+  default     = "LRS"
+
+  validation {
+    condition     = contains(["LRS", "ZRS", "GRS", "RAGRS", "GZRS", "RAGZRS"], var.vault_storage_replication_type)
+    error_message = "vault_storage_replication_type must be one of LRS, ZRS, GRS, RAGRS, GZRS, RAGZRS."
+  }
+}
+
 variable "vault_exposures" {
   description = "Vault UI ingress exposures (multi-network ingress per profile). Same shape as other *_exposures vars. Typically internal — ops team via VPN. When host is empty, it is auto-derived (app name: 'vault')."
   type = map(object({

--- a/providers/azure/vault.tf
+++ b/providers/azure/vault.tf
@@ -39,7 +39,7 @@ resource "azurerm_key_vault" "vault_unseal" {
   tenant_id                  = var.tenant_id
   sku_name                   = "standard"
   rbac_authorization_enabled = true
-  soft_delete_retention_days = 7
+  soft_delete_retention_days = var.vault_kv_soft_delete_days
 
   # NO purge_protection — toggle false must remove all resources cleanly.
   purge_protection_enabled = false
@@ -89,7 +89,7 @@ resource "azurerm_storage_account" "vault_backup" {
   resource_group_name      = azurerm_resource_group.platform.name
   location                 = azurerm_resource_group.platform.location
   account_tier             = "Standard"
-  account_replication_type = "LRS"
+  account_replication_type = var.vault_storage_replication_type
   min_tls_version          = "TLS1_2"
 
   blob_properties {


### PR DESCRIPTION
**Phase 1 (critical)** — vault-ingress chart fixes the hardcoded Ingress workaround:

- New `core/components/vault-ingress/` chart (mirror of grafana-ingress; backend vault-ui:8200; default health-check tuned for Vault: standbyok+sealedcode+uninitcode all 200 so LB routes to uninitialized pods for `vault operator init` over the LB; ALB + Traefik branches; basic_auth fails loud — Vault has its own auth).
- New `bootstrap/platform-root/templates/vault-ingress.yaml` Application gated on provider+components.vault+enabled exposures. Forwards `exposuresJson` + `global.acmCertificateArn` + `global.dnsProvider` via helm.parameters. Sync-wave 9.
- `providers/{aws,azure}/platform-outputs.tf`: `vault.exposuresJson` (Secret) → `global.vaultExposures` (ConfigMap) — ADR 0014 alignment; hostnames + CIDRs are non-sensitive.

**Phase 2 (tunables)**:

- `vault_kms_deletion_window_days` (AWS, default 7, 7-30)
- `vault_kv_soft_delete_days` (Azure, default 7, 7-90)
- `vault_storage_replication_type` (Azure, default LRS, validated LRS/ZRS/GRS/RAGRS/GZRS/RAGZRS)

Pairs with [`estabilis-platform-gitops#33`](https://github.com/Estabilis/estabilis-platform-gitops/pull/33) (overlay cleanup: drop dead-code placeholders + gp3 default).

## Test plan

- [x] `helm template` renders both `vault` and `vault-ingress` Applications without errors
- [ ] After merge + tag + cortex bump:
  - [ ] `vault.eks-cortex-platform-prd-us-east-1.estabilis-cortex.com` resolves via cortex's `vault_exposures.external`
  - [ ] No literal ARN/host/group in cortex `overrides/vault/values.yaml` (revert to just `storageClass: gp2`)
  - [ ] `global.vaultExposures` appears in the platform-infrastructure ConfigMap