### PR TITLE
feat(provider-aws): existing_subnet_role_tags_management opt-out for shared VPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,80 @@
 # Changelog
 
+## [0.33.0] - 2026-04-28
+
+### Added — `existing_subnet_role_tags_management` opt-out for shared-VPC deployments (AWS provider)
+
+`vpc_mode = "existing"` deployments unconditionally created
+`aws_ec2_tag.existing_private_internal_elb` (`kubernetes.io/role/internal-elb=1`)
+and `aws_ec2_tag.existing_public_elb` (`kubernetes.io/role/elb=1`) on the
+operator-supplied subnets. ALB Controller requires these for subnet
+auto-discovery, but their KEYS are NOT cluster-scoped — the AWS Load
+Balancer Controller hardcodes them — so when N Estabilis deployments share
+the same VPC each TF state would own the same tag.
+
+The failure mode is asymmetric:
+
+- **`apply`-time**: AWS `CreateTags` is idempotent, so two clusters
+  applying the same `(subnet, key, value)` triple does not error in
+  practice — both states co-own the tag.
+- **`destroy`-time**: the FIRST cluster to destroy issues `DeleteTags`,
+  removing the tag from the shared subnets. The surviving cluster's
+  ALB Controller then loses subnet auto-discovery until the next
+  `terraform apply` re-asserts the tag.
+
+Karpenter discovery tags were already opt-out via the per-cluster
+`karpenter_discovery_tag_key`; the cluster-membership tag
+(`kubernetes.io/cluster/<name>=shared`) is cluster-scoped by name and never
+collides. Only the two role tags above are shared keys.
+
+Added `existing_subnet_role_tags_management` (string, default `"create"`):
+
+- `"create"` (default — preserves current behavior): TF creates and owns
+  the tags. Use for the FIRST cluster sharing a VPC, or any standalone
+  deployment.
+- `"skip"`: TF does NOT manage these tags. Use for the SECOND/Nth cluster
+  sharing a VPC where another deployment (or the operator) already owns
+  them. Eliminates cross-state ownership and makes `terraform destroy`
+  non-destructive to the surviving cluster's ALB subnet discovery.
+
+The variable name follows the codebase convention of prefixing
+`existing_`-only variables (`private_subnet_ids`, `public_subnet_ids`,
+`vpc_id`) so the `vpc_mode = "existing"` scoping is signalled at the
+call site without relying on the description. A precondition guard
+(`terraform_data.existing_subnet_role_tags_guard` in `eks.tf`) rejects
+the nonsensical combination `vpc_mode = "create" + "skip"` at plan
+time instead of silently no-op'ing.
+
+Backward compatible: existing deployments keep the current behavior on
+upgrade. No state migration required.
+
+### Migration playbook (multi-cluster shared VPC)
+
+When promoting a second Estabilis deployment into a VPC where another
+Estabilis cluster already runs:
+
+1. Bump the second deployment's module ref to `v0.33.0+`.
+2. Set `existing_subnet_role_tags_management = "skip"` in the second
+   deployment's `terraform.tfvars` BEFORE the first apply.
+3. Apply normally. Verify ALB ingress lifecycle on both clusters.
+
+When retrofitting an already-deployed second cluster:
+
+1. Bump module ref to `v0.33.0+`.
+2. Set `existing_subnet_role_tags_management = "skip"`.
+3. Run `terraform plan` — expect
+   `length(var.private_subnet_ids) + length(var.public_subnet_ids)`
+   `aws_ec2_tag` resources to be destroyed (one per private subnet for
+   `internal-elb`, one per public subnet for `elb`). For the typical
+   3-AZ deployment with 3 private + 3 public subnets that is 6
+   resources; counts vary with the actual subnet topology.
+4. Run `terraform apply` to release the state resources. The AWS tags
+   are NOT removed: the FIRST cluster's TF state still owns them at
+   the AWS API, so the surviving cluster's ALB Controller continues
+   subnet auto-discovery without interruption. This step only mutates
+   the second cluster's state file. Verify post-apply that ingress
+   reconciliation on both clusters remains healthy.
+
 ## [0.32.1] - 2026-04-27
 
 ### Fixed — `validation` null short-circuit on storage-class IOPS/throughput

