### PR TITLE
feat(ecr): split repo ownership + pull-through cache defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog
 
+## [0.31.0] - 2026-04-26
+
+### Changed — ECR ownership model + pull-through cache defaults
+
+Splits ECR responsibility between platform-declarative repos and
+CI-owned workload repos, and gives pull-through cache usable defaults.
+
+#### Ownership model
+
+- `var.ecr_repositories` is now scoped to **platform-managed** repos
+  only — CLI-published addons (workload-operator image, chart). The
+  variable description is updated to call this out.
+- **Workload application repos no longer go in TF.** CI pipelines
+  create them on first `docker push` via the OIDC IAM role (added in a
+  follow-up). Forcing every workload onboarding through `terraform
+  apply` was the friction this split removes.
+- No variables removed. Existing operators keep working; updated
+  descriptions document the boundary.
+
+#### Pull-through cache
+
+- New resource `aws_ecr_repository_creation_template.pull_through_cache`
+  applied with `applied_for = ["PULL_THROUGH_CACHE"]` so cache-created
+  repos inherit KMS encryption + lifecycle policy. Without it, AWS
+  defaults apply (AES256, no lifecycle).
+- `var.ecr_pull_through_cache_upstreams` left empty with
+  `ecr_pull_through_cache_enabled = true` now activates a default
+  anonymous public set: `ghcr`, `quay`, `k8s`, `public-ecr`. Override
+  to add `docker-hub` (still requires
+  `ecr_dockerhub_credentials_secret_arn` to bypass anonymous rate
+  limits).
+
+#### Output
+
+- New output `ecr_pull_through_cache_prefixes` — map of prefix to
+  upstream URL. Use it to construct cached image refs like
+  `<registry>/k8s/coredns/coredns:v1.11.1`.
+
+#### Files changed
+
+- `providers/aws/ecr.tf` — full rewrite: locals + creation template.
+- `providers/aws/variables.tf` — descriptions updated for
+  `ecr_repositories`, `ecr_pull_through_cache_enabled`,
+  `ecr_pull_through_cache_upstreams`.
+- `providers/aws/outputs.tf` — new `ecr_pull_through_cache_prefixes`.
+- `providers/aws/platform-outputs.tf` — `global.ecrRegistry` now
+  follows `ecr_enabled` only (was guarded by non-empty
+  `ecr_repositories`, which excluded PT-cache-only deployments).
+- `providers/aws/terraform.tfvars.example` — comments updated.
+
+#### Operator notes
+
+- No state mutations on existing repos. Apply is additive: PT-cache
+  operators see 4 new pull-through cache rules + 4 creation templates
+  on first apply when leaving the upstreams map empty.
+- Operators using `ecr_repositories` for workload apps should remove
+  those entries; existing repos remain in AWS but become unmanaged
+  (lifecycle/scan settings stay as last applied).
+
 ## [0.30.0] - 2026-04-26
 
 ### Added — Single source of truth for module version (`VERSION` file)

--- a/providers/aws/ecr.tf
+++ b/providers/aws/ecr.tf
@@ -1,13 +1,68 @@
 # ---------------------------------------------------------------------------
-# ECR (Elastic Container Registry) — optional.
+# ECR (Elastic Container Registry)
 #
-# Provisions:
-#   - Per-repository with scan-on-push + immutable tags + lifecycle policy
-#   - Optional pull-through cache rules for public upstream registries
-#     (Docker Hub, Quay, GHCR, k8s.io, public ECR)
+# Two ownership models, distinct on purpose:
 #
