### PR TITLE
fix(argocd): root-cause server.secretkey wipe on self-manage sync (v0.28.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,89 @@
 # Changelog
 
+## [0.28.3] - 2026-04-25
+
+### Fixed — `argocd-secret server.secretkey` wipe on self-manage sync (root-cause)
+
+ArgoCD self-managed via the `argocd` Application would periodically
+end up with an empty `argocd-secret`, surfacing as:
+
+```
+argocd-server: "Unable to parse updated settings: server.secretkey is missing"
+argocd-server: "failed to list *v1.Secret: Unauthorized" (watch loops)
+UI/CLI: 401 on every request
+```
+
+Live observation on cortex-eks: the Secret would be populated for a
+few minutes after a fresh `helm install`, then drop back to empty
+data on the first ArgoCD self-sync — repeating every reconcile cycle.
+
+#### Root cause
+
+The argo-cd chart populates `argocd-secret.data` (server.secretkey,
+admin.password, etc.) via the `redisSecretInit` Job pre-install hook.
+That hook is intentionally disabled in
+`core/components/argocd/values.yaml`:
+
+```yaml
+# Disable redis-secret-init hook — the Redis password is managed by
+# Terraform (Key Vault) + ExternalSecret, not Helm hooks.
+# Hooks cause foregroundDeletion deadlocks on ArgoCD self-manage sync.
+redisSecretInit:
+  enabled: false
+```
+
+But disabling the hook left the chart rendering `argocd-secret` with
+`data: {}`. The self-managed `argocd` Application would
+ServerSideApply that empty manifest on every reconcile, taking
+ownership of the `/data` field manager and wiping whatever was
+populated there (manual patches, prior helm hook output, anything).
+
+#### Fix (defense in depth)
+
+1. **`core/components/argocd/values.yaml`** — set
+   `configs.secret.createSecret: false`. The chart no longer renders
+   `argocd-secret` at all. Eliminates the SSA wipe vector at its
+   source.
+2. **`providers/{aws,azure}/argocd-secret.tf` (NEW)** — terraform
+   generates a 32-byte `server.secretkey` via `random_password` and
+   creates the `argocd-secret` directly. Lifecycle `ignore_changes`
+   on the field set ArgoCD/operators may write later
+   (`admin.password`, `webhook.*`, `dex.*` OIDC secrets) so terraform
+   doesn't fight whoever populates those.
+3. **`bootstrap/platform-root/templates/argocd.yaml`** — adds
+   `ignoreDifferences` for `Secret/argocd-secret/data` on the argocd
+   Application. Belt-and-suspenders: even if some future change
+   re-enables chart-side rendering, the data field is protected from
+   SSA overwrite on self-sync.
+
+Rotation: change `random_password.argocd_secretkey.keepers` (or
+destroy+recreate the resource) to rotate. `argocd-server` picks up
+the new key on the next pod restart.
+
+### Migration
+
+For all v0.28.x clusters where Vault is being deployed (or any
+deployment hitting the secretkey wipe loop):
+
+1. Bump `ref` and `platform_revision` to `v0.28.3`.
+2. `terraform init -upgrade && terraform apply` — creates
+   `argocd-secret` with a freshly generated `server.secretkey`.
+   If the Secret already exists with operator-provided data,
+   terraform takes ownership of the `data` map; lifecycle ignores
+   the listed fields so admin.password / webhooks / dex secrets
+   are preserved.
+3. `estabilis promote <client> -d <deployment> --force-refresh` —
+   re-renders the `argocd` Application, picking up the new
+   `configs.secret.createSecret = false` value file change AND the
+   ignoreDifferences from the bootstrap template.
+4. Verify: `kubectl -n argocd logs deploy/argocd-server | grep -i
+   secretkey` should be silent. `kubectl -n argocd get secret
+   argocd-secret -o jsonpath='{.data}' | jq 'keys'` should include
+   `server.secretkey`.
+
+For deployments not affected (no symptoms): no-op, but recommended
+for hygiene — eliminates a latent failure mode.
+
 ## [0.28.2] - 2026-04-25
 
 ### Added — `vault-ingress` chart (consumes `vault_exposures` dynamically)

--- a/bootstrap/platform-root/templates/argocd.yaml
+++ b/bootstrap/platform-root/templates/argocd.yaml
@@ -39,6 +39,22 @@ spec:
       kind: ValidatingWebhookConfiguration
       jqPathExpressions:
         - .webhooks[]?.clientConfig.caBundle
+    {{- /* argocd-secret: the chart renders this Secret with `data: {}`
+           because `redisSecretInit.enabled = false` (see
+           core/components/argocd/values.yaml — disabling that hook avoids
+           foregroundDeletion deadlocks on ArgoCD self-manage sync).
+           Without ignoreDifferences here, every reconcile of the argocd
+           Application would overwrite `/data` via ServerSideApply,
+           wiping `server.secretkey`. Terraform pre-populates
+           `server.secretkey` via `kubernetes_secret_v1_data` in
+           providers/{aws,azure}/argocd-secret.tf — this ignoreDifferences
+           keeps it intact across syncs. */}}
+    - group: ""
+      kind: Secret
+      name: argocd-secret
+      namespace: argocd
+      jsonPointers:
+        - /data
   syncPolicy:
     {{- include "platform-root.managedNamespaceMetadataExcluded" . | nindent 4 }}
     retry:

--- a/core/components/argocd/values.yaml
+++ b/core/components/argocd/values.yaml
@@ -11,6 +11,21 @@ commonLabels:
 redisSecretInit:
   enabled: false
 
+# Disable chart-managed argocd-secret. With redisSecretInit off, the
+# chart would otherwise render `argocd-secret` with `data: {}` — and
+# every reconcile of the self-managed `argocd` Application would
+# ServerSideApply that empty manifest, wiping `server.secretkey` and
+# breaking session signing (`server.secretkey is missing` warnings,
+# Unauthorized watches, UI/CLI 401s).
+#
+# Foundation v0.28.3+: terraform owns argocd-secret end-to-end via
+# `providers/{aws,azure}/argocd-secret.tf`. The chart skips creation
+# entirely when `configs.secret.createSecret = false`. This eliminates
+# the SSA wipe vector at its source.
+configs:
+  secret:
+    createSecret: false
+
 global:
   securityContext:
     runAsNonRoot: true

--- a/providers/aws/argocd-secret.tf
+++ b/providers/aws/argocd-secret.tf
@@ -1,0 +1,76 @@
+# =============================================================================
+# argocd-secret — terraform-owned (foundation v0.28.3 fix)
+# =============================================================================
+# Postmortem:
+#
+# The argo-cd chart populates `argocd-secret.data` (server.secretkey,
+# admin.password, etc.) via a `redisSecretInit` Job pre-install hook.
+# That hook is intentionally disabled in `core/components/argocd/values.yaml`
+# because it causes `foregroundDeletion` deadlocks on ArgoCD self-manage
+# sync (the App goes Progressing forever when re-applying the hook Job).
+#
+# Side effect: chart used to render `argocd-secret` with `data: {}`.
+# Every reconcile of the `argocd` Application then ServerSideApply-
+# overwrote `/data` to empty, wiping `server.secretkey`. argocd-server
+# could no longer sign session tokens — Unauthorized watches, UI 401s.
+#
+# Fix (v0.28.3, paired with `configs.secret.createSecret = false` in
+# core/components/argocd/values.yaml): terraform owns the Secret
+# end-to-end. The chart no longer creates it, so the SSA wipe vector
+# is eliminated at the source. ArgoCD's `argocd` Application also has
+# `ignoreDifferences` on Secret/argocd-secret/data as defense in depth.
+#
+# Rotation: change `random_password.argocd_secretkey.keepers` to
+# trigger regeneration. argocd-server picks up the new key on the
+# next pod restart.
+# =============================================================================
+
+resource "random_password" "argocd_secretkey" {
+  length  = 32
+  special = false # base64-safe alphanumeric
+
+  keepers = {
+    cluster_name = local.cluster_name
+  }
+}
+
+resource "kubernetes_secret" "argocd_secret" {
+  count = var.platform_outputs_enabled ? 1 : 0
+
+  metadata {
+    name      = "argocd-secret"
+    namespace = kubernetes_namespace.argocd[0].metadata[0].name
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/part-of"    = "estabilis-platform"
+      "app.kubernetes.io/name"       = "argocd-secret"
+    }
+  }
+
+  type = "Opaque"
+
+  data = {
+    "server.secretkey" = random_password.argocd_secretkey.result
+  }
+
+  # The argocd-server pod (and operators using the UI) may write
+  # additional fields here over time (e.g. admin.password, dex.* OIDC
+  # secrets, repository creds when the user adds them via UI). Don't
+  # fight that — terraform owns server.secretkey only; everything else
+  # stays under whichever field manager wrote it.
+  lifecycle {
+    ignore_changes = [
+      data["admin.password"],
+      data["admin.passwordMtime"],
+      data["webhook.github.secret"],
+      data["webhook.gitlab.secret"],
+      data["webhook.bitbucketserver.secret"],
+      data["webhook.bitbucket.uuid"],
+      data["webhook.gogs.secret"],
+      data["webhook.azuredevops.username"],
+      data["webhook.azuredevops.password"],
+      data["dex.github.clientSecret"],
+      data["dex.gitlab.clientSecret"],
+    ]
+  }
+}

