### PR TITLE
fix(alloy): drop KSM namespace relabel rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog
 
+## [0.36.10] - 2026-04-30
+
+### Fixed — alloy KSM namespace label rewrite destroyed pod namespace info
+
+`core/components/grafana-stack/alloy-values.yaml` removes the
+`prometheus.relabel "kube_state_metrics"` rule that overrode
+`namespace = "kube-state-metrics"` on every metric scraped from KSM.
+
+The rule was introduced in commit d4eed7a (2026-03-13, "feat: add
+kube-state-metrics and OpenCost/KSM scrape jobs in Alloy") alongside
+an analogous rule for OpenCost. The OpenCost rule remains untouched
+because the OpenCost pod's metrics ARE about itself
+(`namespace="opencost"` is correct). KSM is different: it reports
+about OTHER pods — each metric carries the real pod's namespace
+natively, and overwriting it destroys the information.
+
+Effect on every cluster running this chart pre-v0.36.10:
+
+  count by (namespace) (kube_pod_container_resource_requests)
+  → only one bucket: namespace="kube-state-metrics"
+
+Real namespace values (`kube-system`, `app-*`, `cnpg-system`, ...)
+were absent from the namespace label of every `kube_*` metric.
+
+Tools silently broken:
+  - KRR / Goldilocks / VPA-style sizing — KRR's cluster-summary
+    query `sum(kube_pod_container_resource_requests{namespace=
+    "kube-system",...})` returned zero results, KRR aborted.
+  - Grafana dashboards filtering `kube_*` by namespace mixed all
+    namespaces into one bucket.
+  - Cost-allocation dashboards (opencost / kubecost) using KSM
+    attributed all costs to `kube-state-metrics` namespace.
+  - Mimir alerts on `kube_pod_*{namespace="X"}` had silent miss.
+
+Discovered 2026-04-30 when KRR ran against cortex prd:
+
+  [WARNING] Error: Expected exactly one result from Prometheus query
+  but instead got 0. sum(kube_pod_container_resource_requests
+  {namespace="kube-system", resource="memory"})
+  [CRITICAL] No objects available to scan.
+
+Direct Mimir confirmation showed all 288 `kube_pod_container_resource_
+requests` series carrying `namespace="kube-state-metrics"`.
+
+Verified at runtime on cortex prd via the local override workaround
+in [Cortex-Innovation/cortex-platform-aws-us-east-1-prd#46](https://github.com/Cortex-Innovation/cortex-platform-aws-us-east-1-prd/pull/46):
+after the same one-rule deletion, Mimir returned 36 distinct
+namespaces. Cortex prd's local override should be dropped once the
+cluster bumps `platform_version` to v0.36.10+.
+
+Inline comment added in alloy-values.yaml warning future operators
+not to re-add the rule.
+
 ## [0.36.9] - 2026-04-30
 
 ### Fixed — argocd controller worker tunables actually reach the running pod

--- a/core/components/grafana-stack/alloy-values.yaml
+++ b/core/components/grafana-stack/alloy-values.yaml
@@ -433,10 +433,14 @@ alloy:
           target_label = "job"
           replacement  = "kube-state-metrics"
         }
-        rule {
-          target_label = "namespace"
-          replacement  = "kube-state-metrics"
-        }
+        // NOTE: do NOT add a `target_label = "namespace"` rewrite here.
+        // KSM emits metrics ABOUT OTHER PODS — each carries the real
+        // namespace of the reported pod (e.g. namespace="app-foo").
+        // Overwriting the namespace label destroys that information,
+        // breaking KRR / Goldilocks / Grafana dashboards filtering by
+        // namespace / Mimir alerts on `kube_*{namespace="X"}` / cost-
+        // allocation tooling. Originating bug: commit d4eed7a
+        // (2026-03-13). Fixed: 2026-04-30.
         rule {
           action = "labeldrop"
           regex  = "instance"


### PR DESCRIPTION
## Summary

Removes a `prometheus.relabel "kube_state_metrics"` rule from the alloy config that was silently overriding `namespace="kube-state-metrics"` on every metric scraped from kube-state-metrics. Restores the actual pod namespace label so any consumer filtering `kube_*` metrics by namespace works correctly.

## Root cause

Introduced in commit [d4eed7a](https://github.com/Estabilis/estabilis-platform/commit/d4eed7a) (2026-03-13, *"feat: add kube-state-metrics and OpenCost/KSM scrape jobs in Alloy"*) alongside an analogous rule for OpenCost:

```river
prometheus.relabel "kube_state_metrics" {
  rule { target_label = "job"; replacement = "kube-state-metrics" }
  rule { target_label = "namespace"; replacement = "kube-state-metrics" }   ← removed
  rule { action = "labeldrop"; regex = "instance" }
  forward_to = [prometheus.remote_write.mimir.receiver]
}
```

The `namespace` rule unconditionally rewrites the namespace label on every metric. KSM emits metrics ABOUT OTHER PODS — each one carries the real namespace of the reported pod natively. Overwriting it destroys that information.

The OpenCost rule one block above is left untouched: the OpenCost pod's metrics ARE about itself, so `namespace="opencost"` is correct.

## Effect on every cluster running this chart pre-v0.36.10

```
count by (namespace) (kube_pod_container_resource_requests)
→ {namespace="kube-state-metrics"} 288 series  (sole bucket)
```

Real namespace values (kube-system, app-*, cnpg-system, ...) were nowhere in the `namespace` label of any `kube_*` metric.

Silently broken consumers:
- **KRR / Goldilocks / VPA-style sizing tooling** — KRR's cluster-summary query returned zero, KRR aborted with `CRITICAL No objects available to scan`
- **Grafana dashboards** filtering `kube_*` by namespace mixed all namespaces
- **Cost-allocation dashboards** (opencost / kubecost) using KSM attributed all costs to `kube-state-metrics`
- **Mimir alerts** on `kube_pod_*{namespace="X"}` had silent miss

## Discovered

2026-04-30 when KRR ran against cortex prd and aborted. Direct Mimir confirmation showed all 288 `kube_pod_container_resource_requests` series carrying `namespace="kube-state-metrics"`.

## Verified at runtime

Same one-rule deletion was applied as a local override workaround in [Cortex-Innovation/cortex-platform-aws-us-east-1-prd#46](https://github.com/Cortex-Innovation/cortex-platform-aws-us-east-1-prd/pull/46) (820 lines because the alloy chart 1.6.x only exposes `configMap.content` as a single string with no merge/append mechanism, forcing the override to replicate the entire alloy config to change one rule).

After applying the override:
- Mimir went from 1 namespace bucket → **36 distinct namespaces**
- KRR ran successfully end-to-end

This PR ports the same one-rule deletion to the upstream platform source, so all client clusters inherit the fix when they bump `platform_version` to v0.36.10+.

## Code change

```diff
 prometheus.relabel "kube_state_metrics" {
   rule {
     target_label = "job"
     replacement  = "kube-state-metrics"
   }
-  rule {
-    target_label = "namespace"
-    replacement  = "kube-state-metrics"
-  }
+  // NOTE: do NOT add a `target_label = "namespace"` rewrite here.
+  // KSM emits metrics ABOUT OTHER PODS — each carries the real
+  // namespace of the reported pod (e.g. namespace="app-foo").
+  // Overwriting the namespace label destroys that information,
+  // breaking KRR / Goldilocks / Grafana dashboards filtering by
+  // namespace / Mimir alerts on `kube_*{namespace="X"}` / cost-
+  // allocation tooling. Originating bug: commit d4eed7a
+  // (2026-03-13). Fixed: 2026-04-30.
   rule {
     action = "labeldrop"
     regex  = "instance"
   }
   forward_to = [prometheus.remote_write.mimir.receiver]
 }
```

Inline comment included to warn future operators not to re-add the namespace rewrite rule.

## Downstream cleanup after merge + tag

After `v0.36.10` lands and a client bumps `platform_version`:

- **cortex-platform-aws-us-east-1-prd**: drop the 820-line override in `overrides/alloy/values.yaml`. The Block 3 portion (just `alloy.resources`) shrinks the file back to ~30 lines.

## Test plan

- [x] KSM block now has 2 rules (job + labeldrop) instead of 3 — verified by line-count grep
- [x] Inline comment warns about re-adding the rule
- [x] Verified at runtime in cortex prd via local override (PR #46) — Mimir went from 1 ns bucket to 36 distinct namespaces
- [ ] After merge: auto-tag workflow creates `v0.36.10` tag + GitHub Release
- [ ] Follow-up: cortex prd bumps `platform_version` to v0.36.10 and drops the local override