### PR TITLE
fix(vault): ignoreDifferences for StatefulSet volumeClaimTemplates drift (v0.28.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## [0.28.3] - 2026-04-25
+
+### Fixed — Permanent OutOfSync on Vault `StatefulSet` (volumeClaimTemplates drift)
+
+ArgoCD reported persistent drift on `apps/StatefulSet/vault/vault` even
+on a fresh deploy where Vault was Healthy and Running. Root cause:
+known ArgoCD diff quirk with StatefulSet `volumeClaimTemplates`.
+
+Kubernetes API server **normalizes** templates on creation by adding
+`apiVersion: v1` and `kind: PersistentVolumeClaim` (the default for
+embedded resources without explicit version/kind). The Vault helm
+chart renders the templates without these (they're inherited from
+the PodSpec context). ArgoCD's diff then sees the api-server-added
+fields as drift — every reconcile reports OutOfSync.
+
+#### Fix
+
+`bootstrap/platform-root/templates/vault.yaml` gains an
+`ignoreDifferences` block scoped to the StatefulSet:
+
+```yaml
+ignoreDifferences:
+  - group: apps
+    kind: StatefulSet
+    name: vault
+    namespace: vault
+    jqPathExpressions:
+      - .spec.volumeClaimTemplates[]?.apiVersion
+      - .spec.volumeClaimTemplates[]?.kind
+```
+
+Cosmetic-only — does not affect PVC binding, Raft data persistence,
+or auto-unseal. Eliminates a permanent OutOfSync that operators
+otherwise had to chase down on every cluster.
+
+### Migration
+
+For all v0.28.0+ clusters with Vault enabled:
+
+1. Bump `ref` and `platform_revision` to `v0.28.3`.
+2. `terraform init -upgrade && terraform apply` — no infrastructure
+   changes (template-only).
+3. `estabilis promote <client> -d <deployment> --force-refresh` —
+   re-renders the Vault Application with the new `ignoreDifferences`.
+4. The Vault Application transitions from `OutOfSync (cosmetic)` to
+   `Synced` without any pod restart or data movement.
+
+For deployments without Vault (`vault_enabled = false`): no-op.
+
 ## [0.28.2] - 2026-04-25
 
 ### Added — `vault-ingress` chart (consumes `vault_exposures` dynamically)

--- a/bootstrap/platform-root/templates/vault.yaml
+++ b/bootstrap/platform-root/templates/vault.yaml
@@ -150,6 +150,21 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: vault
+  ignoreDifferences:
+    {{- /* StatefulSet volumeClaimTemplates drift — known ArgoCD quirk.
+           Kubernetes API server normalizes templates by adding
+           `apiVersion: v1` + `kind: PersistentVolumeClaim` (default
+           apiVersion of the Pod template). The chart-rendered manifest
+           omits these (they're inherited), so ArgoCD's diff sees the
+           api-server-added fields as drift. Cosmetic — does not affect
+           PVC binding or Vault Raft data persistence. */}}
+    - group: apps
+      kind: StatefulSet
+      name: vault
+      namespace: vault
+      jqPathExpressions:
+        - .spec.volumeClaimTemplates[]?.apiVersion
+        - .spec.volumeClaimTemplates[]?.kind
   syncPolicy:
     {{- include "platform-root.managedNamespaceMetadataExcluded" . | nindent 4 }}
     retry:


### PR DESCRIPTION
Fixes a permanent OutOfSync on `apps/StatefulSet/vault/vault` that affects every cluster with Vault enabled.

## Root cause

Kubernetes API server normalizes `StatefulSet.spec.volumeClaimTemplates` on creation by adding `apiVersion: v1` + `kind: PersistentVolumeClaim` (defaults for embedded PVC resources). The Vault Helm chart renders templates without these (inherited from PodSpec context), so ArgoCD's three-way diff sees them as drift on every reconcile.

Cosmetic-only — does not affect PVC binding, Raft data persistence, or auto-unseal.

## Fix

`bootstrap/platform-root/templates/vault.yaml` gains an `ignoreDifferences` block scoped to the vault StatefulSet:

```yaml
ignoreDifferences:
  - group: apps
    kind: StatefulSet
    name: vault
    namespace: vault
    jqPathExpressions:
      - .spec.volumeClaimTemplates[]?.apiVersion
      - .spec.volumeClaimTemplates[]?.kind
```

Validated via `helm template` — Application renders the block correctly.

## Test plan

- [x] helm template renders the ignoreDifferences correctly
- [ ] After v0.28.3 deploy on cortex (already manually patched live), the App spec converges with upstream — drift disappears as Synced/Healthy