### PR TITLE
feat(replacement-safety): flexibility-first rails for force_new resources (v0.29.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,93 @@
 # Changelog
 
+## [0.29.0] - 2026-04-26
+
+### Added — Replacement-safety rails for force_new resources
+
+Audit triggered by a real `409 ResourceInUseException` hit on cortex when
+bumping `mng_instance_types` + `mng_capacity_type`. Root cause: the
+`terraform-aws-modules/eks` submodule hardcodes
+`lifecycle { create_before_destroy = true }` on `aws_eks_node_group`, and
+the explicit NG name (forced by IAM 38-char prefix budget) collides with
+itself on any force_new field.
+
+Audit found 3 other recurrence-prone spots: vault backup S3 bucket
+(global namespace + 60-90 day retention), cluster encryption flip
+(one-way at AWS API), Karpenter IAM roles (collision risk for short
+cluster names in shared accounts).
+
+This release ships **flexibility-first** rails: defaults preserve current
+behavior, opt-ins enable safer modes, plan-time preconditions catch
+foot-guns before apply.
+
+#### New variables
+
+- **`mng_replacement_strategy`** — `"static"` (default) | `"rolling"`.
+  - `static`: NG name `<cluster>-default` (backward-compat). Force_new
+    changes (instance_types/capacity_type/ami_type/disk_size) require
+    `terraform destroy -target` before `terraform apply`.
+  - `rolling`: NG name `<cluster>-default-gen<mng_generation>`.
+    Force_new changes are made by bumping `mng_generation` in the same
+    apply — `create_before_destroy` provisions the new NG before
+    draining the old. Zero-downtime when other compute (Karpenter,
+    additional NGs) is present to absorb workloads.
+
+- **`mng_generation`** — integer >= 1 (default `1`). Suffix bumped to
+  trigger zero-downtime rollover when `mng_replacement_strategy='rolling'`.
+  Ignored on `static`.
+
+- **`vault_backup_bucket_naming`** — `"static"` (default) | `"random_suffix"`.
+  - `static`: bucket `<cluster>-vault-backup` (backward-compat).
+  - `random_suffix`: bucket `<cluster>-vault-<suffix>`, consistent with
+    the other 6 platform buckets, avoiding S3 global-namespace 60-90 day
+    retention conflicts on teardown+recreate.
+
+#### New plan-time preconditions
+
+- `terraform_data.mng_size_guard` — fails plan when
+  `mng_min_size > mng_desired_size` or `mng_desired_size > mng_max_size`.
+  Caught at plan, not apply.
+- `terraform_data.karpenter_naming_guard` — fails plan when
+  `length(cluster_name) < 8` and Karpenter is enabled, preventing IAM
+  role name collisions across deployments in the same AWS account.
+
+#### New variable validations
+
+- `mng_min_size >= 0`, `mng_desired_size >= 0`, `mng_max_size >= 1`.
+
+#### Documentation hardening
+
+- `cluster_secrets_encryption_enabled` description now flags the
+  one-way nature of EKS encryption_config: flipping `true → false` on a
+  running cluster forces full cluster destroy/recreate at the AWS API
+  level. Treat as immutable once enabled.
+- All MNG variables that force NG recreation
+  (`mng_instance_types`, `mng_capacity_type`, `mng_disk_size_gb`,
+  `mng_ami_type`) now have `REPLACEMENT NOTE` blocks pointing at
+  `mng_replacement_strategy`.
+
+#### Migration
+
+All changes are backward-compatible. Existing deployments behave
+identically with no tfvars changes:
+
+- MNG keeps name `<cluster>-default` (because `mng_replacement_strategy`
+  defaults to `"static"`).
+- Vault backup bucket keeps name `<cluster>-vault-backup` (because
+  `vault_backup_bucket_naming` defaults to `"static"`).
+- Encryption variable description is doc-only.
+
+To opt into safer behavior on an existing cluster:
+
+- Switching `mng_replacement_strategy` `static → rolling` IS a force_new
+  event on the NG `name` (it gains `-gen1` suffix). The module's
+  `create_before_destroy` makes this safe (zero-downtime), but it IS a
+  real replacement window. Plan accordingly.
+- Switching `vault_backup_bucket_naming` `static → random_suffix` forces
+  destroy+create of the bucket. Snapshot history is lost. Only do this
+  on clusters where vault backup history is acceptable to lose, or
+  manually copy snapshots first.
+
 ## [0.28.3] - 2026-04-26
 
 ### Changed — Move `vault-ingress` chart to `estabilis-platform-gitops` (ADR 0002 Phase 2)

--- a/providers/aws/eks.tf
+++ b/providers/aws/eks.tf
@@ -83,6 +83,22 @@ locals {
     },
   )
 
