### PR TITLE
fix(ecr): drop ghcr/quay from PT cache default — auth-required (v0.31.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [0.31.1] - 2026-04-26
+
+### Fixed — ECR pull-through cache default no longer includes auth-required upstreams
+
+The v0.31.0 default upstream set `{ ghcr, quay, k8s, public-ecr }`
+broke at apply time with `UnsupportedUpstreamRegistryException` —
+AWS requires Secrets Manager credentials for `ghcr.io`, `quay.io`,
+`gitlab-registry.com`, and Docker Hub. Only `registry.k8s.io` and
+`public.ecr.aws` are truly anonymous.
+
+Fix: drop ghcr/quay from `local.ecr_default_pt_cache_upstreams`.
+Operators caching auth-required upstreams must set
+`ecr_pull_through_cache_upstreams` explicitly and provide credentials
+(`ecr_dockerhub_credentials_secret_arn` for Docker Hub today; per-
+upstream credential map planned for v0.32.0).
+
+#### Files changed
+
+- `providers/aws/ecr.tf` — `local.ecr_default_pt_cache_upstreams` reduced to `{ k8s, public-ecr }`.
+- `providers/aws/variables.tf` — descriptions of `ecr_pull_through_cache_enabled` and `ecr_pull_through_cache_upstreams` rewritten to call out the auth requirement.
+- `providers/aws/terraform.tfvars.example` — comments updated to mark which upstreams are anonymous vs authenticated.
+
+#### Operator notes
+
+- v0.31.0 deployments with `ecr_pull_through_cache_upstreams` left empty failed at apply (or partially applied). On bump to v0.31.1, plan shows `+2` PT cache rules + `+2` creation templates total (k8s, public-ecr only); any state from a partial v0.31.0 apply is reconciled.
+- v0.31.0 deployments that explicitly limited upstreams to `{ k8s, public-ecr }` see no plan changes.
+
 ## [0.31.0] - 2026-04-26
 
 ### Changed — ECR ownership model + pull-through cache defaults

--- a/providers/aws/ecr.tf
+++ b/providers/aws/ecr.tf
@@ -23,13 +23,12 @@
 # ---------------------------------------------------------------------------
 
 locals {
-  # Anonymous public upstreams applied when pull-through cache is enabled
-  # but `var.ecr_pull_through_cache_upstreams` is left empty. Docker Hub is
-  # opt-in (requires `ecr_dockerhub_credentials_secret_arn` to avoid the
-  # 100-pulls/6h anonymous rate limit).
+  # Truly anonymous upstreams only. AWS requires Secrets Manager credentials
+  # for ghcr.io, quay.io, gitlab-registry.com, and Docker Hub — including
+  # them in the default would fail with UnsupportedUpstreamRegistryException
+  # on apply. To cache from auth-required upstreams, set
+  # `ecr_pull_through_cache_upstreams` explicitly and provide credentials.
   ecr_default_pt_cache_upstreams = {
-    ghcr       = "ghcr.io"
-    quay       = "quay.io"
     k8s        = "registry.k8s.io"
     public-ecr = "public.ecr.aws"
   }

--- a/providers/aws/terraform.tfvars.example
+++ b/providers/aws/terraform.tfvars.example
@@ -182,20 +182,22 @@ client_gitops_repo_revision = "main"
 #      Workload app repos are NOT declared here — CI creates them on push.
 #   2. ecr_pull_through_cache_enabled: caches public upstream registries
 #      locally with KMS + lifecycle. Empty upstreams map activates the
-#      default anonymous set { ghcr, quay, k8s, public-ecr }.
+#      anonymous default { k8s, public-ecr }. AWS requires Secrets Manager
+#      credentials for ghcr/quay/gitlab/docker-hub — set the upstreams map
+#      explicitly AND wire credentials when caching from those.
 #
 # ecr_enabled                          = false
 # ecr_repositories                     = []
 # ecr_image_tag_mutability             = "IMMUTABLE"
 # ecr_scan_on_push                     = true
 # ecr_lifecycle_untagged_days          = 14
-# ecr_pull_through_cache_enabled       = false   # true → default 4 upstreams
+# ecr_pull_through_cache_enabled       = false   # true → default { k8s, public-ecr }
 # ecr_pull_through_cache_upstreams     = {}      # override to customize:
-#   # ghcr        = "ghcr.io"
-#   # quay        = "quay.io"
-#   # k8s         = "registry.k8s.io"
-#   # public-ecr  = "public.ecr.aws"
-#   # docker-hub  = "registry-1.docker.io"   # Needs ecr_dockerhub_credentials_secret_arn
+#   # k8s         = "registry.k8s.io"          # anonymous
+#   # public-ecr  = "public.ecr.aws"           # anonymous
+#   # docker-hub  = "registry-1.docker.io"     # needs ecr_dockerhub_credentials_secret_arn
+#   # ghcr        = "ghcr.io"                  # auth required (v0.32.0+)
+#   # quay        = "quay.io"                  # auth required (v0.32.0+)
 
 # --- Observability / Backup ---
 # diagnostics_enabled           = true

--- a/providers/aws/variables.tf
+++ b/providers/aws/variables.tf
@@ -1089,13 +1089,13 @@ variable "ecr_lifecycle_untagged_days" {
 }
 
 variable "ecr_pull_through_cache_enabled" {
-  description = "Enable ECR pull-through cache rules. When true with an empty `ecr_pull_through_cache_upstreams`, a default anonymous set is provisioned: { ghcr, quay, k8s, public-ecr }. Cached repos auto-created by ECR inherit KMS + lifecycle from `aws_ecr_repository_creation_template.pull_through_cache`."
+  description = "Enable ECR pull-through cache rules. When true with an empty `ecr_pull_through_cache_upstreams`, a 2-prefix anonymous default is provisioned: { k8s, public-ecr }. AWS requires Secrets Manager credentials for ghcr.io, quay.io, gitlab-registry.com, and Docker Hub — those are NOT in the default. Cached repos auto-created by ECR inherit KMS + lifecycle from `aws_ecr_repository_creation_template.pull_through_cache`."
   type        = bool
   default     = false
 }
 
 variable "ecr_pull_through_cache_upstreams" {
-  description = "Pull-through cache upstreams: prefix -> upstream_registry_url. Empty + `ecr_pull_through_cache_enabled = true` activates the default anonymous set { ghcr = ghcr.io, quay = quay.io, k8s = registry.k8s.io, public-ecr = public.ecr.aws }. Override to add docker-hub (also set `ecr_dockerhub_credentials_secret_arn`) or restrict the set."
+  description = "Pull-through cache upstreams: prefix -> upstream_registry_url. Empty + `ecr_pull_through_cache_enabled = true` activates the anonymous default { k8s = registry.k8s.io, public-ecr = public.ecr.aws }. To cache from an auth-required upstream (ghcr.io, quay.io, gitlab-registry.com, docker-hub), set this map explicitly AND provide credentials — `ecr_dockerhub_credentials_secret_arn` for Docker Hub; other authenticated upstreams currently require module extension (planned for v0.32.0)."
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
## Summary

The v0.31.0 default upstream set included `ghcr.io` and `quay.io`, both of which AWS rejects without Secrets Manager credentials (`UnsupportedUpstreamRegistryException`). This patch drops both from the default; only `registry.k8s.io` and `public.ecr.aws` (truly anonymous) remain.

## Why

Caught on the first real consumer apply (cortex AWS pilot, https://github.com/Cortex-Innovation/cortex-platform-aws-us-east-1-prd/pull/25). The `aws_ecr_pull_through_cache_rule` resource for `ghcr` failed with:

> UnsupportedUpstreamRegistryException: The specified upstream registry requires authentication. Specify a valid Secrets Manager ARN containing the upstream registry credentials and try again.

Per current AWS docs, only `registry.k8s.io`, `public.ecr.aws`, and `nvcr.io` are anonymous. `ghcr.io`, `quay.io`, `gitlab-registry.com`, and Docker Hub all require credentials.

## Files changed

- \`providers/aws/ecr.tf\` — \`local.ecr_default_pt_cache_upstreams\` reduced from 4 to 2 entries.
- \`providers/aws/variables.tf\` — descriptions of \`ecr_pull_through_cache_enabled\` and \`ecr_pull_through_cache_upstreams\` rewritten to call out the auth requirement.
- \`providers/aws/terraform.tfvars.example\` — comments updated to mark anonymous vs authenticated upstreams.
- \`CHANGELOG.md\` — \`[0.31.1]\` entry.

## Operator notes

- v0.31.0 deployments with \`ecr_pull_through_cache_upstreams\` left empty failed at apply (or partially applied). On bump to v0.31.1, plan shows \`+2\` PT cache rules + \`+2\` creation templates total — any partial state is reconciled.
- v0.31.0 deployments that explicitly limited upstreams to \`{ k8s, public-ecr }\` see no plan changes.

## Future

A \`ecr_pull_through_cache_credentials\` map will be added in v0.32.0 to support per-upstream credential ARNs (today only Docker Hub is supported via \`ecr_dockerhub_credentials_secret_arn\`).

## Test plan

- [x] \`pre-commit run --files <changed>\` — terraform fmt + validate + tflint clean
- [ ] Cortex pilot bumps to v0.31.1, terraform apply succeeds, \`aws ecr describe-pull-through-cache-rules\` lists 2 entries