--- a/providers/azure/argocd-secret.tf
+++ b/providers/azure/argocd-secret.tf
@@ -1,0 +1,57 @@
+# =============================================================================
+# argocd-secret — terraform-owned (foundation v0.28.3 fix, Azure mirror)
+# =============================================================================
+# See providers/aws/argocd-secret.tf for the full postmortem + fix
+# rationale. Same problem on AKS — the argo-cd chart's empty
+# `argocd-secret` would be re-applied on every self-sync, wiping
+# server.secretkey.
+#
+# Fix (v0.28.3, paired with `configs.secret.createSecret = false` in
+# core/components/argocd/values.yaml): terraform owns the Secret
+# end-to-end.
+# =============================================================================
+
+resource "random_password" "argocd_secretkey" {
+  length  = 32
+  special = false
+
+  keepers = {
+    cluster_name = azurerm_kubernetes_cluster.platform.name
+  }
+}
+
+resource "kubernetes_secret" "argocd_secret" {
+  count = var.platform_outputs_enabled ? 1 : 0
+
+  metadata {
+    name      = "argocd-secret"
+    namespace = kubernetes_namespace.argocd[0].metadata[0].name
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/part-of"    = "estabilis-platform"
+      "app.kubernetes.io/name"       = "argocd-secret"
+    }
+  }
+
+  type = "Opaque"
+
+  data = {
+    "server.secretkey" = random_password.argocd_secretkey.result
+  }
+
+  lifecycle {
+    ignore_changes = [
+      data["admin.password"],
+      data["admin.passwordMtime"],
+      data["webhook.github.secret"],
+      data["webhook.gitlab.secret"],
+      data["webhook.bitbucketserver.secret"],
+      data["webhook.bitbucket.uuid"],
+      data["webhook.gogs.secret"],
+      data["webhook.azuredevops.username"],
+      data["webhook.azuredevops.password"],
+      data["dex.github.clientSecret"],
+      data["dex.gitlab.clientSecret"],
+    ]
+  }
+}