-# CI/CD push automation (IAM role for pipelines) is intentionally out of
-# scope for Phase 1.
+#   1. Platform-managed repos (`var.ecr_repositories`) — declarative.
+#      For repositories the platform itself publishes (CLI addons such as
+#      the workload-operator image and chart). Lifecycle, scan-on-push,
+#      immutability and KMS are enforced by Terraform; drift is detectable.
+#
+#   2. Workload application repos — CI-owned, auto-created on push.
+#      Application images do NOT belong in `var.ecr_repositories`. The CI
+#      pipeline (via the OIDC IAM role with `ecr:CreateRepository`) creates
+#      the repo on first `docker push`. Adding every workload app to TF
+#      would force a `terraform apply` on every onboarding.
+#
+#   3. Pull-through cache repos — auto-created by ECR on first pull.
+#      `aws_ecr_repository_creation_template.pull_through_cache` aligns
+#      cache-created repos with platform defaults (KMS + lifecycle).
+#      Without it, AWS uses AES256 and no lifecycle.
+#
+# CI/CD push role (OIDC trust + IAM policy) is added in a follow-up.
+# ---------------------------------------------------------------------------
+
+locals {
+  # Anonymous public upstreams applied when pull-through cache is enabled
+  # but `var.ecr_pull_through_cache_upstreams` is left empty. Docker Hub is
+  # opt-in (requires `ecr_dockerhub_credentials_secret_arn` to avoid the
+  # 100-pulls/6h anonymous rate limit).
+  ecr_default_pt_cache_upstreams = {
+    ghcr       = "ghcr.io"
+    quay       = "quay.io"
+    k8s        = "registry.k8s.io"
+    public-ecr = "public.ecr.aws"
+  }
+
+  ecr_pt_cache_upstreams = (
+    var.ecr_enabled && var.ecr_pull_through_cache_enabled
+    ? (length(var.ecr_pull_through_cache_upstreams) > 0
+      ? var.ecr_pull_through_cache_upstreams
+    : local.ecr_default_pt_cache_upstreams)
+    : {}
+  )
+
+  ecr_lifecycle_policy_json = var.ecr_lifecycle_untagged_days > 0 ? jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Delete untagged images after ${var.ecr_lifecycle_untagged_days} days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = var.ecr_lifecycle_untagged_days
+        }
+        action = {
+          type = "expire"
+        }
+      },
+    ]
+  }) : null
+}
+
+# ---------------------------------------------------------------------------
+# Platform-managed repositories (CLI addons, declarative)
 # ---------------------------------------------------------------------------
 
 resource "aws_ecr_repository" "this" {
@@ -30,37 +85,46 @@ resource "aws_ecr_lifecycle_policy" "this" {
   for_each = var.ecr_enabled && var.ecr_lifecycle_untagged_days > 0 ? toset(var.ecr_repositories) : toset([])
 
   repository = aws_ecr_repository.this[each.value].name
-
-  policy = jsonencode({
-    rules = [
-      {
-        rulePriority = 1
-        description  = "Delete untagged images after ${var.ecr_lifecycle_untagged_days} days"
-        selection = {
-          tagStatus   = "untagged"
-          countType   = "sinceImagePushed"
-          countUnit   = "days"
-          countNumber = var.ecr_lifecycle_untagged_days
-        }
-        action = {
-          type = "expire"
-        }
-      },
-    ]
-  })
+  policy     = local.ecr_lifecycle_policy_json
 }
 
 # ---------------------------------------------------------------------------
-# Pull-through cache
+# Pull-through cache rules
 # ---------------------------------------------------------------------------
 
 resource "aws_ecr_pull_through_cache_rule" "this" {
-  for_each = var.ecr_enabled && var.ecr_pull_through_cache_enabled ? var.ecr_pull_through_cache_upstreams : {}
+  for_each = local.ecr_pt_cache_upstreams
 
   ecr_repository_prefix = each.key
   upstream_registry_url = each.value
 
-  # Docker Hub authenticated cache requires a Secrets Manager ARN. Other
-  # upstreams (quay, ghcr, k8s, public-ecr) are anonymous.
+  # Only the docker-hub upstream supports authenticated pulls. Passing a
+  # credential ARN to anonymous upstreams (ghcr, quay, k8s, public-ecr)
+  # would error.
   credential_arn = each.key == "docker-hub" && length(var.ecr_dockerhub_credentials_secret_arn) > 0 ? var.ecr_dockerhub_credentials_secret_arn : null
+}
+
+# ---------------------------------------------------------------------------
+# Repository creation templates — applied when ECR auto-creates a repo for
+# pull-through cache. `applied_for` is scoped to PULL_THROUGH_CACHE only;
+# operator/CI `docker push` does NOT trigger the template.
+# ---------------------------------------------------------------------------
+
+resource "aws_ecr_repository_creation_template" "pull_through_cache" {
+  for_each = local.ecr_pt_cache_upstreams
+
+  prefix      = each.key
+  description = "KMS + lifecycle for repos under '${each.key}/' created by pull-through cache."
+  applied_for = ["PULL_THROUGH_CACHE"]
+
+  # MUTABLE: upstream tags (`:stable`, `:latest`) move; an IMMUTABLE cached
+  # repo would refuse re-pulls when the upstream tag is updated.
+  image_tag_mutability = "MUTABLE"
+
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = aws_kms_key.s3_data.arn
+  }
+
+  lifecycle_policy = local.ecr_lifecycle_policy_json
 }

