### PR TITLE
fix(bridge): cluster-name annotation includes name_prefix (v0.31.6)

### DIFF
--- a/providers/aws/platform-outputs.tf
+++ b/providers/aws/platform-outputs.tf
@@ -226,7 +226,7 @@ resource "kubernetes_secret" "hub_cluster" {
       #                         cluster (cost optimization). Per-app
       #                         override remains via values.yaml when
       #                         isolation is required.
-      "estabilis.io/bridge.cluster-name"       = var.deployment_id
+      "estabilis.io/bridge.cluster-name"       = "${var.name_prefix}-${var.deployment_id}"
       "estabilis.io/bridge.domain"             = var.domain
       "estabilis.io/bridge.ingress-group-name" = "${var.name_prefix}-${var.environment}-shared-apps"
 


### PR DESCRIPTION
v0.31.5 set bridge.cluster-name = var.deployment_id (e.g. `platform-aws-us-east-1-prd`). DNS pattern `{app}.{cluster}.{domain}` becomes `sitesearch-meli.platform-aws-us-east-1-prd.estabilis-cortex.com`, dropping the org prefix. Cortex existing pilot uses `cortex-platform-aws-us-east-1-prd` (with prefix). Compose with name_prefix to preserve the convention.