### PR TITLE
feat(observability): close 10 alloy/Mimir scrape gaps + bump series limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,75 @@
 # Changelog
 
+## [0.37.0] - 2026-04-30
+
+### Added — observability stack completeness sweep
+
+Audit on cortex prd 2026-04-30 found 10 distinct visibility gaps in
+the alloy → Mimir pipeline. None blocked anything functionally — they
+just meant the corresponding Grafana dashboards had no data. This
+release closes them all + raises the Mimir tenant series limit so the
+extra scrapes don't get dropped.
+
+#### alloy — new scrape jobs
+
+  argocd-applicationset-controller    pod discovery, port 8080
+  trivy-server                         svc trivy-service:4954
+  vault                                svc vault-active:8200/v1/sys/metrics
+  mimir-self                           pod discovery (label name=mimir, port 8080)
+  loki-self                            pod discovery (label name=loki, port 3100)
+  grafana-self                         pod discovery (label name=grafana, port 3000)
+  tempo-self                           pod discovery (label name=tempo, port 3100)
+  pyroscope-self                       pod discovery (label name=pyroscope, port 4040)
+  alloy-self                           pod discovery (label name=alloy, port 12345; clustering disabled — every replica reports its own state)
+
+#### alloy — fixed external-secrets target
+
+The previous scrape target `external-secrets-metrics.external-secrets.svc.cluster.local:8080`
+referenced a Service that does NOT exist in the chart. The actual
+controller pod listens on container port 8080. Switched to pod-discovery
+(role=pod, namespace=external-secrets, label app.kubernetes.io/name=
+external-secrets) which targets the controller pod's IP directly.
+
+#### vault — `unauthenticated_metrics_access`
+
+Vault's `/v1/sys/metrics` endpoint returns 403 by default. Without
+authentication, alloy can't scrape — and threading a Vault token
+through alloy adds a TTL/rotation problem we don't need for an
+in-cluster scrape that's already restricted by NetworkPolicy
+(`allow-vault` already pinned port 8200 to grafana ns only).
+
+Adds the `telemetry { unauthenticated_metrics_access = true }` block
+inside the `listener "tcp"` HCL stanza, in BOTH the AWS and Azure
+provider branches of `bootstrap/platform-root/templates/vault.yaml`.
+
+Reference: HashiCorp docs note that the metrics endpoint exposes
+operational counters/gauges only — no secrets.
+
+#### mimir — `max_global_series_per_user` 150k → 500k
+
+The Mimir default per-tenant active-series cap of 150,000 was too low
+for a cluster with KSM + kyverno + cnpg + alloy + 6-component grafana
+self-monitoring. Direct evidence from cortex prd 2026-04-30 alloy
+logs:
+
+    "non-recoverable error ... err='per-user series limit of 150000
+     exceeded (err-mimir-max-series-per-user)' ... 2000 samples failed"
+
+Existing scrape pipelines (kyverno_*, cnpg_*) had samples silently
+dropped — the metrics appeared in `/api/v1/label/__name__/values`
+(stale index) but `count({__name__=~"kyverno_.*"})` returned 0 series.
+
+Bumped to 500,000 — covers KSM (~50k) + kyverno (~30k) + cnpg (~10k)
++ alloy/mimir/loki self-monitoring (~80k) + cortex apps (~20k) with
+4× headroom for high-cardinality histograms.
+
+#### Downstream propagation
+
+NetworkPolicy fixes for cert-manager / cnpg-system / trivy-system
+ship in `Estabilis/estabilis-platform-gitops` v0.39.7 (PR #38).
+Bumping `platform_version` to v0.37.0 + `platformGitopsVersion` to
+v0.39.7 in a client repo unlocks the full visibility sweep.
+
 ## [0.36.10] - 2026-04-30
 
 ### Fixed — alloy KSM namespace label rewrite destroyed pod namespace info

--- a/bootstrap/platform-root/templates/vault.yaml
+++ b/bootstrap/platform-root/templates/vault.yaml
@@ -67,6 +67,14 @@ spec:
                 tls_disable     = 1
                 address         = "[::]:8200"
                 cluster_address = "[::]:8201"
+                telemetry {
+                  # Allow unauthenticated /v1/sys/metrics scrape from
+                  # in-cluster alloy. Without this flag the endpoint
+                  # returns 403 and the vault job in Mimir reads up=0.
+                  # Network is restricted to grafana ns by NetworkPolicy
+                  # `allow-vault` (port 8200 from grafana only).
+                  unauthenticated_metrics_access = true
+                }
               }
 
               storage "raft" {
@@ -113,6 +121,14 @@ spec:
                 tls_disable     = 1
                 address         = "[::]:8200"
                 cluster_address = "[::]:8201"
+                telemetry {
+                  # Allow unauthenticated /v1/sys/metrics scrape from
+                  # in-cluster alloy. Without this flag the endpoint
+                  # returns 403 and the vault job in Mimir reads up=0.
+                  # Network is restricted to grafana ns by NetworkPolicy
+                  # `allow-vault` (port 8200 from grafana only).
+                  unauthenticated_metrics_access = true
+                }
               }
 
               storage "raft" {

--- a/core/components/grafana-stack/alloy-values.yaml
+++ b/core/components/grafana-stack/alloy-values.yaml
@@ -243,6 +243,44 @@ alloy:
         forward_to = [prometheus.remote_write.mimir.receiver]
       }
 