+  # MNG name + IAM role name selection per replacement strategy.
+  # See var.mng_replacement_strategy + var.mng_generation for full rationale.
+  # 'static' preserves historical names (`<cluster>-default`) for
+  # backward-compat with existing deployments. 'rolling' suffixes the
+  # generation so force_new changes can roll over via create_before_destroy.
+  mng_default_name = var.mng_replacement_strategy == "rolling" ? (
+    "${local.cluster_name}-default-gen${var.mng_generation}"
+    ) : (
+    "${local.cluster_name}-default"
+  )
+  mng_default_iam_role_name = var.mng_replacement_strategy == "rolling" ? (
+    "${local.cluster_name}-default-node-gen${var.mng_generation}"
+    ) : (
+    "${local.cluster_name}-default-node"
+  )
+
   # Access entries converted from our flat variable shape to the module shape.
   eks_access_entries_map = {
     for idx, entry in var.eks_access_entries : "entry_${idx}" => {
@@ -97,6 +113,26 @@ locals {
           }
         }
       } : {}
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Validation rail: MNG size ordering (min <= desired <= max).
+# Variable-level validation can't express cross-variable relations, so this
+# precondition runs at plan time and fails loud if the operator inverts
+# the relationship.
+# ---------------------------------------------------------------------------
+
+resource "terraform_data" "mng_size_guard" {
+  count = contains(["cluster_autoscaler", "hybrid"], var.autoscaler) ? 1 : 0
+
+  input = "${var.mng_min_size}-${var.mng_desired_size}-${var.mng_max_size}"
+
+  lifecycle {
+    precondition {
+      condition     = var.mng_min_size <= var.mng_desired_size && var.mng_desired_size <= var.mng_max_size
+      error_message = "MNG size ordering invalid: requires mng_min_size <= mng_desired_size <= mng_max_size. Got min=${var.mng_min_size}, desired=${var.mng_desired_size}, max=${var.mng_max_size}."
     }
   }
 }
