### PR TITLE
fix(acm): align wildcard cert FQDN with bridge.cluster-name annotation (v0.31.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [0.31.7] - 2026-04-26
+
+### Fixed — ACM wildcard cert FQDN aligned with bridge.cluster-name annotation
+
+ACM `domain_name` used `local.cluster_name` (= `eks-${base}`).
+Bridge annotation `cluster-name` (v0.31.5+) uses
+`${name_prefix}-${deployment_id}`. App FQDNs composed from the bridge
+annotation never matched the cert — ALB auto-discovery couldn't pick
+it up, HTTPS broke.
+
+Fix: cert covers `*.${name_prefix}-${deployment_id}.${domain}` —
+same identifier as the bridge annotation. Single wildcard covers all
+apps in the cluster.
+
+#### Files changed
+
+- `providers/aws/acm.tf` — `domain_name` realigned + Cloudflare
+  validation comment updated.
+
+#### Operator notes
+
+- `aws_acm_certificate.wildcard` is **destroyed and recreated**
+  (immutable `domain_name`). `lifecycle.create_before_destroy = true`
+  issues the new cert before deleting the old; DNS-01 validation via
+  Cloudflare takes ~30-90s.
+- ALB Controller auto-rediscovers the new cert; existing Ingresses
+  pick it up on next reconciliation (~30s).
+
+## [0.31.6] - 2026-04-26 — `cluster-name` annotation includes `name_prefix`
+
+(Empty release commit — see [#122](https://github.com/Estabilis/estabilis-platform/pull/122).)
+
 ## [0.31.5] - 2026-04-26
 
 ### Added — cluster Secret annotations for ADR 0023 Etapa B (dynamic cluster metadata)

--- a/providers/aws/acm.tf
+++ b/providers/aws/acm.tf
@@ -8,7 +8,15 @@
 # _acme-challenge CNAME via the Cloudflare API token already required
 # by external-dns / cert-manager DNS-01 issuer.
 #
-# Domain: *.{cluster_name}.{domain}
+# Domain: *.{name_prefix}-{deployment_id}.{domain}
+#
+# Aligned with the `estabilis.io/bridge.cluster-name` Secret annotation
+# (ADR 0023 Etapa B, v0.31.5+) so app FQDNs composed as
+# `{app}.{cluster-name}.{domain}` are covered by this single wildcard
+# cert. Earlier versions (v0.31.5 and prior) used `local.cluster_name`
+# (= `eks-{base_name}`) which produced a different identifier and a
+# cert that didn't match app hosts — see v0.31.7 CHANGELOG.
+#
 # Extra SANs: var.acm_extra_domain_names
 # ---------------------------------------------------------------------------
 
@@ -45,7 +53,7 @@ resource "null_resource" "acm_requires_managed_dns" {
 resource "aws_acm_certificate" "wildcard" {
   count = var.acm_enabled ? 1 : 0
 
-  domain_name               = "*.${local.cluster_name}.${var.domain}"
+  domain_name               = "*.${var.name_prefix}-${var.deployment_id}.${var.domain}"
   subject_alternative_names = var.acm_extra_domain_names
   validation_method         = "DNS"
 
@@ -99,7 +107,7 @@ resource "cloudflare_record" "acm_validation" {
   type    = each.value.type
   ttl     = 60
   proxied = false
-  comment = "ACM cert validation for ${local.cluster_name} (managed by estabilis-platform)"
+  comment = "ACM cert validation for ${var.name_prefix}-${var.deployment_id} (managed by estabilis-platform)"
 }
 
 resource "aws_acm_certificate_validation" "wildcard" {


### PR DESCRIPTION
v0.31.5 introduced bridge.cluster-name annotation but ACM cert used a different identifier (local.cluster_name = eks-…). HTTPS broken on the bridge-pattern FQDN. Fix realigns cert to use the same identifier the chart consumes.