### PR TITLE
fix(mimir-rules): upload rules via mimirtool Job on AWS

### DIFF
--- a/bootstrap/platform-root/templates/grafana-stack.yaml
+++ b/bootstrap/platform-root/templates/grafana-stack.yaml
@@ -402,6 +402,11 @@ spec:
       helm:
         valueFiles:
           - $values/core/components/mimir-rules/values.yaml
+          # Provider-specific values (e.g. values-aws.yaml flips uploadJob.enabled
+          # because mimir-values-aws.yaml forces ruler_storage to S3, which makes
+          # the ConfigMap mount in the Ruler pod a no-op). ignoreMissingValueFiles
+          # below allows providers without an overlay (e.g. azure today) to skip.
+          - $values/core/components/mimir-rules/values-{{ .Values.global.provider }}.yaml
           {{- include "platform-root.overrideValueFile" (dict "component" "mimir-rules" "root" $) | nindent 10 }}
         {{- include "platform-root.ignoreMissingValueFiles" $ | nindent 8 }}
         {{- include "platform-root.provenanceParametersBlock" $ | nindent 8 }}

--- a/core/components/mimir-rules/Chart.yaml
+++ b/core/components/mimir-rules/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: mimir-rules
 description: Alerting rules for the Estabilis Platform — uploaded to Mimir Ruler via API
 type: application
-version: 0.1.0
+version: 0.2.0