+      // ApplicationSet Controller — metrics on port 8080
+      discovery.relabel "argocd_applicationset" {
+        targets = discovery.kubernetes.argocd.targets
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_component"]
+          action        = "keep"
+          regex         = "applicationset-controller"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_ip"]
+          target_label  = "__address__"
+          replacement   = "$1:8080"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label  = "namespace"
+        }
+      }
+
+      prometheus.scrape "argocd_applicationset" {
+        targets    = discovery.relabel.argocd_applicationset.output
+        forward_to = [prometheus.relabel.argocd_applicationset.receiver]
+        clustering {
+          enabled = true
+        }
+      }
+
+      prometheus.relabel "argocd_applicationset" {
+        rule {
+          target_label = "job"
+          replacement  = "argocd-applicationset-controller"
+        }
+        forward_to = [prometheus.remote_write.mimir.receiver]
+      }
+
       // --- cert-manager ---
       prometheus.scrape "cert_manager" {
         targets = [{
@@ -449,10 +487,40 @@ alloy:
       }
 
       // --- External Secrets Operator ---
+      // The svc `external-secrets-metrics` referenced previously does NOT
+      // exist on this chart version — only `external-secrets-webhook` is
+      // shipped. Switched to pod-discovery so we scrape the controller
+      // pod (which exposes /metrics on container port 8080) directly.
+      discovery.kubernetes "external_secrets" {
+        role = "pod"
+        namespaces {
+          names = ["external-secrets"]
+        }
+      }
+
+      discovery.relabel "external_secrets" {
+        targets = discovery.kubernetes.external_secrets.targets
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          action        = "keep"
+          regex         = "external-secrets"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_ip"]
+          target_label  = "__address__"
+          replacement   = "$1:8080"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label  = "namespace"
+        }
+      }
+
       prometheus.scrape "external_secrets" {
-        targets = [{
-          __address__ = "external-secrets-metrics.external-secrets.svc.cluster.local:8080",
-        }]
+        targets    = discovery.relabel.external_secrets.output
         forward_to = [prometheus.relabel.external_secrets.receiver]
         clustering {
           enabled = true
@@ -462,10 +530,6 @@ alloy:
       prometheus.relabel "external_secrets" {
         rule {
           target_label = "job"
-          replacement  = "external-secrets"
-        }
-        rule {
-          target_label = "namespace"
           replacement  = "external-secrets"
         }
         forward_to = [prometheus.remote_write.mimir.receiver]
@@ -715,6 +779,316 @@ alloy:
         rule {
           target_label = "namespace"
           replacement  = "trivy-system"
+        }
+        forward_to = [prometheus.remote_write.mimir.receiver]
+      }
+
+      // --- Trivy Server (vulnerability DB ClientServer) ---
+      prometheus.scrape "trivy_server" {
+        targets = [{
+          __address__ = "trivy-service.trivy-system.svc.cluster.local:4954",
+        }]
+        forward_to = [prometheus.relabel.trivy_server.receiver]
+        clustering {
+          enabled = true
+        }
+      }
+
+      prometheus.relabel "trivy_server" {
+        rule {
+          target_label = "job"
+          replacement  = "trivy-server"
+        }
+        rule {
+          target_label = "namespace"
+          replacement  = "trivy-system"
+        }
+        forward_to = [prometheus.remote_write.mimir.receiver]
+      }
+
+      // --- Vault (HashiCorp) ---
+      // Requires `unauthenticated_metrics_access = true` in the vault
+      // listener telemetry block — set in the vault helm values upstream.
+      // Without it the /v1/sys/metrics endpoint returns 403.
+      // Targets the active-leader service (only the leader serves real
+      // metrics on the standalone path; HA standbys forward request to
+      // leader which then 403s on the auth check).
+      prometheus.scrape "vault" {
+        targets = [{
+          __address__   = "vault-active.vault.svc.cluster.local:8200",
+          __metrics_path__ = "/v1/sys/metrics",
+        }]
+        params      = { format = ["prometheus"] }
+        forward_to  = [prometheus.relabel.vault.receiver]
+        clustering {
+          enabled = true
+        }
+      }
+
+      prometheus.relabel "vault" {
+        rule {
+          target_label = "job"
+          replacement  = "vault"
+        }
+        rule {
+          target_label = "namespace"
+          replacement  = "vault"
+        }
+        forward_to = [prometheus.remote_write.mimir.receiver]
+      }
+
+      // =====================================================================
+      // Self-monitoring — grafana stack scrapes itself
+      // =====================================================================
+      // Each component in the stack exposes its own /metrics. Without
+      // self-scrape we have no visibility into mimir ingestion errors,
+      // alloy WAL backlog, loki query latency, etc. Self-monitoring is
+      // the standard pattern; see grafana-agent-mixin / mimir-mixin
+      // upstream dashboards which require these targets.
+
+      // --- Mimir self ---
+      // mimir-distributed exposes /metrics on container port 8080 across
+      // every component (distributor/ingester/querier/etc.). Pod
+      // discovery + label-based filter keeps the scrape generic; new
+      // components added by chart upgrades are picked up automatically.
+      discovery.kubernetes "grafana_ns" {
+        role = "pod"
+        namespaces {
+          names = ["grafana"]
+        }
+      }
+
+      discovery.relabel "mimir_self" {
+        targets = discovery.kubernetes.grafana_ns.targets
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          action        = "keep"
+          regex         = "mimir"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_ip"]
+          target_label  = "__address__"
+          replacement   = "$1:8080"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label  = "namespace"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_component"]
+          target_label  = "component"
+        }
+      }
+
+      prometheus.scrape "mimir_self" {
+        targets    = discovery.relabel.mimir_self.output
+        forward_to = [prometheus.relabel.mimir_self.receiver]
+        clustering {
+          enabled = true
+        }
+      }
+
+      prometheus.relabel "mimir_self" {
+        rule {
+          target_label = "job"
+          replacement  = "mimir"
+        }
+        forward_to = [prometheus.remote_write.mimir.receiver]
+      }
+
+      // --- Loki self ---
+      discovery.relabel "loki_self" {
+        targets = discovery.kubernetes.grafana_ns.targets
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          action        = "keep"
+          regex         = "loki"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_ip"]
+          target_label  = "__address__"
+          replacement   = "$1:3100"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label  = "namespace"
+        }
+      }
+
+      prometheus.scrape "loki_self" {
+        targets    = discovery.relabel.loki_self.output
+        forward_to = [prometheus.relabel.loki_self.receiver]
+        clustering {
+          enabled = true
+        }
+      }
+
+      prometheus.relabel "loki_self" {
+        rule {
+          target_label = "job"
+          replacement  = "loki"
+        }
+        forward_to = [prometheus.remote_write.mimir.receiver]
+      }
+
+      // --- Grafana self ---
+      // Grafana metrics are on port 3000 path /metrics. Restricted to
+      // pods labeled `app.kubernetes.io/name=grafana` to avoid scraping
+      // sidecars (sc-dashboard, sc-datasources).
+      discovery.relabel "grafana_self" {
+        targets = discovery.kubernetes.grafana_ns.targets
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          action        = "keep"
+          regex         = "grafana"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_ip"]
+          target_label  = "__address__"
+          replacement   = "$1:3000"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label  = "namespace"
+        }
+      }
+
+      prometheus.scrape "grafana_self" {
+        targets    = discovery.relabel.grafana_self.output
+        forward_to = [prometheus.relabel.grafana_self.receiver]
+        clustering {
+          enabled = true
+        }
+      }
+
+      prometheus.relabel "grafana_self" {
+        rule {
+          target_label = "job"
+          replacement  = "grafana"
+        }
+        forward_to = [prometheus.remote_write.mimir.receiver]
+      }
+
+      // --- Tempo self ---
+      discovery.relabel "tempo_self" {
+        targets = discovery.kubernetes.grafana_ns.targets
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          action        = "keep"
+          regex         = "tempo"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_ip"]
+          target_label  = "__address__"
+          replacement   = "$1:3100"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label  = "namespace"
+        }
+      }
+
+      prometheus.scrape "tempo_self" {
+        targets    = discovery.relabel.tempo_self.output
+        forward_to = [prometheus.relabel.tempo_self.receiver]
+        clustering {
+          enabled = true
+        }
+      }
+
+      prometheus.relabel "tempo_self" {
+        rule {
+          target_label = "job"
+          replacement  = "tempo"
+        }
+        forward_to = [prometheus.remote_write.mimir.receiver]
+      }
+
+      // --- Pyroscope self ---
+      discovery.relabel "pyroscope_self" {
+        targets = discovery.kubernetes.grafana_ns.targets
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          action        = "keep"
+          regex         = "pyroscope"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_ip"]
+          target_label  = "__address__"
+          replacement   = "$1:4040"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label  = "namespace"
+        }
+      }
+
+      prometheus.scrape "pyroscope_self" {
+        targets    = discovery.relabel.pyroscope_self.output
+        forward_to = [prometheus.relabel.pyroscope_self.receiver]
+        clustering {
+          enabled = true
+        }
+      }
+
+      prometheus.relabel "pyroscope_self" {
+        rule {
+          target_label = "job"
+          replacement  = "pyroscope"
+        }
+        forward_to = [prometheus.remote_write.mimir.receiver]
+      }
+
+      // --- Alloy self ---
+      // Each alloy pod scrapes itself (clustering NOT enabled here so
+      // every replica reports its own state — for fleet-wide alloy
+      // diagnostics we WANT all replicas' samples in Mimir).
+      discovery.relabel "alloy_self" {
+        targets = discovery.kubernetes.grafana_ns.targets
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          action        = "keep"
+          regex         = "alloy"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_ip"]
+          target_label  = "__address__"
+          replacement   = "$1:12345"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label  = "namespace"
+        }
+      }
+
+      prometheus.scrape "alloy_self" {
+        targets    = discovery.relabel.alloy_self.output
+        forward_to = [prometheus.relabel.alloy_self.receiver]
+      }
+
+      prometheus.relabel "alloy_self" {
+        rule {
+          target_label = "job"
+          replacement  = "alloy"
         }
         forward_to = [prometheus.remote_write.mimir.receiver]
       }

