### PR TITLE
fix(argocd-ecr): drop auth.jwt from ECRAuthorizationToken — use pod IRSA

### DIFF
--- a/providers/aws/argocd-ecr-creds.tf
+++ b/providers/aws/argocd-ecr-creds.tf
@@ -95,14 +95,10 @@ resource "kubernetes_manifest" "ecr_auth_token" {
     }
     spec = {
       region = var.region
-      auth = {
-        jwt = {
-          serviceAccountRef = {
-            name      = "external-secrets"
-            namespace = "external-secrets"
-          }
-        }
-      }
+      # No `auth` block: ESO uses the controller pod's AWS credentials
+      # (the IRSA bound to the `external-secrets` SA in the `external-secrets`
+      # namespace, extended with ECR permissions above). Avoids the
+      # cross-namespace SA reference complications with `auth.jwt`.
     }
   }
 


### PR DESCRIPTION
Follow-up to PR #117. The ECRAuthorizationToken with auth.jwt.serviceAccountRef pointing at external-secrets/external-secrets failed at runtime with `ServiceAccount "external-secrets" not found` — ESO requires extra config to resolve cross-namespace SA references.

Drop the auth block entirely; ESO uses the controller pod's own AWS credentials (already IRSA-bound to the role we extended in PR #117). Simpler and works on first apply.

Validated against cortex pilot (sitesearch-meli) — ESO logs show successful token mint.