### PR TITLE
fix(acm): include legacy local.cluster_name wildcard as SAN (v0.31.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [0.31.8] - 2026-04-26
+
+### Fixed — ACM cert SAN keeps `*.{local.cluster_name}.{domain}` covered
+
+v0.31.7 changed ACM `domain_name` from `*.{local.cluster_name}.{domain}`
+(`eks-{base}`) to `*.{name_prefix}-{deployment_id}.{domain}` to align
+with the bridge annotation. Platform-managed Ingresses (argocd,
+grafana, vault) still use the old `local.cluster_name` pattern in
+their host field, so they lost cert coverage and the old cert
+couldn't be deleted (in-use by the platform ALB).
+
+Fix: include `*.{local.cluster_name}.{domain}` automatically as a SAN
+when it differs from the primary domain. Cert now covers BOTH
+patterns; new apps and legacy platform Ingresses keep working.
+
+#### Files changed
+
+- `providers/aws/acm.tf` — `locals.acm_legacy_san` derives the legacy
+  wildcard automatically; concatenated into
+  `subject_alternative_names` along with the existing
+  `var.acm_extra_domain_names` user overrides.
+
+#### Operator notes
+
+- `aws_acm_certificate.wildcard` recreated again (immutable
+  domain_name + SANs trigger replace). create_before_destroy lifecycle
+  applies; brief revalidation window via Cloudflare DNS-01 (~30-90s).
+- After apply: `aws acm describe-certificate ... --query 'Certificate.SubjectAlternativeNames'`
+  should list `*.{name_prefix}-{deployment_id}.{domain}`,
+  `*.{local.cluster_name}.{domain}`, plus any extras.
+- The orphaned v0.31.7 cert (no longer in use after this re-issue)
+  gets cleaned up on apply.
+
 ## [0.31.7] - 2026-04-26
 
 ### Fixed — ACM wildcard cert FQDN aligned with bridge.cluster-name annotation

--- a/providers/aws/acm.tf
+++ b/providers/aws/acm.tf
@@ -50,11 +50,26 @@ resource "null_resource" "acm_requires_managed_dns" {
   }
 }
 
+locals {
+  # Primary wildcard — matches the bridge cluster-name convention used
+  # by app FQDNs (chart helper composes {fullname}.{cluster}.{domain}).
+  acm_primary_domain = "*.${var.name_prefix}-${var.deployment_id}.${var.domain}"
+
+  # Legacy wildcard — matches platform-managed Ingresses (argocd,
+  # grafana, vault, etc.) that still pin host=*.{local.cluster_name}.{domain}.
+  # Kept as SAN to avoid breaking those hostnames when the primary
+  # changed in v0.31.7. When local.cluster_name == name_prefix-deployment_id
+  # the SAN is omitted (avoids duplicate-name validation error).
+  acm_legacy_domain = "*.${local.cluster_name}.${var.domain}"
+
+  acm_legacy_san = local.acm_primary_domain != local.acm_legacy_domain ? [local.acm_legacy_domain] : []
+}
+
 resource "aws_acm_certificate" "wildcard" {
   count = var.acm_enabled ? 1 : 0
 
-  domain_name               = "*.${var.name_prefix}-${var.deployment_id}.${var.domain}"
-  subject_alternative_names = var.acm_extra_domain_names
+  domain_name               = local.acm_primary_domain
+  subject_alternative_names = concat(local.acm_legacy_san, var.acm_extra_domain_names)
   validation_method         = "DNS"
 
   lifecycle {


### PR DESCRIPTION
v0.31.7 broke platform Ingresses (argocd, grafana, vault) which use `*.{local.cluster_name}.{domain}`. Cert no longer covered them, old cert can't delete (still in use by platform ALB). Add legacy pattern as SAN automatically.