--- a/core/components/grafana-stack/mimir-values.yaml
+++ b/core/components/grafana-stack/mimir-values.yaml
@@ -44,6 +44,20 @@ mimir:
     limits:
       compactor_blocks_retention_period: "2160h"  # 90 days
       max_label_names_per_series: 60              # AKS nodes carry ~47 labels via kube_node_labels
+      # Per-tenant active series cap. Default 150,000 was too low for a
+      # cluster with KSM + kyverno + cnpg + alloy + 6-component grafana
+      # self-monitoring — alloy logs on cortex prd 2026-04-30 showed:
+      #   "non-recoverable error ... err='per-user series limit of
+      #    150000 exceeded (err-mimir-max-series-per-user)' ... 2000
+      #    samples failed"
+      # New series (kyverno_*, cnpg_*) were silently dropped; old indexed
+      # labels stayed visible in /api/v1/label/__name__/values but
+      # `count({__name__=~\"kyverno_.*\"})` returned 0 instances.
+      # Bumped to 500k — covers KSM (~50k) + kyverno (~30k) + cnpg
+      # (~10k) + alloy/mimir/loki self-monitoring (~80k) + cortex apps
+      # (~20k) with 4× headroom for high-cardinality metrics like
+      # alloy's per-target histograms.
+      max_global_series_per_user: 500000
 
 # Disable embedded minio (we use cloud storage)
 minio:


