### PR TITLE
fix(argocd-ecr): wire ArgoCD to pull OCI helm charts from ECR (v0.31.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## [0.31.2] - 2026-04-26
+
+### Fixed — ArgoCD can now pull OCI helm charts from platform-provisioned ECR
+
+v0.31.0 introduced ECR (per-repo + pull-through cache). `argocd-repo-server`
+had no AWS credentials, so Applications referencing
+`oci://<account>.dkr.ecr.<region>.amazonaws.com/<prefix>/<chart>` failed
+at sync with `basic credential not found`. The cortex pilot blocked on
+this; see [estabilis-platform-tools#202](https://github.com/Estabilis/estabilis-platform-tools/issues/202)
+for the full postmortem.
+
+Fix wires `external-secrets-operator` (already deployed + IRSA-bound) to
+mint ECR auth tokens via the native `ECRAuthorizationToken` generator,
+write them to an ArgoCD repo Secret, and refresh every 10h (under the
+12h ECR token TTL).
+
+#### New file `providers/aws/argocd-ecr-creds.tf`
+
+Three resources, all conditional on `var.ecr_enabled`:
+
+1. `aws_iam_policy.external_secrets_ecr` — adds `ecr:GetAuthorizationToken`
+   (mint tokens) + ECR pull permissions (so the minted token can fetch
+   artifacts; ECR token authority is bound to the requesting principal).
+2. `aws_iam_role_policy_attachment.external_secrets_ecr` — attaches the
+   policy to the existing `external_secrets_irsa` role.
+3. `kubernetes_manifest.ecr_auth_token` — `ECRAuthorizationToken`
+   generator in `argocd` ns referencing ESO's SA.
+4. `kubernetes_manifest.argocd_ecr_repo` — `ExternalSecret` in `argocd`
+   ns targeting `argocd-ecr-repo` Secret with label
+   `argocd.argoproj.io/secret-type=repository`, refreshInterval=10h,
+   url = registry root (so any chart pulled from this registry matches
+   by prefix).
+
+#### Operator notes
+
+- Apply order: ESO CRDs must be installed before the `kubernetes_manifest`
+  resources apply. ESO is deployed by ArgoCD (platform-root chart) on
+  first reconcile after the cluster bootstraps. On a fresh cluster, the
+  first `terraform apply` may report a CRD-not-found error on the
+  `kubernetes_manifest.ecr_auth_token` resource; re-run after ArgoCD
+  syncs the external-secrets Application. Subsequent applies are
+  idempotent.
+- Cortex bump path: `main.tf` ref `v0.31.1` → `v0.31.2`, then
+  `terraform plan` shows `+1` IAM policy + `+1` policy attachment +
+  `+2` Kubernetes manifests. After apply, the `argocd-ecr-repo` Secret
+  appears in `argocd` ns within ~30s of ESO reconciling.
+- Future: migrate the K8s manifests to a chart in
+  `estabilis-platform-gitops/components/argocd-ecr-creds/` rendered by
+  platform-root, eliminating the cross-domain TF→CRD ordering. Tracked
+  in #202.
+
 ## [0.31.1] - 2026-04-26
 
 ### Fixed — ECR pull-through cache default no longer includes auth-required upstreams

--- a/providers/aws/argocd-ecr-creds.tf
+++ b/providers/aws/argocd-ecr-creds.tf
@@ -1,0 +1,172 @@
+# ---------------------------------------------------------------------------
+# ArgoCD ↔ ECR auth bridge
+#
+# Wires `argocd-repo-server` to pull OCI helm charts from the
+# platform-provisioned ECR. Without this, ArgoCD Applications referencing
+# `oci://<account>.dkr.ecr.<region>.amazonaws.com/<prefix>/<chart>` fail
+# at sync with `basic credential not found` (see issue #202 for the full
+# postmortem).
+#
+# Pattern — ESO native ECRAuthorizationToken generator:
+#
+#   1. external-secrets IRSA gets ECR auth + pull permissions
+#      (this file's `aws_iam_policy.external_secrets_ecr`).
+#   2. ECRAuthorizationToken generator in `argocd` ns mints docker
+#      credentials by calling `ecr:GetAuthorizationToken` via ESO's
+#      IRSA-bound ServiceAccount (this file's
+#      `kubernetes_manifest.ecr_auth_token`).
+#   3. ExternalSecret in `argocd` ns writes the credentials to a
+#      Secret labelled `argocd.argoproj.io/secret-type=repository`
+#      with refreshInterval=10h (under ECR's 12h token TTL); ArgoCD
+#      reads it and uses for any Helm OCI source matching the URL
+#      prefix (this file's `kubernetes_manifest.argocd_ecr_repo`).
+#
+# Lifecycle: provisioned only when `var.ecr_enabled = true`. Disabling
+# ECR tears all three resources down cleanly.
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# IAM — extend external-secrets IRSA with ECR permissions
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_policy" "external_secrets_ecr" {
+  count = var.ecr_enabled ? 1 : 0
+
+  name        = "${local.cluster_name}-external-secrets-ecr"
+  description = "Allows external-secrets-operator to mint ECR auth tokens via the ECRAuthorizationToken generator (used by argocd-repo-server to pull OCI helm charts) and the resulting tokens to pull artifacts."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ECRAuthToken"
+        Effect   = "Allow"
+        Action   = ["ecr:GetAuthorizationToken"]
+        Resource = "*"
+      },
+      {
+        Sid    = "ECRPull"
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:BatchGetImage",
+          "ecr:DescribeImages",
+          "ecr:DescribeRepositories",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:ListImages",
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:ecr:${var.region}:${data.aws_caller_identity.current.account_id}:repository/*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "external_secrets_ecr" {
+  count = var.ecr_enabled ? 1 : 0
+
+  role       = module.external_secrets_irsa.iam_role_name
+  policy_arn = aws_iam_policy.external_secrets_ecr[0].arn
+}
+
+# ---------------------------------------------------------------------------
+# K8s — ECRAuthorizationToken generator + ExternalSecret target
+#
+# Both depend on the ESO CRDs being installed in the cluster. ESO is
+# deployed by ArgoCD (platform-root chart) on first reconcile after the
+# cluster comes up. This module does NOT block on ESO install — if the
+# manifests apply before CRDs exist, terraform reports an error and the
+# operator re-runs `terraform apply` after ESO settles. Idempotent.
+#
+# Future: migrate these manifests to a chart in
+# estabilis-platform-gitops/components/argocd-ecr-creds/ rendered by
+# platform-root, eliminating the cross-domain TF→CRD ordering. Tracked
+# in #202.
+# ---------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "ecr_auth_token" {
+  count = var.ecr_enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "generators.external-secrets.io/v1alpha1"
+    kind       = "ECRAuthorizationToken"
+    metadata = {
+      name      = "ecr-auth"
+      namespace = "argocd"
+    }
+    spec = {
+      region = var.region
+      auth = {
+        jwt = {
+          serviceAccountRef = {
+            name      = "external-secrets"
+            namespace = "external-secrets"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.external_secrets_ecr,
+    kubernetes_namespace.argocd,
+  ]
+}
+
+resource "kubernetes_manifest" "argocd_ecr_repo" {
+  count = var.ecr_enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "external-secrets.io/v1"
+    kind       = "ExternalSecret"
+    metadata = {
+      name      = "argocd-ecr-repo"
+      namespace = "argocd"
+    }
+    spec = {
+      # Refresh comfortably under the 12h ECR token TTL.
+      refreshInterval = "10h"
+
+      target = {
+        name           = "argocd-ecr-repo"
+        creationPolicy = "Owner"
+        template = {
+          metadata = {
+            labels = {
+              "argocd.argoproj.io/secret-type" = "repository"
+              "estabilis.io/managed-by"        = "platform"
+              "estabilis.io/component"         = "argocd-ecr-creds"
+            }
+          }
+          # ArgoCD repo Secret schema for Helm OCI:
+          #   type=helm, enableOCI=true, url, username, password
+          # url uses the registry root so any chart pulled from this
+          # registry matches by prefix. Cortex example:
+          #   093996075120.dkr.ecr.us-east-1.amazonaws.com
+          data = {
+            type      = "helm"
+            enableOCI = "true"
+            url       = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.region}.amazonaws.com"
+            username  = "{{ .username }}"
+            password  = "{{ .password }}"
+          }
+        }
+      }
+
+      dataFrom = [
+        {
+          sourceRef = {
+            generatorRef = {
+              apiVersion = "generators.external-secrets.io/v1alpha1"
+              kind       = "ECRAuthorizationToken"
+              name       = "ecr-auth"
+            }
+          }
+        },
+      ]
+    }
+  }
+
+  depends_on = [
+    kubernetes_manifest.ecr_auth_token,
+  ]
+}


### PR DESCRIPTION
## Problem

\`estabilis-platform\` v0.31.0 introduced ECR. \`argocd-repo-server\` has zero AWS credentials, so Applications referencing \`oci://<account>.dkr.ecr.<region>.amazonaws.com/<prefix>/<chart>\` fail at sync with \`basic credential not found\`. Blocks the entire chart-from-ECR workflow.

Discovered on the cortex AWS pilot — \`sitesearch-meli\` Application stuck in \`Unknown / Healthy\` state. Full postmortem: [#202](https://github.com/Estabilis/estabilis-platform-tools/issues/202).

## Fix

Use the de-facto AWS pattern: \`external-secrets-operator\` (already deployed + IRSA-bound) mints ECR auth tokens via the native \`ECRAuthorizationToken\` generator, an \`ExternalSecret\` writes them to an ArgoCD repo Secret with refresh 10h (under 12h ECR token TTL). Self-refreshing, declarative, no CronJob, no static credentials.

## Files

\`providers/aws/argocd-ecr-creds.tf\` (NEW) — 4 resources, all conditional on \`var.ecr_enabled\`:

1. \`aws_iam_policy.external_secrets_ecr\` — \`ecr:GetAuthorizationToken\` + ECR pull.
2. \`aws_iam_role_policy_attachment\` — attaches to existing \`external_secrets_irsa\` role.
3. \`kubernetes_manifest.ecr_auth_token\` — \`ECRAuthorizationToken\` generator in \`argocd\` ns referencing ESO's SA.
4. \`kubernetes_manifest.argocd_ecr_repo\` — \`ExternalSecret\` in \`argocd\` ns targeting \`argocd-ecr-repo\` Secret with label \`argocd.argoproj.io/secret-type=repository\`. URL set to registry root for prefix-matching.

\`CHANGELOG.md\` — \`[0.31.2]\` entry.

## Plan diff (for ECR-enabled consumers)

- \`+1\` \`aws_iam_policy.external_secrets_ecr\`
- \`+1\` \`aws_iam_role_policy_attachment.external_secrets_ecr\`
- \`+1\` \`kubernetes_manifest.ecr_auth_token\` (in \`argocd\` ns)
- \`+1\` \`kubernetes_manifest.argocd_ecr_repo\` (in \`argocd\` ns)
- \`0\` mutations on existing resources

## Operator notes

- ESO CRDs must be installed before the \`kubernetes_manifest\` resources apply. ESO is deployed by ArgoCD (platform-root chart) on first reconcile after the cluster bootstraps. On a **fresh** cluster, the first \`terraform apply\` may report a CRD-not-found error; re-run after ArgoCD syncs the \`external-secrets\` Application. Idempotent thereafter.
- For cortex (existing cluster, ESO already running): plan + apply directly works on first run.
- After apply, the \`argocd-ecr-repo\` Secret appears in \`argocd\` ns within ~30s of ESO reconciling. Verifying:
  \`\`\`
  kubectl -n argocd get secret argocd-ecr-repo -o jsonpath='{.metadata.labels}'
  # → {"argocd.argoproj.io/secret-type":"repository", ...}
  \`\`\`
- Disabling ECR (\`var.ecr_enabled=false\`) tears all four resources down cleanly.

## Future

Migrate the two K8s manifests to a chart in \`estabilis-platform-gitops/components/argocd-ecr-creds/\` rendered by platform-root, eliminating cross-domain TF→CRD ordering. Track in #202.

## Test plan

- [x] \`pre-commit run --files <changed>\` clean (terraform fmt + validate + tflint)
- [ ] Cortex bump to v0.31.2 → \`terraform apply\` adds 4 resources; \`argocd-ecr-repo\` secret appears with label
- [ ] sitesearch-meli Application transitions from \`Unknown\` to \`Synced/Healthy\` (chart pulls successfully)
- [ ] After 11h: ESO refreshes the token transparently; no Application disruption