--- a/core/components/mimir-rules/templates/upload-job.yaml
+++ b/core/components/mimir-rules/templates/upload-job.yaml
@@ -1,3 +1,84 @@
-# Removed: PostSync Job replaced by ruler.extraVolumeMounts in mimir-values.yaml
-# The ConfigMap mimir-alerting-rules is now mounted directly in the ruler pod
-# at /data/rules/anonymous/ — no HTTP upload needed.
+{{- /*
+PostSync Job that uploads alerting rules to the Mimir Ruler API.
+
+Background — why this Job exists despite the ConfigMap mount in
+core/components/grafana-stack/mimir-values.yaml:
+
+  The mount at /data/rules/anonymous/ works only when the Ruler is
+  configured with `ruler_storage.backend: local` (Azure default,
+  inherited from upstream mimir-values.yaml). On AWS the overlay
+  mimir-values-aws.yaml flips the backend to `s3` because the Mimir
+  chart validator rejects sharing one bucket across storage classes
+  without distinct `storage_prefix` per class. Once the Ruler is
+  reading from S3, the local mount is dead weight — nothing reads it.
+
+  This Job restores the original "upload via API" approach but only
+  when explicitly enabled (uploadJob.enabled), so Azure clusters keep
+  using the cheaper mount-based approach untouched.
+*/ -}}
+{{- if .Values.uploadJob.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mimir-rules-upload
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/sync-wave: "1"
+    {{- include "estabilis.annotations" . | nindent 4 }}
+  labels:
+    {{- include "estabilis.labels" . | nindent 4 }}
+spec:
+  backoffLimit: 5
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        {{- include "estabilis.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: mimirtool
+          image: {{ .Values.uploadJob.image | quote }}
+          imagePullPolicy: IfNotPresent
+          args:
+            - rules
+            - sync
+            - --address={{ .Values.uploadJob.mimirAddress }}
+            - --id={{ .Values.uploadJob.tenantId }}
+            {{- if .Values.ruleGroups.platformDown.enabled }}
+            - /etc/rules/tier1-platform-down.yaml
+            {{- end }}
+            {{- if .Values.ruleGroups.platformDegradation.enabled }}
+            - /etc/rules/tier2-degradation.yaml
+            {{- end }}
+            {{- if .Values.ruleGroups.platformOperational.enabled }}
+            - /etc/rules/tier3-operational.yaml
+            {{- end }}
+            {{- range $name, $_ := .Values.customRuleGroups }}
+            - /etc/rules/custom-{{ $name }}.yaml
+            {{- end }}
+          volumeMounts:
+            - name: rules
+              mountPath: /etc/rules
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          resources:
+            {{- toYaml .Values.uploadJob.resources | nindent 12 }}
+      volumes:
+        - name: rules
+          configMap:
+            name: mimir-alerting-rules
+{{- end }}

--- a/core/components/mimir-rules/values-aws.yaml
+++ b/core/components/mimir-rules/values-aws.yaml
@@ -1,0 +1,19 @@
+# AWS-specific mimir-rules values
+# Loaded in addition to values.yaml when provider=aws (selected by
+# bootstrap/platform-root/templates/grafana-stack.yaml).
+#
+# Why this file exists:
+#   core/components/grafana-stack/mimir-values-aws.yaml flips
+#   ruler_storage.backend and alertmanager_storage.backend from the
+#   local/filesystem defaults to s3, because the Mimir chart validator
+#   rejects sharing a bucket across storage classes without distinct
+#   storage_prefix values. Once the Ruler is reading from S3, the
+#   ConfigMap mount at /data/rules/anonymous/ (which works on Azure)
+#   becomes a no-op — nothing on the filesystem is ever read.
+#
+#   Flipping uploadJob.enabled = true here triggers the PostSync Job
+#   defined in templates/upload-job.yaml, which uses `mimirtool rules
+#   sync` to push each tier file via HTTP into the Mimir Ruler API.
+#   The Ruler then persists the rules into S3 itself.
+uploadJob:
+  enabled: true

--- a/core/components/mimir-rules/values-azure.yaml
+++ b/core/components/mimir-rules/values-azure.yaml
@@ -1,0 +1,16 @@
+# Azure-specific mimir-rules values
+# Loaded in addition to values.yaml when provider=azure (selected by
+# bootstrap/platform-root/templates/grafana-stack.yaml).
+#
+# Intentionally empty: on Azure the Mimir Ruler runs with the upstream
+# `ruler_storage.backend: local` default (mimir-values.yaml), and the
+# ConfigMap `mimir-alerting-rules` is mounted directly at
+# /data/rules/anonymous/ via extraVolumeMounts in
+# core/components/grafana-stack/mimir-values.yaml. No HTTP upload Job
+# is needed.
+#
+# This file exists only to satisfy the unconditional valueFiles entry
+# in platform-root/templates/grafana-stack.yaml; deleting it would
+# fail ArgoCD sync on clusters without an overrides repo (where
+# ignoreMissingValueFiles is not emitted).
+{}

--- a/core/components/mimir-rules/values.yaml
+++ b/core/components/mimir-rules/values.yaml
@@ -21,3 +21,37 @@ ruleGroups:
 #           annotations:
 #             summary: "My app is down"
 customRuleGroups: {}
+
+# Upload mechanism for rules — defaults to OFF.
+#
+# When enabled=false (default, used on Azure):
+#   The ConfigMap `mimir-alerting-rules` is mounted directly into the
+#   Mimir Ruler pod at /data/rules/anonymous/ (via extraVolumeMounts in
+#   core/components/grafana-stack/mimir-values.yaml). The Ruler reads
+#   rules from local filesystem because Azure overlay leaves
+#   ruler_storage.backend = local (the upstream default).
+#
+# When enabled=true (used on AWS — see values-aws.yaml):
+#   The mount above is a no-op because mimir-values-aws.yaml flips
+#   ruler_storage.backend to s3 (chart validator requires distinct
+#   bucket+prefix per storage class — see comment in mimir-values-aws.yaml).
+#   This Job runs as a PostSync hook and uses `mimirtool rules sync` to
+#   upload each rule file to the Mimir Ruler API, which then persists
+#   them to S3 under `<bucket>/ruler/<tenant>/`.
+uploadJob:
+  enabled: false
+  # mimirtool image. Pin a known-good tag; bump deliberately.
+  image: grafana/mimirtool:3.0.6
+  # Address of the Mimir gateway (or ruler) inside the cluster.
+  # Gateway is preferred — nginx routes /api/v1/rules/* to the ruler.
+  mimirAddress: http://grafana-mimir-gateway.grafana.svc.cluster.local
+  # Tenant ID used for X-Scope-OrgID. Matches the tenant Alloy writes
+  # to (gateway nginx injects `anonymous` when no header is sent).
+  tenantId: anonymous
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi


### PR DESCRIPTION
## Summary
- Re-introduce a PostSync Job that uses `mimirtool rules sync` to push the platform alerting rules into the Mimir Ruler API on AWS. The rules ConfigMap mount in the Ruler pod (mimir-values.yaml) only works while `ruler_storage.backend = local` (Azure default); AWS overlay flips it to S3 because the Mimir chart validator requires distinct `storage_prefix` per storage class on a shared bucket. With the bucket-backed Ruler, the mount is dead weight and `GET /prometheus/api/v1/rules` returns `groups: []`.
- Job is gated by `uploadJob.enabled` (default `false`) and only enabled by `values-aws.yaml`, so Azure stays untouched.
- Chart bumps `0.1.0 → 0.2.0` (MINOR — new templated resource).
- Adds `values-azure.yaml` (empty placeholder) so platform-root keeps rendering on clusters without an overrides repo (where `ignoreMissingValueFiles` isn't emitted).

## Live validation (AWS prd, before PR)
Patch was applied directly to a bucket-backed AWS cluster with auto-sync briefly disabled.

- Job pod completed in ~5s, exit 0.
- `mimirtool` log: `Sync Summary: 3 Groups Created, 0 Updated, 0 Deleted`.
- Ruler API for tenant `anonymous`: 3 groups / 33 rules (13 + 14 + 6 — matches Azure HML).
- S3 `ruler/rules/anonymous/` populated with 3 base64-encoded namespace/group objects.
- Re-run with the same image idempotent: `Sync Summary: 0 Created, 0 Updated, 0 Deleted`.

## Test plan
- [ ] `helm lint core/components/mimir-rules` passes for `values.yaml`, `values.yaml + values-aws.yaml`, and `values.yaml + values-azure.yaml`.
- [ ] `helm template core/components/mimir-rules` with default values renders only the ConfigMap (Job absent — Azure path unchanged).
- [ ] `helm template core/components/mimir-rules -f values.yaml -f values-aws.yaml` renders ConfigMap + Job with `image: grafana/mimirtool:3.0.6`, `--id=anonymous`, and three tier file args.
- [ ] `helm template bootstrap/platform-root --set global.provider=azure` produces a `mimir-rules` Application referencing `values-azure.yaml`; same with `provider=aws` referencing `values-aws.yaml`.
- [ ] On an AWS deployment after promote: `kubectl logs -n grafana job/mimir-rules-upload` shows `Sync Summary` line; `curl -H 'X-Scope-OrgID: anonymous' …/prometheus/api/v1/rules` returns 3 groups; bucket prefix `ruler/rules/anonymous/` populated.
- [ ] On an Azure deployment after promote: no Job created; existing mount-based behaviour preserved (`groups: []` would indicate regression).