### PR DESCRIPTION
## Summary

Closes 10 observability visibility gaps + bumps Mimir per-tenant series limit so the new + existing scrapes don't drop. None of the items broke function — they just left corresponding Grafana dashboards empty. This is the comprehensive close-all sweep from the cortex prd 2026-04-30 audit.

## Changes

### alloy — 8 new scrape jobs

| job | discovery | port | path |
|---|---|---:|---|
| `argocd-applicationset-controller` | pod (label component=applicationset-controller) | 8080 | /metrics |
| `trivy-server` | static svc | 4954 | /metrics |
| `vault` | static svc vault-active | 8200 | /v1/sys/metrics |
| `mimir-self` | pod (label name=mimir) | 8080 | /metrics |
| `loki-self` | pod (label name=loki) | 3100 | /metrics |
| `grafana-self` | pod (label name=grafana) | 3000 | /metrics |
| `tempo-self` | pod (label name=tempo) | 3100 | /metrics |
| `pyroscope-self` | pod (label name=pyroscope) | 4040 | /metrics |
| `alloy-self` | pod (label name=alloy) | 12345 | /metrics |

### alloy — fixed external-secrets target

The `external-secrets-metrics.external-secrets.svc:8080` target the previous config used **does not exist** (`kubectl get svc -n external-secrets` returns only `external-secrets-webhook`). Switched to pod-discovery role=pod ns=external-secrets keep label app.kubernetes.io/name=external-secrets → port 8080.