--- a/providers/aws/outputs.tf
+++ b/providers/aws/outputs.tf
@@ -255,8 +255,13 @@ output "ecr_registry_url" {
 }
 
 output "ecr_repository_urls" {
-  description = "Map of ECR repository name to URL."
+  description = "Map of platform-managed ECR repository name to URL. Empty when no `ecr_repositories` are declared. Workload app repos created by CI are not in this output."
   value       = { for k, v in aws_ecr_repository.this : k => v.repository_url }
+}
+
+output "ecr_pull_through_cache_prefixes" {
+  description = "Map of pull-through cache prefix to upstream URL. Construct cached image refs as `<ecr_registry_url>/<prefix>/<upstream-path>:<tag>` — e.g. `<registry>/k8s/coredns/coredns:v1.11.1` caches `registry.k8s.io/coredns/coredns:v1.11.1`."
+  value       = { for k, v in aws_ecr_pull_through_cache_rule.this : k => v.upstream_registry_url }
 }
 
 # ===========================================================================

--- a/providers/aws/platform-outputs.tf
+++ b/providers/aws/platform-outputs.tf
@@ -114,8 +114,9 @@ resource "kubernetes_config_map" "platform_infrastructure" {
     "global.karpenterControllerRole"  = contains(["karpenter", "hybrid"], var.autoscaler) ? module.karpenter[0].iam_role_arn : ""
     "global.karpenterDiscoveryTagKey" = var.karpenter_discovery_tag_key
 
-    # ECR
-    "global.ecrRegistry" = length(var.ecr_repositories) > 0 && var.ecr_enabled ? "${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.region}.amazonaws.com" : ""
+    # ECR — registry URL is account+region scoped and exists whenever ECR is
+    # enabled (for pull-through cache, platform repos, or workload repos).
+    "global.ecrRegistry" = var.ecr_enabled ? "${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.region}.amazonaws.com" : ""
 
     # Cost
     "global.curReportName" = var.cost_export_enabled ? local.cur_report_name : ""

--- a/providers/aws/terraform.tfvars.example
+++ b/providers/aws/terraform.tfvars.example
@@ -177,19 +177,25 @@ client_gitops_repo_revision = "main"
 # s3_flow_logs_lifecycle_days                   = 90
 
 # --- ECR ---
+# Two ownership models (see ecr.tf):
+#   1. ecr_repositories: platform-managed repos (CLI-published addons).
+#      Workload app repos are NOT declared here — CI creates them on push.
+#   2. ecr_pull_through_cache_enabled: caches public upstream registries
+#      locally with KMS + lifecycle. Empty upstreams map activates the
+#      default anonymous set { ghcr, quay, k8s, public-ecr }.
+#
 # ecr_enabled                          = false
 # ecr_repositories                     = []
 # ecr_image_tag_mutability             = "IMMUTABLE"
 # ecr_scan_on_push                     = true
 # ecr_lifecycle_untagged_days          = 14
-# ecr_pull_through_cache_enabled       = false
-# ecr_pull_through_cache_upstreams     = {
+# ecr_pull_through_cache_enabled       = false   # true → default 4 upstreams
+# ecr_pull_through_cache_upstreams     = {}      # override to customize:
 #   # ghcr        = "ghcr.io"
 #   # quay        = "quay.io"
 #   # k8s         = "registry.k8s.io"
 #   # public-ecr  = "public.ecr.aws"
 #   # docker-hub  = "registry-1.docker.io"   # Needs ecr_dockerhub_credentials_secret_arn
-# }
 
 # --- Observability / Backup ---
 # diagnostics_enabled           = true

--- a/providers/aws/variables.tf
+++ b/providers/aws/variables.tf
@@ -1060,7 +1060,7 @@ variable "ecr_enabled" {
 }
 
 variable "ecr_repositories" {
-  description = "List of ECR repository names to create (without the account/region prefix). Each repo gets scan-on-push and the lifecycle policy defined below."
+  description = "List of platform-managed ECR repository names (no account/region prefix). Use ONLY for repositories the platform/CLI publishes declaratively (e.g. workload-operator image and chart). Workload application repos must NOT be declared here — CI creates them on push via the OIDC IAM role. Each platform repo gets scan-on-push, KMS encryption, IMMUTABLE tags, and the lifecycle policy below."
   type        = list(string)
   default     = []
 }
@@ -1089,13 +1089,13 @@ variable "ecr_lifecycle_untagged_days" {
 }
 
 variable "ecr_pull_through_cache_enabled" {
-  description = "Enable pull-through cache rules for public upstream registries. Equivalent to Azure ACR cache rules."
+  description = "Enable ECR pull-through cache rules. When true with an empty `ecr_pull_through_cache_upstreams`, a default anonymous set is provisioned: { ghcr, quay, k8s, public-ecr }. Cached repos auto-created by ECR inherit KMS + lifecycle from `aws_ecr_repository_creation_template.pull_through_cache`."
   type        = bool
   default     = false
 }
 
 variable "ecr_pull_through_cache_upstreams" {
-  description = "Map of pull-through cache rules: prefix -> upstream_registry_url. Examples: { docker-hub = 'registry-1.docker.io', quay = 'quay.io', ghcr = 'ghcr.io', k8s = 'registry.k8s.io', public-ecr = 'public.ecr.aws' }."
+  description = "Pull-through cache upstreams: prefix -> upstream_registry_url. Empty + `ecr_pull_through_cache_enabled = true` activates the default anonymous set { ghcr = ghcr.io, quay = quay.io, k8s = registry.k8s.io, public-ecr = public.ecr.aws }. Override to add docker-hub (also set `ecr_dockerhub_credentials_secret_arn`) or restrict the set."
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
## Summary

- Splits ECR repo ownership: `var.ecr_repositories` is now for **platform-managed** repos only (CLI-published addons). Workload application repos move to CI-owned creation on first push.
- Pull-through cache gains a default 4-prefix anonymous set when enabled with an empty upstreams map: `ghcr`, `quay`, `k8s`, `public-ecr`.
- New `aws_ecr_repository_creation_template.pull_through_cache` aligns cache-created repos with platform conventions (KMS + lifecycle) instead of AWS defaults (AES256, no lifecycle).
- `global.ecrRegistry` ConfigMap value now follows `ecr_enabled` only (was incorrectly guarded by non-empty `ecr_repositories`).
- New output `ecr_pull_through_cache_prefixes`.

## Why

Cortex AWS pilot surfaced the friction: enabling ECR forced the operator to enumerate every workload app in the client tfvars, meaning every onboarding required a `terraform apply` on the platform layer. ACR doesn't have this problem because Azure auto-creates repos on push; ECR refuses pushes to non-existent repos. The fix aligns ownership with operational reality: TF declares platform-stable repos, CI creates ephemeral workload repos on push.

## Files changed

- `providers/aws/ecr.tf` — full rewrite with `locals` + creation template.
- `providers/aws/variables.tf` — descriptions reworked for `ecr_repositories`, `ecr_pull_through_cache_enabled`, `ecr_pull_through_cache_upstreams`.
- `providers/aws/outputs.tf` — new `ecr_pull_through_cache_prefixes`.
- `providers/aws/platform-outputs.tf` — `global.ecrRegistry` follows `ecr_enabled` only.
- `providers/aws/terraform.tfvars.example` — comments updated.
- `CHANGELOG.md` — `[0.31.0]` entry.

## Plan diff (additive)

- `+` 4× `aws_ecr_pull_through_cache_rule.this` per consumer that sets `ecr_pull_through_cache_enabled = true`
- `+` 4× `aws_ecr_repository_creation_template.pull_through_cache`
- `~` `kubernetes_config_map.platform_infrastructure` data refresh on consumers with `ecr_enabled = true`
- `0` mutations on existing `aws_ecr_repository` resources

## Operator notes

Operators currently using `ecr_repositories` for workload app images should remove those entries; the existing AWS repos remain (TF stops managing them, last-applied lifecycle/scan settings persist). New workload repos will be created by CI once the OIDC IAM role lands in a follow-up.

## Follow-ups

- [ ] Mirror the variable description changes in `estabilis-platform-downstream/templates/aws/` (separate PR — already drafted locally).
- [ ] Add OIDC IAM role + trust policy for GitHub Actions to assume for `docker push` (Phase 3 of cortex pilot).
- [ ] Bump cortex client `main.tf ref=v0.31.0` once tagged.

## Test plan

- [x] `pre-commit run --files <changed>` — terraform fmt + validate + tflint clean
- [ ] Apply on cortex `platform-aws-us-east-1-prd` after release tag — expect 4 PT cache rules + 4 creation templates + ConfigMap data refresh
- [ ] Verify `aws ecr describe-pull-through-cache-rules --region us-east-1` lists the 4 rules post-apply