### PR DESCRIPTION
Root-cause fix for the recurring `server.secretkey is missing` loop. Live observation on cortex: argocd-secret would populate after fresh helm install, then drop to empty data on first ArgoCD self-sync, repeating every reconcile.

## Root cause

`redisSecretInit.enabled: false` in core/components/argocd/values.yaml (intentional — hook deadlocks self-manage sync) left the chart rendering `argocd-secret` with `data: {}`. Self-managed `argocd` App ServerSideApply'd that empty manifest each reconcile, wiping `/data`.

## Fix (defense in depth)

1. `core/components/argocd/values.yaml`: `configs.secret.createSecret = false` — chart skips Secret entirely.
2. `providers/{aws,azure}/argocd-secret.tf` (NEW): terraform generates server.secretkey via random_password + creates Secret directly. Lifecycle ignores admin.password / webhook.* / dex.* fields so other field managers can write those.
3. `bootstrap/platform-root/templates/argocd.yaml`: ignoreDifferences for Secret/argocd-secret/data — defense in depth.

## Test plan

- [x] helm template renders argocd App with new ignoreDifferences entry
- [ ] Fresh terraform apply on a clean cluster: argocd-secret created with server.secretkey populated; no 'secretkey is missing' warning in argocd-server logs
- [ ] On existing cluster (cortex): bump to v0.28.3, terraform apply takes ownership; server.secretkey persists across argocd App reconciles
- [ ] Operator-set fields (admin.password) preserved via lifecycle ignore_changes