### PR TITLE
fix(argocd): rename controller.args → controller.extraArgs (was silently dropped)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## [0.36.9] - 2026-04-30
+
+### Fixed — argocd controller worker tunables actually reach the running pod
+
+`core/components/argocd/values.yaml` now sets `controller.extraArgs`
+instead of `controller.args`. The argocd helm chart (9.5.x
+`statefulset.yaml`) only renders `extraArgs` — `args` is silently
+dropped at template time. The intended `--status-processors=50` and
+`--operation-processors=25` sizing introduced in commit 6c217ff
+(2026-04-25, "feat(argocd): bump resources to fit ~40-App platform
+deployment") has never reached any client cluster running this
+chart since that commit. Every bootstrap fell back to the
+argocd-application-controller binary defaults:
+
+- `--status-processors=20`
+- `--operation-processors=10`
+
+Symptom: when ApplicationSet emits 30+ children simultaneously
+during cluster bootstrap, the operation processing queue stalls for
+minutes. Sync requests pile up; argocd-server times out waiting for
+controller responses; UI loads indefinitely; users perceive the
+control plane as dead. Verified on cortex prd 2026-04-30 — peak
+controller-1 memory hit 87% of the 2Gi limit during a 20-app sync
+wave (incremental, not full bootstrap), and the actual bootstrap
+the day before exhibited the symptom that motivated this fix.
+
+Confirmed via `helm template` against chart 9.5.6:
+
+  controller.extraArgs:[--status-processors=50,...]  → rendered ✓
+  controller.args:[--status-processors=50,...]       → ignored ✗
+
+And via `kubectl get sts argocd-application-controller -o jsonpath
+='{.spec.template.spec.containers[0].args}'` on the running cluster
+before/after the fix.
+
+Downstream propagation: clients pinned to v0.36.7/v0.36.8 should
+either bump `platform_version` to v0.36.9 OR add `controller.extraArgs`
+in their per-cluster `overrides/argocd/values.yaml` as an immediate
+hotfix (cortex prd already applied the override on 2026-04-30 in
+[Cortex-Innovation/cortex-platform-aws-us-east-1-prd#44](https://github.com/Cortex-Innovation/cortex-platform-aws-us-east-1-prd/pull/44);
+that override should be dropped once cortex prd is bumped to
+v0.36.9+).
+
 ## [0.36.8] - 2026-04-30
 
 ### Fixed — `grafana-llm-provisioning` ConfigMap rendered unconditionally

--- a/core/components/argocd/values.yaml
+++ b/core/components/argocd/values.yaml
@@ -148,7 +148,15 @@ server:
 
 controller:
   replicas: 1
-  args:
+  # The argocd helm chart (9.5.x statefulset.yaml) only renders
+  # `controller.extraArgs`, NOT `controller.args` — the latter is a
+  # silent no-op. The platform set `args:` since 6c217ff (2026-04-25)
+  # but the intended 50/25 worker sizing has never reached any client
+  # cluster running this chart, so every bootstrap fell back to the
+  # binary defaults `--status-processors=20` and `--operation-processors=10`.
+  # Result: operation queue stalls during 30+ App reconcile waves
+  # (sync travando + UI argocd-server loading sem fim).
+  extraArgs:
     - --status-processors=50
     - --operation-processors=25
   resources:


### PR DESCRIPTION
## Summary

The argocd helm chart 9.5.x `statefulset.yaml` template only renders `controller.extraArgs`. **`controller.args` is a silent no-op** — the value never reaches the running container.

This file has used `controller.args:` since commit [6c217ff](https://github.com/Estabilis/estabilis-platform/commit/6c217ff) (2026-04-25, *feat(argocd): bump resources to fit ~40-App platform deployment*). The intended worker concurrency tunables (`--status-processors=50`, `--operation-processors=25`) have **never reached any client cluster** running this chart in the ~5 days since. Every bootstrap fell back to the argocd binary defaults: `--status-processors=20`, `--operation-processors=10`.

## Symptom this resolves

Operator-reported recurring during cluster bootstrap: *"sync travando + UI argocd-server loading sem fim"*. Mechanism: when ApplicationSet emits 30+ children simultaneously, only 10 sync ops run concurrently → queue stalls for minutes → argocd-server times out waiting on controller → UI hangs.

## Verification

```
$ helm template test argo-cd-9.5.6 -f core/components/argocd/values.yaml
  containers:
  - args:
    - /usr/local/bin/argocd-application-controller
    - --metrics-port=8082
    - --status-processors=50      ← previously dropped, now emitted
    - --operation-processors=25   ← previously dropped, now emitted
```

Confirmed at runtime on cortex prd via the local override workaround applied in [Cortex-Innovation/cortex-platform-aws-us-east-1-prd#44](https://github.com/Cortex-Innovation/cortex-platform-aws-us-east-1-prd/pull/44) — args visible at `/proc/1/cmdline` of the running controller container immediately after rolling deploy.

## Why upstream fix in addition to the cortex prd local override

The override at the cortex prd downstream is a hotfix; this PR is the source-of-truth correction. Without this, every other client cluster consuming this chart (and any future client) inherits the broken `args:` key with no warning.

## Downstream propagation

After merge + tag (v0.36.9):

- **cortex-platform-aws-us-east-1-prd** (currently pinned to `platform_version=v0.36.7`): bump to `v0.36.9`, then drop the local override added in PR #44.
- Any other client cluster pinned to `v0.36.7` / `v0.36.8`: bump to `v0.36.9` to inherit the fix.

## Test plan

- [x] `helm template` against chart 9.5.6 emits the two flags into `args[]`
- [x] Same fix applied as local override on cortex prd (PR #44, merged 2026-04-30) — verified via `/proc/1/cmdline` that the binary received the flags
- [ ] After merge: auto-tag workflow creates `v0.36.9` tag + GitHub Release
- [ ] Follow-up: bump cortex prd's `platform_version` to v0.36.9 and drop the local override