@@ -184,9 +220,14 @@ module "eks" {
   #   - 'hybrid': MNG hosts platform control-plane; Karpenter layers on
   #     top for workloads
   # Skipped for 'karpenter' (Karpenter-only) and 'none' (BYO).
+  #
+  # Naming strategy: see var.mng_replacement_strategy. 'static' keeps
+  # the historical name `<cluster>-default` (force_new changes require
+  # manual destroy before apply). 'rolling' suffixes `-gen<N>` so that
+  # force_new changes can roll over with zero downtime via create_before_destroy.
   eks_managed_node_groups = contains(["cluster_autoscaler", "hybrid"], var.autoscaler) ? {
     default = {
-      name           = "${local.cluster_name}-default"
+      name           = local.mng_default_name
       instance_types = var.mng_instance_types
       capacity_type  = var.mng_capacity_type
       min_size       = var.mng_min_size
@@ -213,7 +254,7 @@ module "eks" {
       # additional MNGs colliding-free.
       use_name_prefix          = false
       iam_role_use_name_prefix = false
-      iam_role_name            = "${local.cluster_name}-default-node"
+      iam_role_name            = local.mng_default_iam_role_name
 
       # Attach the EKS cluster primary security group to the MNG nodes.
       # Without this, the MNG ENIs only receive the module's node

--- a/providers/aws/karpenter.tf
+++ b/providers/aws/karpenter.tf
@@ -58,6 +58,25 @@ module "karpenter" {
   }
 }
 
+# Validation rail: cluster_name length must be enough to keep Karpenter IAM
+# role names (`Karpenter-<cluster>` / `KarpenterNode-<cluster>`) unique
+# across deployments in the same AWS account. Without this rail, two
+# deployments with very short or identical cluster_name prefixes would
+# silently collide on the IAM role names — a foot-gun discovered when
+# auditing replacement collisions.
+resource "terraform_data" "karpenter_naming_guard" {
+  count = contains(["karpenter", "hybrid"], var.autoscaler) ? 1 : 0
+
+  input = local.cluster_name
+
+  lifecycle {
+    precondition {
+      condition     = length(local.cluster_name) >= 8
+      error_message = "cluster_name must be >= 8 chars when Karpenter is enabled, to keep IAM role names (`Karpenter-<cluster>` / `KarpenterNode-<cluster>`) unique across deployments in the same AWS account. Current length: ${length(local.cluster_name)}."
+    }
+  }
+}
+
 # Allow Karpenter controller to garbage-collect orphaned instance profiles.
 resource "aws_iam_role_policy" "karpenter_instance_profile_gc" {
   count = contains(["karpenter", "hybrid"], var.autoscaler) ? 1 : 0

--- a/providers/aws/variables.tf
+++ b/providers/aws/variables.tf
@@ -211,7 +211,21 @@ variable "cluster_log_retention_days" {
 }
 
 variable "cluster_secrets_encryption_enabled" {
-  description = "Enable EKS envelope encryption for Kubernetes Secrets using a customer-managed KMS key."
+  description = <<-EOT
+    Enable EKS envelope encryption for Kubernetes Secrets using a
+    customer-managed KMS key.
+
+    !!! IRREVERSIBLE WARNING !!!
+    EKS encryption_config is ONE-WAY (add-only) at the AWS API level.
+      - false -> true on a running cluster: in-place update via UpdateClusterConfig.
+      - true  -> false on a running cluster: NOT supported by AWS. Terraform will
+        plan a full cluster destroy + recreate, which deletes EVERYTHING
+        (worker nodes, EBS volumes, EKS API endpoint, ENIs, etc.).
+
+    Default true. Once enabled in production, treat as immutable. If you
+    must remove encryption, plan a full cluster migration (new cluster +
+    velero restore), not a flip of this variable.
+  EOT
   type        = bool
   default     = true
 }
@@ -296,13 +310,30 @@ variable "autoscaler" {
 # --- Managed Node Group (only used when autoscaler = "cluster_autoscaler") ---
 
 variable "mng_instance_types" {
-  description = "EC2 instance types for the managed node group (cluster_autoscaler mode). First matching type is used; extras provide capacity fallback."
+  description = <<-EOT
+    EC2 instance types for the managed node group. First matching type is
+    used; extras provide capacity fallback (especially valuable for SPOT
+    capacity-optimized allocation).
+
+    REPLACEMENT NOTE: changing this on a running cluster forces NG
+    recreation. The behavior depends on `mng_replacement_strategy`:
+      - 'static' (default): collides with itself on the explicit name
+        (HTTP 409 ResourceInUseException). Operator must
+        `terraform destroy -target=...eks_managed_node_group["default"]`
+        before `terraform apply`.
+      - 'rolling': bump `mng_generation` in the same change to swap to a
+        new NG name; create_before_destroy gives zero-downtime rollover.
+  EOT
   type        = list(string)
   default     = ["t3a.medium", "t3.medium"]
 }
 
 variable "mng_capacity_type" {
-  description = "Capacity type for the managed node group: ON_DEMAND or SPOT."
+  description = <<-EOT
+    Capacity type for the managed node group: ON_DEMAND or SPOT.
+    REPLACEMENT NOTE: same as mng_instance_types — changing forces NG
+    recreation. See `mng_replacement_strategy` to control rollover.
+  EOT
   type        = string
   default     = "ON_DEMAND"
 
@@ -316,30 +347,129 @@ variable "mng_min_size" {
   description = "Minimum number of nodes in the managed node group."
   type        = number
   default     = 2
+
+  validation {
+    condition     = var.mng_min_size >= 0
+    error_message = "mng_min_size must be >= 0."
+  }
 }
 
 variable "mng_max_size" {
   description = "Maximum number of nodes in the managed node group."
   type        = number
   default     = 4
+
+  validation {
+    condition     = var.mng_max_size >= 1
+    error_message = "mng_max_size must be >= 1."
+  }
 }
 
 variable "mng_desired_size" {
   description = "Desired (initial) number of nodes in the managed node group."
   type        = number
   default     = 2
+
+  validation {
+    condition     = var.mng_desired_size >= 0
+    error_message = "mng_desired_size must be >= 0."
+  }
 }
 
 variable "mng_disk_size_gb" {
-  description = "Root EBS volume size (GB) for the managed node group."
+  description = <<-EOT
+    Root EBS volume size (GB) for the managed node group.
+    REPLACEMENT NOTE: changing forces NG recreation.
+    See `mng_replacement_strategy`.
+  EOT
   type        = number
   default     = 50
 }
 
 variable "mng_ami_type" {
-  description = "AMI type for the managed node group. AL2023_x86_64_STANDARD is the current AWS default."
+  description = <<-EOT
+    AMI type for the managed node group. AL2023_x86_64_STANDARD is the
+    current AWS default.
+    REPLACEMENT NOTE: changing forces NG recreation.
+    See `mng_replacement_strategy`.
+  EOT
   type        = string
   default     = "AL2023_x86_64_STANDARD"
+}
+
+# --- MNG replacement strategy (force_new safety rails) -----------------------
+#
+# Why this exists: aws_eks_node_group has multiple force_new fields
+# (instance_types, capacity_type, ami_type, disk_size). The upstream
+# terraform-aws-modules/eks module hardcodes lifecycle.create_before_destroy
+# on the resource — combined with the explicit NG name we are forced to use
+# (IAM role 38-char prefix budget overflow on long cluster names), any
+# force_new change collides with itself on the name, failing apply with
+# `409 ResourceInUseException: NodeGroup already exists`.
+#
+# This pair of variables exposes two strategies for handling that:
+#
+#   - 'static' (default, backward-compat): NG name is `<cluster>-default`.
+#     On force_new changes, operator runs `terraform destroy -target` first.
+#     Workload migrates to Karpenter / other compute during the drain.
+#
+#   - 'rolling': NG name includes `-gen<mng_generation>`. To trigger a
+#     replacement, operator bumps mng_generation in the SAME change. The
+#     module's create_before_destroy provisions the new NG before draining
+#     the old, giving zero-downtime rollover.
+#
+# Defaults preserve current behavior; new clusters can opt into 'rolling'
+# from day 1 for safer instance-type / capacity changes.
+# ---------------------------------------------------------------------------
+
+variable "mng_replacement_strategy" {
+  description = <<-EOT
+    How the module handles force_new changes on the managed node group
+    (instance_types, capacity_type, ami_type, disk_size).
+
+    - 'static' (default): NG name is `<cluster>-default`. Backward-compat
+      with deployments that already exist. Force_new changes require
+      `terraform destroy -target` on the NG before `terraform apply`,
+      because the module's create_before_destroy collides with itself
+      on the explicit name.
+
+    - 'rolling': NG name is `<cluster>-default-gen<mng_generation>`.
+      Force_new changes are made by bumping `mng_generation` in the same
+      apply: a new NG comes up with the new name, then the old one
+      drains+destroys via the module's create_before_destroy. Zero-downtime
+      rollover. Recommended for clusters that have other compute (Karpenter,
+      additional NGs) able to absorb workloads during the brief window
+      where both NGs coexist.
+
+    SWITCHING FROM static -> rolling: the NG itself is renamed, which is
+    a force_new event on `name`. The module's create_before_destroy makes
+    this safe (zero-downtime), but it IS a real replacement.
+  EOT
+  type        = string
+  default     = "static"
+
+  validation {
+    condition     = contains(["static", "rolling"], var.mng_replacement_strategy)
+    error_message = "mng_replacement_strategy must be 'static' or 'rolling'."
+  }
+}
+
+variable "mng_generation" {
+  description = <<-EOT
+    Generation suffix appended to the MNG name when
+    mng_replacement_strategy='rolling'. Bump this integer in the same
+    `terraform apply` that changes a force_new field (instance_types,
+    capacity_type, ami_type, disk_size) to trigger zero-downtime rollover.
+
+    Ignored when mng_replacement_strategy='static'.
+  EOT
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.mng_generation >= 1
+    error_message = "mng_generation must be >= 1."
+  }
 }
 
 # --- Karpenter (only used when autoscaler = "karpenter") ---
@@ -1206,6 +1336,33 @@ variable "vault_backup_retention_days" {
   description = "Days to retain Raft snapshot backups in S3. The CronJob that uploads snapshots is deferred to a follow-up release; the bucket + lifecycle is provisioned here so future enablement needs no IAM change."
   type        = number
   default     = 30
+}
+
+variable "vault_backup_bucket_naming" {
+  description = <<-EOT
+    Naming strategy for the Vault Raft snapshot backup S3 bucket.
+
+    - 'static' (default): bucket name is `<cluster>-vault-backup`. Backward-
+      compat with existing deployments. Risk: if the bucket is destroyed
+      (toggle vault_enabled false → true) within the AWS S3 60-90 day
+      name retention window, recreating with the same name fails.
+
+    - 'random_suffix': bucket name is `<cluster>-vault-<random_suffix>`,
+      consistent with the other 6 platform buckets (observability, velero,
+      cnpg, tfstate, flow_logs, cur). Avoids the global-namespace retention
+      trap on teardown+recreate cycles.
+
+    SWITCHING FROM static -> random_suffix on a cluster that already has
+    Vault data: the bucket name changes, which forces destroy+create.
+    Snapshot history is lost. Plan accordingly.
+  EOT
+  type        = string
+  default     = "static"
+
+  validation {
+    condition     = contains(["static", "random_suffix"], var.vault_backup_bucket_naming)
+    error_message = "vault_backup_bucket_naming must be 'static' or 'random_suffix'."
+  }
 }
 
 variable "vault_kms_deletion_window_days" {

--- a/providers/aws/vault.tf
+++ b/providers/aws/vault.tf
@@ -47,10 +47,22 @@ resource "aws_kms_alias" "vault" {
 
 # --- S3 bucket for Raft snapshot backups ---
 
+locals {
+  # Bucket name selection per var.vault_backup_bucket_naming. 'static'
+  # preserves historical name; 'random_suffix' aligns with the other
+  # platform buckets and avoids S3 global-namespace retention conflicts
+  # on teardown+recreate cycles.
+  vault_backup_bucket_name = var.vault_backup_bucket_naming == "random_suffix" ? (
+    "${local.cluster_name}-vault-${random_string.bucket_suffix.result}"
+    ) : (
+    "${local.cluster_name}-vault-backup"
+  )
+}
+
 resource "aws_s3_bucket" "vault_backup" {
   count = var.vault_enabled ? 1 : 0
 
-  bucket        = "${local.cluster_name}-vault-backup"
+  bucket        = local.vault_backup_bucket_name
   force_destroy = true
 }
 


### PR DESCRIPTION
## Summary

Adds opt-in safety rails for resources prone to `force_new` collisions, after a real `409 ResourceInUseException` hit on cortex when bumping `mng_instance_types` + `mng_capacity_type`. Defaults preserve current behavior; new modes enable safer rollover.

## Audit findings

| Resource | Risk | Mitigation in this PR |
|---|---|---|
| `aws_eks_node_group` | Explicit name + force_new fields + module's hardcoded create_before_destroy → 409 collision (HIT TODAY) | `mng_replacement_strategy` + `mng_generation` |
| `aws_s3_bucket` vault_backup | Global namespace + 60-90 day retention on teardown+recreate | `vault_backup_bucket_naming` |
| `aws_eks_cluster` encryption_config | One-way at AWS API; flip true→false destroys cluster | Variable description warning |
| Karpenter IAM roles | Short cluster_name → collision across deployments | precondition: cluster_name >= 8 |

## Changes

### New variables (backward-compatible)

- `mng_replacement_strategy` — `"static"` (default) | `"rolling"`
- `mng_generation` — integer >= 1, default `1`
- `vault_backup_bucket_naming` — `"static"` (default) | `"random_suffix"`

### New plan-time preconditions

- `terraform_data.mng_size_guard` — fails plan when `min > desired || desired > max`
- `terraform_data.karpenter_naming_guard` — fails plan when `length(cluster_name) < 8` AND Karpenter enabled

### New variable validations

- `mng_min_size >= 0`, `mng_desired_size >= 0`, `mng_max_size >= 1`

### Documentation

- All MNG force_new vars get `REPLACEMENT NOTE` blocks
- `cluster_secrets_encryption_enabled` flags irreversibility

## Test plan

- [x] `terraform fmt -recursive` clean
- [x] `terraform validate` Success
- [ ] Verified backward-compat on cortex (next: rebase + retry the original `mng_instance_types`/`mng_capacity_type` apply with strategy=static path; pre-destroy still required)
- [ ] Roll cortex onto `mng_replacement_strategy=rolling` in a follow-up to validate the zero-downtime path

## Migration

All existing deployments behave identically with no tfvars change. Opt-ins are documented in the CHANGELOG with replacement-window expectations.