### vault — `unauthenticated_metrics_access`

`/v1/sys/metrics` returns 403 by default. Adds the telemetry block inside the listener "tcp" HCL stanza in both provider branches of `bootstrap/platform-root/templates/vault.yaml`. Network is restricted by NetworkPolicy `allow-vault` (port 8200 from grafana ns only) — endpoint exposes only operational counters/gauges, no secrets.

### mimir — `max_global_series_per_user` 150k → 500k

Direct evidence from cortex prd alloy logs:

```
non-recoverable error ... err='per-user series limit of 150000
exceeded (err-mimir-max-series-per-user)' ... 2000 samples failed
```

Existing pipelines (kyverno_*, cnpg_*) had samples silently dropped. Bumped to 500k — covers KSM (~50k) + kyverno (~30k) + cnpg (~10k) + grafana self-monitoring (~80k) + cortex apps (~20k) with 4× headroom.

## Validated via `helm template`

```
$ helm template t alloy-1.6 -f core/components/grafana-stack/alloy-values.yaml
  scrape blocks confirmed in render:
  ✓ argocd_applicationset
  ✓ trivy_server
  ✓ vault
  ✓ mimir_self / loki_self / grafana_self / tempo_self / pyroscope_self / alloy_self
  ✓ external_secrets (now via pod-discovery)
```

## Companion downstream PR

NetworkPolicy fixes (cert-manager 9402, cnpg-system 8080+9187, trivy-system 8080+4954 from grafana) ship via [Estabilis/estabilis-platform-gitops#38](https://github.com/Estabilis/estabilis-platform-gitops/pull/38) → tag v0.39.7.

Bumping `platform_version=v0.37.0` + `platformGitopsVersion=v0.39.7` in a client repo unlocks the full visibility sweep.

## Test plan

- [x] `helm template` confirms render emits all new scrape jobs
- [x] alloy-values.yaml YAML parse passes
- [x] vault.yaml template render passes (Helm parameter HCL string)
- [ ] After merge + tag + cortex prd bump: re-curl `up{job=...}` for all components; expect up=1 across the board
- [ ] Confirm Mimir `count({__name__=~"kyverno_.*"})` > 0 (was 0 due to series limit drop)
- [ ] Confirm vault metrics readable: `kyverno run curl -- curl http://vault-active:8200/v1/sys/metrics?format=prometheus | head` returns metrics, not 403