--- a/providers/aws/eks.tf
+++ b/providers/aws/eks.tf
@@ -326,7 +326,41 @@ module "eks" {
 # Subnet tag re-inforcement for existing-VPC mode. When the operator brings
 # their own subnets, we can only best-effort add the discovery tags — they
 # are required for ALB Controller + Karpenter to find the subnets.
+#
+# Tag scoping:
+#   - Karpenter discovery: keyed on `var.karpenter_discovery_tag_key`,
+#     unique per cluster by convention. Always managed.
+#   - kubernetes.io/role/{elb,internal-elb}: SHARED keys (no per-cluster
+#     suffix possible — ALB Controller hardcodes them). Cross-state
+#     ownership is the failure mode when N clusters share a VPC. Gated by
+#     `var.existing_subnet_role_tags_management` so the second/Nth cluster
+#     can opt out and let the first cluster own the tags.
+#   - kubernetes.io/cluster/<cluster-name>: cluster-scoped, always
+#     managed.
+#
+# State migration safety (v0.32.x → v0.33.0+):
+#   With the default `existing_subnet_role_tags_management = "create"` the
+#   for_each set is unchanged from prior versions, so existing state
+#   addresses persist with zero plan diff. Deployments that opt into
+#   "skip" will see one `aws_ec2_tag` per supplied subnet destroyed at
+#   plan time — this is a state-only release; AWS retains the tags
+#   because the FIRST cluster's TF state still owns them at the AWS API.
 # ---------------------------------------------------------------------------
+
+# Cross-variable guard: "skip" is only meaningful in vpc_mode = "existing".
+# In vpc_mode = "create" the module owns subnet creation and the role
+# tags must be managed by Terraform, so silently accepting "skip" would
+# be a footgun. Mirrors the mng_size_guard pattern above.
+resource "terraform_data" "existing_subnet_role_tags_guard" {
+  input = "${var.vpc_mode}:${var.existing_subnet_role_tags_management}"
+
+  lifecycle {
+    precondition {
+      condition     = var.vpc_mode == "existing" || var.existing_subnet_role_tags_management == "create"
+      error_message = "existing_subnet_role_tags_management = \"skip\" requires vpc_mode = \"existing\". When vpc_mode = \"create\" the module owns the subnets and their role tags; \"skip\" would be a silent no-op and is rejected to surface the misconfiguration."
+    }
+  }
+}
 
 resource "aws_ec2_tag" "existing_private_karpenter_discovery" {
   for_each = var.vpc_mode == "existing" && contains(["karpenter", "hybrid"], var.autoscaler) ? toset(var.private_subnet_ids) : []
@@ -337,7 +371,7 @@ resource "aws_ec2_tag" "existing_private_karpenter_discovery" {
 }
 
 resource "aws_ec2_tag" "existing_private_internal_elb" {
-  for_each = var.vpc_mode == "existing" ? toset(var.private_subnet_ids) : []
+  for_each = var.vpc_mode == "existing" && var.existing_subnet_role_tags_management == "create" ? toset(var.private_subnet_ids) : []
 
   resource_id = each.value
   key         = "kubernetes.io/role/internal-elb"
@@ -345,7 +379,7 @@ resource "aws_ec2_tag" "existing_private_internal_elb" {
 }
 
 resource "aws_ec2_tag" "existing_public_elb" {
-  for_each = var.vpc_mode == "existing" ? toset(var.public_subnet_ids) : []
+  for_each = var.vpc_mode == "existing" && var.existing_subnet_role_tags_management == "create" ? toset(var.public_subnet_ids) : []
 
   resource_id = each.value
   key         = "kubernetes.io/role/elb"

--- a/providers/aws/variables.tf
+++ b/providers/aws/variables.tf
@@ -568,6 +568,48 @@ variable "public_subnet_ids" {
   default     = []
 }
 
+variable "existing_subnet_role_tags_management" {
+  description = <<-EOT
+    Only meaningful when vpc_mode = "existing". Controls whether Terraform
+    manages the shared `kubernetes.io/role/elb` and
+    `kubernetes.io/role/internal-elb` tags on the operator-supplied
+    subnets. Ignored (and validated against) when vpc_mode = "create",
+    where Terraform always owns the subnets and their tags.
+
+    These role tags are required by AWS Load Balancer Controller for
+    subnet auto-discovery, but their KEYS are NOT cluster-scoped — the
+    controller hardcodes them. When N Estabilis deployments share the
+    same VPC, each TF state would otherwise own the same tag, causing
+    `terraform destroy` of one cluster to remove tags relied upon by
+    the survivors.
+
+    Modes:
+      - "create" (default): Terraform creates and owns the role tags.
+        Use for the FIRST cluster sharing a VPC, or any standalone
+        deployment.
+      - "skip": Terraform does NOT manage the role tags. Use for the
+        SECOND/Nth cluster sharing a VPC where another deployment
+        (or the operator) already owns them. Eliminates cross-state
+        ownership and makes `terraform destroy` non-destructive to the
+        surviving cluster's ALB subnet discovery.
+
+    Naming follows the convention of `private_subnet_ids` /
+    `public_subnet_ids` / `vpc_id`: the `existing_` prefix signals that
+    the variable is only consumed in vpc_mode = "existing".
+
+    The cluster-membership tag (`kubernetes.io/cluster/<cluster-name>=shared`)
+    and the per-cluster Karpenter discovery tag are always managed — they
+    are cluster-scoped and never collide between deployments.
+  EOT
+  type        = string
+  default     = "create"
+
+  validation {
+    condition     = contains(["create", "skip"], var.existing_subnet_role_tags_management)
+    error_message = "existing_subnet_role_tags_management must be one of: create, skip."
+  }
+}
+
 variable "vpc_cidr" {
   description = "CIDR block for the VPC (create mode). Must not overlap with on-prem or peered networks."
   type        = string


### PR DESCRIPTION
## Summary

Adds `existing_subnet_role_tags_management` (string, default `"create"`) so that the second/Nth Estabilis deployment sharing an AWS VPC can opt out of managing the shared `kubernetes.io/role/{elb,internal-elb}` subnet tags. Eliminates the destroy-time footgun where one cluster's `terraform destroy` removed tags relied upon by surviving clusters.

## Why

`vpc_mode = "existing"` deployments unconditionally tag operator-supplied subnets with `kubernetes.io/role/elb=1` and `kubernetes.io/role/internal-elb=1`. ALB Controller **hardcodes** those keys, so they cannot be made cluster-scoped. When N deployments share a VPC:

- **`apply` time**: AWS `CreateTags` is idempotent → multiple TF states co-own the same tag without error.
- **`destroy` time**: the first cluster to destroy issues `DeleteTags` → tags vanish → surviving cluster's ALB Controller loses subnet auto-discovery until next apply.

Karpenter discovery tag is already opt-out via `karpenter_discovery_tag_key` (per-cluster). Cluster-membership tag is cluster-scoped by name. Only the two role tags above were unfixable without a new flag.

## What

| File | Change |
|---|---|
| `providers/aws/variables.tf` | New variable `existing_subnet_role_tags_management` (`"create"` \| `"skip"`, default `"create"`) with full description + enum validation |
| `providers/aws/eks.tf` | (a) Gate `aws_ec2_tag.existing_private_internal_elb` and `aws_ec2_tag.existing_public_elb` `for_each` on the new variable. (b) New `terraform_data.existing_subnet_role_tags_guard` precondition rejects `vpc_mode = "create" + "skip"` to surface misconfigurations. (c) Expanded comment block documents tag scoping + state migration safety |
| `CHANGELOG.md` | `[0.33.0]` entry with rationale, mode semantics, and migration playbooks (greenfield + retrofit) |

## Backward compatibility

Default `"create"` preserves current behavior. Existing deployments see **zero plan diff** on upgrade — `for_each` set is unchanged when default is selected. No state migration required for first-only or standalone deployments.

## Test plan

- [x] `terraform fmt -recursive providers/aws/` clean
- [x] `pre-commit run --files providers/aws/eks.tf providers/aws/variables.tf CHANGELOG.md` all hooks pass (fmt + validate + tflint + secrets)
- [x] Brutal review pass (5 issues raised by `brutal-code-critic`, all addressed before commit)
- [ ] Smoke test: `cortex-platform-aws-us-east-1-hml` (vpc_mode=existing, default `"create"`) — first downstream consumer post-merge
- [ ] Verify `vpc_mode="create" + "skip"` errors loud at plan time