### PR TITLE
feat(mimir-alertmanager-config): platform standard for AM routing

### DIFF
--- a/bootstrap/platform-root/templates/grafana-stack.yaml
+++ b/bootstrap/platform-root/templates/grafana-stack.yaml
@@ -429,3 +429,73 @@ spec:
         maxDuration: 3m
 {{- end }}
 {{- end }}
+
+---
+{{- /* observability: Mimir Alertmanager tenant config + Grafana NGAlert
+       routing setup. Downstream can disable via
+       components.mimir-alertmanager-config: false. Both this and
+       grafana-mimir gate the Application because the chart's Job
+       depends on the Mimir gateway being deployed. */ -}}
+{{- if ne (index .Values.components "mimir-alertmanager-config") false }}
+{{- if ne (index .Values.components "mimir") false }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mimir-alertmanager-config
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "8"
+spec:
+  project: platform
+  sources:
+    - repoURL: {{ .Values.platformRepoUrl }}
+      targetRevision: {{ .Values.platformVersion }}
+      path: core/components/mimir-alertmanager-config
+      helm:
+        valueFiles:
+          - $values/core/components/mimir-alertmanager-config/values.yaml
+          # Provider-specific overlay (currently empty placeholders for
+          # both providers — provider-specific behaviour is driven by
+          # parameters below). Mirrors the mimir-rules pattern.
+          - $values/core/components/mimir-alertmanager-config/values-{{ .Values.global.provider }}.yaml
+          {{- include "platform-root.overrideValueFile" (dict "component" "mimir-alertmanager-config" "root" $) | nindent 10 }}
+        {{- include "platform-root.ignoreMissingValueFiles" $ | nindent 8 }}
+        {{- include "platform-root.provenanceParametersBlock" $ | nindent 8 }}
+        parameters:
+          {{- /* slack.enabled gate — same openai pattern. AWS gets the
+                value computed by providers/aws/platform-outputs.tf
+                (`global.slackAlertingEnabled` = tostring(var.slack_alerting_enabled));
+                Azure stays false unless a downstream override flips it. */}}
+          - name: slack.enabled
+            value: "{{ default false .Values.global.slackAlertingEnabled }}"
+          {{- if eq .Values.global.provider "aws" }}
+          {{- /* AWS Secrets Manager secrets live under
+                estabilis/<deploymentId>/* (the IRSA scope for external-secrets).
+                ExternalSecret remoteRef.key must be the full SM secret name.
+                Pattern matches core/components/platform-secrets templates. */}}
+          - name: kvSecrets.slackWebhookCritical
+            value: "{{ .Values.global.secretsPathPrefix }}/platform-alertmanager-slack-critical"
+          - name: kvSecrets.slackWebhookWarnings
+            value: "{{ .Values.global.secretsPathPrefix }}/platform-alertmanager-slack-warnings"
+          - name: kvSecrets.slackWebhookInfo
+            value: "{{ .Values.global.secretsPathPrefix }}/platform-alertmanager-slack-info"
+          {{- end }}
+    - repoURL: {{ .Values.platformRepoUrl }}
+      targetRevision: {{ .Values.platformVersion }}
+      ref: values
+    {{- include "platform-root.overrideSource" . | nindent 4 }}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: grafana
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+{{- end }}
+{{- end }}

--- a/core/components/grafana-stack/grafana-values.yaml
+++ b/core/components/grafana-stack/grafana-values.yaml
@@ -14,16 +14,47 @@ datasources:
         jsonData:
           timeInterval: 30s
           httpHeaderName1: X-Scope-OrgID
+          # Surface mimir-rules groups under Alerting -> Alert rules
+          # natively (no datasource view toggle needed in the UI).
+          manageAlerts: true
+          manageAlertingRules: true
+          # Tell Grafana this Prometheus is Mimir-flavored so it uses
+          # the Mimir Ruler config API path (/config/v1/rules/<ns>)
+          # instead of vanilla Prometheus paths. Validated 2026-05-03 via
+          # /api/datasources/uid/mimir/health -> features.rulerApiEnabled=true.
+          # Lets the Alerting -> Alert rules UI create/edit "Data source-
+          # managed" rules directly in Mimir Ruler (S3-backed on AWS,
+          # filesystem on Azure).
+          # CAVEAT: editing one of the platform rules shipped via the
+          # mimir-rules ConfigMap from the UI creates drift between git
+          # (ConfigMap) and the Ruler backend. Convention: rules that
+          # should live in git stay in the ConfigMap; ad-hoc/experimental
+          # rules are created via UI.
+          prometheusType: Mimir
+          prometheusVersion: "3.0.1"
         secureJsonData:
           httpHeaderValue1: anonymous
       - name: Mimir Alertmanager
         uid: mimir-alertmanager
         type: alertmanager
         access: proxy
-        url: http://grafana-mimir-gateway.grafana.svc.cluster.local/alertmanager
+        # NOTE: URL is the gateway ROOT, not /alertmanager. The Grafana
+        # proxy calls `<url>/api/v1/alerts` for tenant config; with the
+        # /alertmanager suffix the call hit the deprecated AM v1 API and
+        # got HTTP 410 (validated 2026-05-03 in cortex prd). Root URL
+        # routes correctly to Mimir's multitenant config endpoint.
+        url: http://grafana-mimir-gateway.grafana.svc.cluster.local
         jsonData:
           implementation: mimir
           httpHeaderName1: X-Scope-OrgID
+          # Allow Grafana UI to surface this AM's contact points + routing
+          # tree, and accept Grafana-managed alert routing through this AM
+          # (mimir-alertmanager-config chart's grafana-ngalert-external-am
+          # Job sets alertmanagersChoice=external + external_alertmanager_uid
+          # = mimir-alertmanager so Grafana auto-discovers this datasource
+          # as the dispatch target).
+          manageAlerts: true
+          handleGrafanaManagedAlerts: true
         secureJsonData:
           httpHeaderValue1: anonymous
       - name: Loki

--- a/core/components/mimir-alertmanager-config/Chart.yaml
+++ b/core/components/mimir-alertmanager-config/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: mimir-alertmanager-config
+description: Tenant Alertmanager configuration uploader for the platform's Mimir deployment, plus Grafana NGAlert routing setup
+type: application
+version: 0.1.0

--- a/core/components/mimir-alertmanager-config/files/alertmanager.yaml.tpl
+++ b/core/components/mimir-alertmanager-config/files/alertmanager.yaml.tpl
@@ -1,0 +1,117 @@
+{{- /*
+Alertmanager configuration template for Mimir.
+
+Two layers of templating:
+  1. Helm `tpl` renders this file at chart-sync time, materialising the
+     channel names, routing tree, repeat intervals, etc. from
+     .Values.slack.* into static YAML.
+  2. The rendered YAML still contains __SLACK_WEBHOOK_*__ placeholders
+     for the secret values; the Job's initContainer substitutes those
+     at runtime before calling `mimirtool alertmanager load`.
+
+The double-curly literals like `{{` `}}` you see below escape the
+inner Go templates that Alertmanager itself processes when formatting
+each notification (so the sequence `{{` ... `}}` survives Helm rendering
+and reaches Alertmanager intact).
+
+Template functions: Alertmanager uses Go text/template + a small set of
+helpers (toUpper, toLower, title, join, match, reReplaceAll, safeHtml,
+stringSlice). It does NOT include Sprig's `default` — use `or` (text/
+template builtin: returns first non-empty arg) for missing-label fallback.
+Confirmed in cortex prd 2026-05-03 by `function "default" not defined`
+notify error.
+*/ -}}
+route:
+  receiver: slack-warnings
+  group_by: {{ toJson .Values.slack.defaults.groupBy }}
+  group_wait: {{ .Values.slack.defaults.groupWait }}
+  group_interval: {{ .Values.slack.defaults.groupInterval }}
+  repeat_interval: {{ .Values.slack.defaults.repeatInterval }}
+  routes:
+{{- if .Values.slack.channels.critical.enabled }}
+    - matchers:
+        - tier="{{ .Values.slack.channels.critical.tier }}"
+      receiver: slack-critical
+      group_wait: {{ .Values.slack.channels.critical.groupWait }}
+      repeat_interval: {{ .Values.slack.channels.critical.repeatInterval }}
+      continue: {{ .Values.slack.criticalContinue }}
+{{- end }}
+{{- if .Values.slack.channels.warnings.enabled }}
+    - matchers:
+        - tier="{{ .Values.slack.channels.warnings.tier }}"
+      receiver: slack-warnings
+      group_wait: {{ .Values.slack.channels.warnings.groupWait }}
+      repeat_interval: {{ .Values.slack.channels.warnings.repeatInterval }}
+{{- end }}
+{{- if .Values.slack.channels.info.enabled }}
+    - matchers:
+        - tier="{{ .Values.slack.channels.info.tier }}"
+      receiver: slack-info
+      group_wait: {{ .Values.slack.channels.info.groupWait }}
+      repeat_interval: {{ .Values.slack.channels.info.repeatInterval }}
+{{- end }}
+
+inhibit_rules:
+  # A firing critical alert silences related warning/info alerts so a
+  # single underlying incident doesn't page three times in three channels.
+  - source_matchers:
+      - severity="critical"
+    target_matchers:
+      - severity=~"warning|info"
+    equal: [alertname, namespace]
+
+receivers:
+{{- if .Values.slack.channels.critical.enabled }}
+  - name: slack-critical
+    slack_configs:
+      - api_url: __SLACK_WEBHOOK_CRITICAL__
+        channel: '{{ .Values.slack.channels.critical.channelName }}'
+        send_resolved: {{ if hasKey .Values.slack.channels.critical "sendResolved" }}{{ .Values.slack.channels.critical.sendResolved }}{{ else }}{{ .Values.slack.defaults.sendResolved }}{{ end }}
+        color: '{{ .Values.slack.channels.critical.color }}'
+        title: '{{`[{{ .Status | toUpper }}] {{ .GroupLabels.alertname }}`}}'
+        text: |
+          {{`*Cluster:* {{ or .CommonLabels.cluster "?" }}`}}
+          {{`*Namespace:* {{ or .CommonLabels.namespace "?" }}`}}
+          {{`*Tier:* {{ or .CommonLabels.tier "?" }} | *Severity:* {{ or .CommonLabels.severity "?" }}`}}
+          {{`{{ range .Alerts -}}`}}
+          {{`  • *{{ .Annotations.summary }}*`}}
+          {{`    {{ .Annotations.description }}`}}
+          {{`{{ end }}`}}
+{{- end }}
+{{- if .Values.slack.channels.warnings.enabled }}
+  - name: slack-warnings
+    slack_configs:
+      - api_url: __SLACK_WEBHOOK_WARNINGS__
+        channel: '{{ .Values.slack.channels.warnings.channelName }}'
+        send_resolved: {{ if hasKey .Values.slack.channels.warnings "sendResolved" }}{{ .Values.slack.channels.warnings.sendResolved }}{{ else }}{{ .Values.slack.defaults.sendResolved }}{{ end }}
+        color: '{{ .Values.slack.channels.warnings.color }}'
+        title: '{{`[{{ .Status | toUpper }}] {{ .GroupLabels.alertname }}`}}'
+        text: |
+          {{`*Cluster:* {{ or .CommonLabels.cluster "?" }}`}}
+          {{`*Namespace:* {{ or .CommonLabels.namespace "?" }}`}}
+          {{`*Tier:* {{ or .CommonLabels.tier "?" }} | *Severity:* {{ or .CommonLabels.severity "?" }}`}}
+          {{`{{ range .Alerts -}}`}}
+          {{`  • *{{ .Annotations.summary }}*`}}
+          {{`    {{ .Annotations.description }}`}}
+          {{`{{ end }}`}}
+{{- end }}
+{{- if .Values.slack.channels.info.enabled }}
+  - name: slack-info
+    slack_configs:
+      - api_url: __SLACK_WEBHOOK_INFO__
+        channel: '{{ .Values.slack.channels.info.channelName }}'
+        send_resolved: {{ if hasKey .Values.slack.channels.info "sendResolved" }}{{ .Values.slack.channels.info.sendResolved }}{{ else }}{{ .Values.slack.defaults.sendResolved }}{{ end }}
+        color: '{{ .Values.slack.channels.info.color }}'
+        title: '{{`[{{ .Status | toUpper }}] {{ .GroupLabels.alertname }}`}}'
+        text: |
+          {{`*Cluster:* {{ or .CommonLabels.cluster "?" }}`}}
+          {{`*Namespace:* {{ or .CommonLabels.namespace "?" }}`}}
+          {{`*Tier:* {{ or .CommonLabels.tier "?" }}`}}
+          {{`{{ range .Alerts -}}`}}
+          {{`  • {{ .Annotations.summary }}`}}
+          {{`{{ end }}`}}
+{{- end }}
+  # `null` receiver is mandatory in Alertmanager configs even when nothing
+  # routes there — the Mimir AM config validator complains about
+  # unreachable receivers but accepts a placeholder.
+  - name: 'null'

--- a/core/components/mimir-alertmanager-config/templates/_helpers.tpl
+++ b/core/components/mimir-alertmanager-config/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{/*
+Estabilis Platform — standard metadata helpers.
+
+Duplicated identically across every internal chart in the platform
+(Option 2 from estabilis-platform-tools issue #45). Keep them in sync —
+if you change one, run
+`git grep -A 8 "define \"estabilis.labels\""` across core/components
+and apply the same edit everywhere.
+*/}}
+{{- define "estabilis.labels" -}}
+estabilis.io/component: {{ .Chart.Name }}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: estabilis-platform
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "estabilis.annotations" -}}
+estabilis.io/platform: "Estabilis Platform"
+estabilis.io/chart-version: {{ .Chart.Version | quote }}
+estabilis.io/website: "https://estabilis.com"
+estabilis.io/source: "https://github.com/Estabilis/estabilis-platform"
+estabilis.io/support: "ops@estabilis.com"
+estabilis.io/license: "proprietary"
+{{- include "estabilis.provenanceAnnotations" . }}
+{{- end -}}
+
+{{- define "estabilis.provenanceAnnotations" -}}
+{{- if and .Values.global .Values.global.provenance .Values.global.provenance.gitRevision }}
+estabilis.io/git-revision: {{ .Values.global.provenance.gitRevision | quote }}
+estabilis.io/git-source: {{ .Values.global.provenance.gitSource | quote }}
+estabilis.io/built-at: {{ .Values.global.provenance.builtAt | quote }}
+estabilis.io/build-id: {{ .Values.global.provenance.buildId | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "estabilis.metadata" -}}
+labels:
+  {{- include "estabilis.labels" . | nindent 2 }}
+annotations:
+  {{- include "estabilis.annotations" . | nindent 2 }}
+{{- end -}}

--- a/core/components/mimir-alertmanager-config/templates/configmap.yaml
+++ b/core/components/mimir-alertmanager-config/templates/configmap.yaml
@@ -1,0 +1,25 @@
+{{- /*
+ConfigMap holding the Alertmanager YAML *template* — webhook URLs are
+placeholders (__SLACK_WEBHOOK_*__) substituted at runtime by the
+upload-job.yaml initContainer using values pulled from the K8s Secret
+produced by external-secret.yaml in this chart.
+
+We render the template via Helm `tpl` so per-channel settings
+(channelName, color, repeatInterval, etc.) and the routing tree are
+materialised at chart-sync time; only the secret values are deferred.
+
+Gated on slack.enabled — without Slack receivers there's no point
+shipping the AM config (Mimir AM keeps its in-pod fallback YAML, which
+on AWS is unused but on Azure remains the active config).
+*/ -}}
+{{- if .Values.slack.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertmanager-config-template
+  namespace: {{ .Release.Namespace }}
+  {{- include "estabilis.metadata" . | nindent 2 }}
+data:
+  alertmanager.yaml.tpl: |
+{{ tpl (.Files.Get "files/alertmanager.yaml.tpl") . | indent 4 }}
+{{- end }}

--- a/core/components/mimir-alertmanager-config/templates/external-secret.yaml
+++ b/core/components/mimir-alertmanager-config/templates/external-secret.yaml
@@ -1,0 +1,52 @@
+{{- /*
+ExternalSecret pulling the three Slack webhook URLs from the platform
+secret store (`platform-secret-store`, ESO ClusterSecretStore wired by
+core/components/external-secrets — AWS Secrets Manager on AWS, Key Vault
+on Azure). Resulting K8s Secret `alertmanager-slack-webhooks` carries
+one key per channel:
+  - critical
+  - warnings
+  - info
+
+Gated on slack.enabled to follow the openai_api_key precedent (chart
+does NOT render the ExternalSecret when the upstream secret won't
+exist — keeps the cluster clean of perpetual SecretSyncError noise on
+deployments that haven't enabled the integration).
+
+The remoteRef.key values are SHORT defaults in values.yaml; on AWS the
+platform-root template overrides each with the full prefixed path
+`estabilis/<deploymentId>/...` (same mechanism as
+core/components/platform-secrets `kvSecrets`).
+*/ -}}
+{{- if .Values.slack.enabled }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alertmanager-slack-webhooks
+  namespace: {{ .Release.Namespace }}
+  {{- include "estabilis.metadata" . | nindent 2 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: platform-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: alertmanager-slack-webhooks
+    creationPolicy: Owner
+  data:
+    {{- if .Values.slack.channels.critical.enabled }}
+    - secretKey: critical
+      remoteRef:
+        key: {{ .Values.kvSecrets.slackWebhookCritical | quote }}
+    {{- end }}
+    {{- if .Values.slack.channels.warnings.enabled }}
+    - secretKey: warnings
+      remoteRef:
+        key: {{ .Values.kvSecrets.slackWebhookWarnings | quote }}
+    {{- end }}
+    {{- if .Values.slack.channels.info.enabled }}
+    - secretKey: info
+      remoteRef:
+        key: {{ .Values.kvSecrets.slackWebhookInfo | quote }}
+    {{- end }}
+{{- end }}

--- a/core/components/mimir-alertmanager-config/templates/grafana-ngalert-admin-config-job.yaml
+++ b/core/components/mimir-alertmanager-config/templates/grafana-ngalert-admin-config-job.yaml
@@ -1,0 +1,112 @@
+{{- /*
+Set Grafana NGAlert `alertmanagersChoice = external` so any rule created
+via Grafana UI ("Grafana-managed" rules) routes through the Mimir
+Alertmanager instead of Grafana's built-in (empty) AM. Combined with
+`handleGrafanaManagedAlerts: true` on the Mimir AM datasource (set in
+core/components/grafana-stack/grafana-values.yaml), Grafana auto-
+discovers Mimir AM and dispatches there.
+
+Why a Job instead of a config file:
+  alertmanagersChoice lives in Grafana's `ngalert_configuration` table
+  (per-org row). There is NO grafana.ini key and NO file-based
+  provisioning hook for it — confirmed by inspecting Grafana 12.x source
+  (pkg/services/ngalert/store/admin_configuration.go). The only way to
+  set it as code is to call the admin_config API after Grafana is up.
+
+Idempotence: POST /api/v1/ngalert/admin_config overwrites the row.
+
+Survivability: persists in CNPG (Postgres). A pod restart or chart
+resync doesn't lose the setting. This Job exists to recover from a
+CNPG-recreate-without-restore scenario, AND to make the platform
+reproducible on a fresh cluster (zero-touch from operator).
+
+Always renders when chart is installed (gated only by chart presence
+via components.mimir-alertmanager-config in platform-root). Independent
+of slack.enabled — the standard "Mimir AM is the source of truth for
+routing" applies whether or not Slack receivers are configured.
+*/ -}}
+{{- if .Values.grafanaExternalAm.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: grafana-ngalert-external-am
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/sync-wave: "2"
+    {{- include "estabilis.annotations" . | nindent 4 }}
+  labels:
+    {{- include "estabilis.labels" . | nindent 4 }}
+spec:
+  backoffLimit: 5
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        {{- include "estabilis.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: set-external-am
+          image: {{ .Values.images.curl | quote }}
+          imagePullPolicy: IfNotPresent
+          command: ['/bin/sh', '-c']
+          args:
+            - |
+              set -eu
+              GRAFANA_URL="http://grafana.{{ .Release.Namespace }}.svc.cluster.local"
+              # Wait until grafana /api/health returns OK (db: ok). Up to ~2 min.
+              echo "waiting for Grafana to be reachable at ${GRAFANA_URL}/api/health..."
+              for i in $(seq 1 60); do
+                if curl -sS --fail --max-time 3 "${GRAFANA_URL}/api/health" >/dev/null 2>&1; then
+                  echo "  grafana reachable on attempt ${i}"
+                  break
+                fi
+                sleep 2
+              done
+              echo "current admin_config:"
+              curl -sS -u "admin:${ADMIN_PASSWORD}" "${GRAFANA_URL}/api/v1/ngalert/admin_config" || true
+              echo
+              # Set alertmanagersChoice = external. external_alertmanager_uid
+              # enables Grafana UI <-> Mimir AM contact-points/notification-policies
+              # config sync via the named datasource.
+              echo "POST /api/v1/ngalert/admin_config (alertmanagersChoice=external, external_alertmanager_uid={{ .Values.grafanaExternalAm.alertmanagerDatasourceUid }})..."
+              HTTP=$(curl -sS -o /tmp/resp.json -w '%{http_code}' \
+                -u "admin:${ADMIN_PASSWORD}" \
+                -H 'Content-Type: application/json' \
+                -X POST \
+                "${GRAFANA_URL}/api/v1/ngalert/admin_config" \
+                -d '{"alertmanagersChoice":"external","external_alertmanager_uid":"{{ .Values.grafanaExternalAm.alertmanagerDatasourceUid }}"}')
+              echo "HTTP ${HTTP}"
+              cat /tmp/resp.json
+              echo
+              if [ "${HTTP}" != "201" ] && [ "${HTTP}" != "200" ]; then
+                echo "ERROR: unexpected HTTP ${HTTP}"
+                exit 1
+              fi
+              echo "post-update admin_config:"
+              curl -sS -u "admin:${ADMIN_PASSWORD}" "${GRAFANA_URL}/api/v1/ngalert/admin_config"
+              echo
+              echo "done"
+          env:
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-admin-credentials
+                  key: admin-password
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: [ALL]
+          resources:
+            {{- toYaml .Values.resources.curl | nindent 12 }}
+{{- end }}

--- a/core/components/mimir-alertmanager-config/templates/upload-job.yaml
+++ b/core/components/mimir-alertmanager-config/templates/upload-job.yaml
@@ -1,0 +1,129 @@
+{{- /*
+PostSync Job that uploads the rendered Alertmanager configuration to the
+Mimir Alertmanager API for tenant `anonymous`.
+
+Two-container pipeline:
+  - initContainer (busybox): substitutes __SLACK_WEBHOOK_*__ placeholders
+    in the YAML template (mounted from ConfigMap) with values pulled
+    from the alertmanager-slack-webhooks Secret. Writes rendered config
+    to a shared emptyDir.
+  - main container (mimirtool): calls
+    `mimirtool alertmanager load /shared/alertmanager.yaml` against the
+    Mimir gateway. mimirtool is distroless — that's why the substitution
+    happens in a separate container that has a shell.
+
+Why not env-var expansion in fallbackConfig:
+  Mimir's `-config.expand-env=true` flag interpolates env vars in the
+  *global* Mimir process config (mimir.yaml) only — NOT in the
+  Alertmanager fallback config file. Confirmed reading
+  pkg/alertmanager/multitenant.go on grafana/mimir main: fallback file
+  is loaded with `os.ReadFile()` raw, no expansion. So secrets must be
+  inlined at upload time.
+
+Idempotence: `mimirtool alertmanager load` overwrites the tenant config
+in place; re-running this Job is safe. hook-delete-policy
+`BeforeHookCreation,HookSucceeded` cleans up successful runs and only
+retains failed ones for triage.
+
+Gated on slack.enabled.
+*/ -}}
+{{- if .Values.slack.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mimir-alertmanager-config-upload
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/sync-wave: "1"
+    {{- include "estabilis.annotations" . | nindent 4 }}
+  labels:
+    {{- include "estabilis.labels" . | nindent 4 }}
+spec:
+  backoffLimit: 5
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        {{- include "estabilis.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: render-config
+          image: {{ .Values.images.shell | quote }}
+          imagePullPolicy: IfNotPresent
+          command: ['/bin/sh', '-c']
+          args:
+            - |
+              set -eu
+              # Substitute __SLACK_WEBHOOK_*__ placeholders. Using `|`
+              # delimiter because URLs contain `/` but never `|`.
+              sed \
+                -e "s|__SLACK_WEBHOOK_CRITICAL__|${SLACK_WEBHOOK_CRITICAL:-}|g" \
+                -e "s|__SLACK_WEBHOOK_WARNINGS__|${SLACK_WEBHOOK_WARNINGS:-}|g" \
+                -e "s|__SLACK_WEBHOOK_INFO__|${SLACK_WEBHOOK_INFO:-}|g" \
+                /etc/am-template/alertmanager.yaml.tpl > /shared/alertmanager.yaml
+              # Sanity log (no URLs printed — just a webhook count to confirm substitution worked).
+              echo "rendered $(wc -l < /shared/alertmanager.yaml) lines, $(grep -c hooks.slack.com /shared/alertmanager.yaml) webhook URLs substituted"
+          env:
+            {{- if .Values.slack.channels.critical.enabled }}
+            - name: SLACK_WEBHOOK_CRITICAL
+              valueFrom: { secretKeyRef: { name: alertmanager-slack-webhooks, key: critical } }
+            {{- end }}
+            {{- if .Values.slack.channels.warnings.enabled }}
+            - name: SLACK_WEBHOOK_WARNINGS
+              valueFrom: { secretKeyRef: { name: alertmanager-slack-webhooks, key: warnings } }
+            {{- end }}
+            {{- if .Values.slack.channels.info.enabled }}
+            - name: SLACK_WEBHOOK_INFO
+              valueFrom: { secretKeyRef: { name: alertmanager-slack-webhooks, key: info } }
+            {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: am-template
+              mountPath: /etc/am-template
+              readOnly: true
+            - name: shared
+              mountPath: /shared
+          resources:
+            {{- toYaml .Values.resources.init | nindent 12 }}
+      containers:
+        - name: mimirtool
+          image: {{ .Values.images.mimirtool | quote }}
+          imagePullPolicy: IfNotPresent
+          args:
+            - alertmanager
+            - load
+            - --address={{ .Values.mimir.gatewayUrl }}
+            - --id={{ .Values.mimir.tenantId }}
+            - /shared/alertmanager.yaml
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          resources:
+            {{- toYaml .Values.resources.mimirtool | nindent 12 }}
+      volumes:
+        - name: am-template
+          configMap:
+            name: alertmanager-config-template
+        - name: shared
+          emptyDir: {}
+{{- end }}

--- a/core/components/mimir-alertmanager-config/values-aws.yaml
+++ b/core/components/mimir-alertmanager-config/values-aws.yaml
@@ -1,0 +1,10 @@
+# AWS-specific overlay for mimir-alertmanager-config.
+# Loaded after values.yaml when provider=aws via
+# bootstrap/platform-root/templates/grafana-stack.yaml.
+#
+# Intentionally empty: the AWS-specific behaviour (slack.enabled flipping
+# based on operator's tfvars) is driven by helm.parameters from the
+# platform-root template (`slack.enabled` from `global.slackAlertingEnabled`
+# + `kvSecrets.*` paths with the full SM prefix). No static value diffs
+# from the chart default are needed here.
+{}

--- a/core/components/mimir-alertmanager-config/values-azure.yaml
+++ b/core/components/mimir-alertmanager-config/values-azure.yaml
@@ -1,0 +1,15 @@
+# Azure-specific overlay for mimir-alertmanager-config.
+# Loaded after values.yaml when provider=azure.
+#
+# Intentionally empty: on Azure the Mimir Alertmanager keeps the upstream
+# `alertmanager_storage.backend: filesystem` default (mimir-values.yaml).
+# The Slack pipeline stays opt-in via the downstream override; the
+# Grafana NGAlert admin-config Job runs unconditionally (chart-level)
+# to set alertmanagersChoice=external — same standard regardless of
+# provider.
+#
+# This file exists to satisfy the unconditional valueFiles entry in
+# bootstrap/platform-root/templates/grafana-stack.yaml; deleting it
+# would fail ArgoCD sync on clusters without an overrides repo (where
+# the platform-root.ignoreMissingValueFiles helper isn't emitted).
+{}

--- a/core/components/mimir-alertmanager-config/values.yaml
+++ b/core/components/mimir-alertmanager-config/values.yaml
@@ -1,0 +1,156 @@
+# Mimir tenant Alertmanager configuration + Grafana NGAlert routing setup.
+#
+# Two pieces under one chart:
+#
+#   1. Slack alerting pipeline (gated on `slack.enabled`):
+#      - ConfigMap with the Alertmanager YAML config TEMPLATE
+#      - ExternalSecret pulling 3 webhook URLs from AWS Secrets Manager
+#      - PostSync Job that substitutes __SLACK_WEBHOOK_*__ placeholders
+#        and uploads the rendered config to Mimir Alertmanager via
+#        `mimirtool alertmanager load`.
+#
+#   2. Grafana NGAlert "external Alertmanager" mode (gated on
+#      `grafanaExternalAm.enabled`, default true):
+#      - PostSync Job that POSTs `alertmanagersChoice=external` to
+#        Grafana's /api/v1/ngalert/admin_config endpoint, so any
+#        Grafana-managed alert rule routes through the Mimir Alertmanager
+#        (discovered via the Mimir Alertmanager datasource that has
+#        `handleGrafanaManagedAlerts: true` set in grafana-stack/grafana-values.yaml).
+#
+# Why one chart instead of two: both pieces are about "Mimir AM is the
+# single source of truth for alert routing on this platform". Splitting
+# them adds two ArgoCD Applications and a sync ordering concern with
+# zero benefit — they have no overlapping resource names and gate
+# independently.
+#
+# Provider behaviour:
+#   - Azure: keeps mimir.alertmanager_storage.backend = filesystem
+#     (mimir-values.yaml). The Slack pipeline can still be opted into,
+#     but its primary motivation (S3-backed multitenant config that
+#     ignores the in-pod fallback) is AWS-specific.
+#   - AWS: mimir-values-aws.yaml flips alertmanager_storage to s3, which
+#     makes the in-pod fallbackConfig file unused — the Slack pipeline
+#     uploads via API as the only path that lands per-tenant config.
+
+# -----------------------------------------------------------------------
+# Slack alerting pipeline (opt-in)
+# -----------------------------------------------------------------------
+slack:
+  # Master flag for the Slack pipeline. On AWS this is overridden via
+  # platform-root helm.parameters from `global.slackAlertingEnabled`
+  # (which `providers/aws/platform-outputs.tf` computes from
+  # `var.slack_alerting_enabled`). Stays false on Azure unless the
+  # downstream override flips it.
+  enabled: false
+
+  channels:
+    critical:
+      enabled: true
+      channelName: "#platform-critical"
+      tier: "1"
+      groupWait: 0s              # critical: no batching delay
+      repeatInterval: 1h         # remind hourly while firing
+      color: danger
+    warnings:
+      enabled: true
+      channelName: "#platform-warnings"
+      tier: "2"
+      groupWait: 30s
+      repeatInterval: 4h
+      color: warning
+    info:
+      enabled: true
+      channelName: "#platform-info"
+      tier: "3"
+      groupWait: 30s
+      repeatInterval: 12h
+      color: "#3b82f6"
+      sendResolved: false        # info volume is high enough that
+                                 # resolved spam is undesirable
+
+  defaults:
+    groupBy: [alertname, cluster, namespace, severity]
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 4h
+    sendResolved: true
+
+  # When true, a tier=1 alert is also forwarded to slack-warnings
+  # (so people watching only -warnings still see escalations).
+  criticalContinue: true
+
+# -----------------------------------------------------------------------
+# Grafana NGAlert external Alertmanager mode
+# -----------------------------------------------------------------------
+grafanaExternalAm:
+  # Always-on by default — the platform standard is "Mimir AM is the
+  # single source of truth for routing", regardless of whether Slack is
+  # configured today. With this true, any Grafana-managed alert rule
+  # (none today, but possible) routes via the Mimir AM the operator has
+  # configured as datasource.
+  enabled: true
+
+  # UID of the Mimir Alertmanager datasource (set in
+  # grafana-stack/grafana-values.yaml). Used to fill the
+  # `external_alertmanager_uid` field of /api/v1/ngalert/admin_config —
+  # enables Grafana UI <-> Mimir AM contact-points/notification-policies
+  # config sync.
+  alertmanagerDatasourceUid: mimir-alertmanager
+
+# -----------------------------------------------------------------------
+# Mimir gateway address (in-cluster, fixed by the chart)
+# -----------------------------------------------------------------------
+mimir:
+  gatewayUrl: http://grafana-mimir-gateway.grafana.svc.cluster.local
+  # Tenant ID. Matches the tenant Alloy writes metrics to (gateway nginx
+  # injects `anonymous` when no X-Scope-OrgID header is sent).
+  tenantId: anonymous
+
+# -----------------------------------------------------------------------
+# Job images (pin deliberately, bump in CHANGELOG when changing)
+# -----------------------------------------------------------------------
+images:
+  # Mimir's CLI for uploading tenant AM config + reading rules. Match
+  # the Mimir 3.0.x server line so API protocol stays consistent.
+  mimirtool: grafana/mimirtool:3.0.6
+  # Shell + sed for substituting __SLACK_WEBHOOK_*__ placeholders in the
+  # template before mimirtool reads it. busybox is the minimum (sh + sed).
+  shell: busybox:1.36
+  # curl + sh for posting to Grafana NGAlert admin_config API. Alpine-
+  # based, has the shell idioms the Job relies on.
+  curl: curlimages/curl:8.10.1
+
+# -----------------------------------------------------------------------
+# Resources (small — these are short-lived Jobs)
+# -----------------------------------------------------------------------
+resources:
+  init:
+    requests: { cpu: 10m, memory: 16Mi }
+    limits:   { cpu: 50m, memory: 32Mi }
+  mimirtool:
+    requests: { cpu: 25m, memory: 32Mi }
+    limits:   { cpu: 200m, memory: 128Mi }
+  curl:
+    requests: { cpu: 10m, memory: 16Mi }
+    limits:   { cpu: 50m, memory: 32Mi }
+
+# -----------------------------------------------------------------------
+# AWS Secrets Manager source secret names for the 3 webhooks.
+#
+# Defaults are SHORT names; the bootstrap/platform-root template
+# overrides each entry with the full `estabilis/<deploymentId>/*`
+# prefixed path when provider=aws (same pattern used by
+# core/components/platform-secrets — see comment on its `kvSecrets`
+# block in bootstrap/platform-root/templates/platform-secrets.yaml).
+# -----------------------------------------------------------------------
+kvSecrets:
+  slackWebhookCritical: "platform-alertmanager-slack-critical"
+  slackWebhookWarnings: "platform-alertmanager-slack-warnings"
+  slackWebhookInfo:     "platform-alertmanager-slack-info"
+
+# -----------------------------------------------------------------------
+# Provenance — populated via global.provenance.* helm parameters
+# (ADR 0005 Phase 2b).
+# -----------------------------------------------------------------------
+global:
+  provenance: {}

--- a/providers/aws/platform-outputs.tf
+++ b/providers/aws/platform-outputs.tf
@@ -106,6 +106,14 @@ resource "kubernetes_config_map_v1" "platform_infrastructure" {
     # continuous "Secret does not exist" reconcile errors.
     "global.openaiApiKeyEnabled" = tostring(var.openai_api_key != "")
 
+    # Mimir Alertmanager Slack pipeline — flag flows into the
+    # mimir-alertmanager-config chart's `slack.enabled` value via
+    # platform-root helm.parameters. With this gate, the chart's
+    # ExternalSecret + ConfigMap + upload Job render only when the
+    # operator opted in (var.slack_alerting_enabled = true) — same
+    # openai pattern.
+    "global.slackAlertingEnabled" = tostring(var.slack_alerting_enabled)
+
     # ADR 0014 — App exposures as JSON-encoded map(object), filtered to
     # only enabled profiles.
     "global.lokiExposures"     = jsonencode({ for k, v in local.loki_exposures_resolved : k => v if v.enabled })

--- a/providers/aws/secrets-manager.tf
+++ b/providers/aws/secrets-manager.tf
@@ -127,6 +127,54 @@ resource "aws_secretsmanager_secret_version" "openai_api_key" {
 }
 
 # ---------------------------------------------------------------------------
+# Mimir Alertmanager Slack webhooks — one secret per channel (tier 1/2/3).
+# Consumed by the mimir-alertmanager-config chart's ExternalSecret (which
+# pulls into K8s Secret `alertmanager-slack-webhooks` in the grafana ns).
+# Gated by slack_alerting_enabled + per-URL non-empty (matching openai
+# pattern: empty value = no SM resource = chart's ExternalSecret also
+# skipped via slack.enabled gate, so no SecretSyncError noise).
+# ---------------------------------------------------------------------------
+
+resource "aws_secretsmanager_secret" "alertmanager_slack_critical" {
+  count                   = var.slack_alerting_enabled && var.slack_webhook_alertmanager_critical != "" ? 1 : 0
+  name                    = "${local.secrets_path_prefix}/platform-alertmanager-slack-critical"
+  kms_key_id              = aws_kms_key.platform_secrets.arn
+  recovery_window_in_days = var.secretsmanager_recovery_days
+}
+
+resource "aws_secretsmanager_secret_version" "alertmanager_slack_critical" {
+  count         = var.slack_alerting_enabled && var.slack_webhook_alertmanager_critical != "" ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.alertmanager_slack_critical[0].id
+  secret_string = var.slack_webhook_alertmanager_critical
+}
+
+resource "aws_secretsmanager_secret" "alertmanager_slack_warnings" {
+  count                   = var.slack_alerting_enabled && var.slack_webhook_alertmanager_warnings != "" ? 1 : 0
+  name                    = "${local.secrets_path_prefix}/platform-alertmanager-slack-warnings"
+  kms_key_id              = aws_kms_key.platform_secrets.arn
+  recovery_window_in_days = var.secretsmanager_recovery_days
+}
+
+resource "aws_secretsmanager_secret_version" "alertmanager_slack_warnings" {
+  count         = var.slack_alerting_enabled && var.slack_webhook_alertmanager_warnings != "" ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.alertmanager_slack_warnings[0].id
+  secret_string = var.slack_webhook_alertmanager_warnings
+}
+
+resource "aws_secretsmanager_secret" "alertmanager_slack_info" {
+  count                   = var.slack_alerting_enabled && var.slack_webhook_alertmanager_info != "" ? 1 : 0
+  name                    = "${local.secrets_path_prefix}/platform-alertmanager-slack-info"
+  kms_key_id              = aws_kms_key.platform_secrets.arn
+  recovery_window_in_days = var.secretsmanager_recovery_days
+}
+
+resource "aws_secretsmanager_secret_version" "alertmanager_slack_info" {
+  count         = var.slack_alerting_enabled && var.slack_webhook_alertmanager_info != "" ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.alertmanager_slack_info[0].id
+  secret_string = var.slack_webhook_alertmanager_info
+}
+
+# ---------------------------------------------------------------------------
 # Resource policies — defense-in-depth on top of IAM identity policies.
 #
 # Only the Terraform principal (for apply/destroy) and the external-secrets
@@ -192,6 +240,27 @@ resource "aws_secretsmanager_secret_policy" "grafana_admin" {
 resource "aws_secretsmanager_secret_policy" "grafana_db" {
   count               = var.secretsmanager_resource_policy_enabled ? 1 : 0
   secret_arn          = aws_secretsmanager_secret.grafana_db.arn
+  policy              = data.aws_iam_policy_document.platform_secret_policy[0].json
+  block_public_policy = true
+}
+
+resource "aws_secretsmanager_secret_policy" "alertmanager_slack_critical" {
+  count               = var.slack_alerting_enabled && var.slack_webhook_alertmanager_critical != "" && var.secretsmanager_resource_policy_enabled ? 1 : 0
+  secret_arn          = aws_secretsmanager_secret.alertmanager_slack_critical[0].arn
+  policy              = data.aws_iam_policy_document.platform_secret_policy[0].json
+  block_public_policy = true
+}
+
+resource "aws_secretsmanager_secret_policy" "alertmanager_slack_warnings" {
+  count               = var.slack_alerting_enabled && var.slack_webhook_alertmanager_warnings != "" && var.secretsmanager_resource_policy_enabled ? 1 : 0
+  secret_arn          = aws_secretsmanager_secret.alertmanager_slack_warnings[0].arn
+  policy              = data.aws_iam_policy_document.platform_secret_policy[0].json
+  block_public_policy = true
+}
+
+resource "aws_secretsmanager_secret_policy" "alertmanager_slack_info" {
+  count               = var.slack_alerting_enabled && var.slack_webhook_alertmanager_info != "" && var.secretsmanager_resource_policy_enabled ? 1 : 0
+  secret_arn          = aws_secretsmanager_secret.alertmanager_slack_info[0].arn
   policy              = data.aws_iam_policy_document.platform_secret_policy[0].json
   block_public_policy = true
 }

--- a/providers/aws/secrets.auto.tfvars.example
+++ b/providers/aws/secrets.auto.tfvars.example
@@ -20,6 +20,18 @@ cloudflare_api_token = ""
 # --- Grafana LLM plugin (optional) ---
 openai_api_key = ""
 
+# --- Mimir Alertmanager Slack pipeline (optional) ---
+# Sensitive — webhook URLs only. The non-sensitive master toggle
+# `slack_alerting_enabled = true` lives in terraform.tfvars (alongside
+# vault_enabled), and when on requires all three URLs below to be
+# non-empty (3 SM secrets are then provisioned and the chart's Slack
+# templates render). Create the Slack app via the manifest in
+# core/components/mimir-alertmanager-config/docs/ (or any client repo
+# providing operational docs).
+slack_webhook_alertmanager_critical = ""
+slack_webhook_alertmanager_warnings = ""
+slack_webhook_alertmanager_info     = ""
+
 # --- ECR pull-through cache for Docker Hub (only when the docker-hub upstream
 # is declared in ecr_pull_through_cache_upstreams) ---
 # A Secrets Manager secret ARN holding { username, accessToken }.

--- a/providers/aws/variables.tf
+++ b/providers/aws/variables.tf
@@ -1246,6 +1246,51 @@ variable "openai_api_key" {
 }
 
 # ---------------------------------------------------------------------------
+# Mimir Alertmanager — Slack alerting pipeline.
+#
+# Master toggle (slack_alerting_enabled, non-sensitive — lives in
+# terraform.tfvars alongside vault_enabled etc) gates:
+#   - 3 aws_secretsmanager_secret resources in secrets-manager.tf
+#   - the `slack.enabled` parameter passed to the
+#     mimir-alertmanager-config chart from platform-root (which gates
+#     ConfigMap + ExternalSecret + upload-job rendering — same openai
+#     pattern: chart skips the resources entirely when disabled, no
+#     SecretSyncError noise).
+#
+# Three webhook URL variables (slack_webhook_alertmanager_*, sensitive)
+# carry the actual Slack Incoming Webhook URLs. Each non-empty value
+# becomes the `secret_string` of the corresponding SM secret. Routing
+# tier-based (1/2/3) defined in the chart values.
+# ---------------------------------------------------------------------------
+
+variable "slack_alerting_enabled" {
+  description = "Master toggle for the Mimir Alertmanager Slack alerting pipeline. When true, terraform creates 3 SM secrets and the platform-root chart enables the mimir-alertmanager-config Slack templates. Requires all 3 slack_webhook_alertmanager_* variables non-empty."
+  type        = bool
+  default     = false
+}
+
+variable "slack_webhook_alertmanager_critical" {
+  description = "Slack Incoming Webhook URL for tier 1 (critical) alerts. Required when slack_alerting_enabled = true. Pass via secrets.auto.tfvars or TF_VAR_slack_webhook_alertmanager_critical."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "slack_webhook_alertmanager_warnings" {
+  description = "Slack Incoming Webhook URL for tier 2 (warning) alerts. Required when slack_alerting_enabled = true. Pass via secrets.auto.tfvars or TF_VAR_slack_webhook_alertmanager_warnings."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "slack_webhook_alertmanager_info" {
+  description = "Slack Incoming Webhook URL for tier 3 (info) alerts. Required when slack_alerting_enabled = true. Pass via secrets.auto.tfvars or TF_VAR_slack_webhook_alertmanager_info."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+# ---------------------------------------------------------------------------
 # Shared Hub Secrets (cross-deployment secret sharing, analog of the shared
 # Azure Key Vault). Published via Secrets Manager under a shared path that
 # workload clusters read.


### PR DESCRIPTION
## Summary

Defines and ships the platform standard for alert routing on every deployment: **Mimir Alertmanager is the single source of truth** for both Mimir-Ruler-managed and Grafana-managed alert rules.

- New chart `core/components/mimir-alertmanager-config` (v0.1.0) with two independently-gated pieces:
  1. Slack alerting pipeline — opt-in (`slack.enabled`, default false; flipped to true on AWS via `global.slackAlertingEnabled` from TF). Renders ConfigMap (AM YAML template with tier-based routing) + ExternalSecret (3 webhooks → K8s Secret) + PostSync Job (`grafana/mimirtool:3.0.6 alertmanager load`).
  2. Grafana NGAlert external mode — always-on (default true). PostSync Job POSTs `alertmanagersChoice=external` + `external_alertmanager_uid=mimir-alertmanager` to `/api/v1/ngalert/admin_config`.
- Mirrors `openai_api_key` gating: when toggle off, **zero resources rendered** — no `SecretSyncError` noise.
- `core/components/grafana-stack/grafana-values.yaml` adds 4 datasource flags so the Grafana UI surfaces Mimir rules + AM contact points natively. Also fixes the Mimir AM datasource URL (was `.../alertmanager`, now gateway root — old URL hit Mimir's deprecated AM v1 API and returned HTTP 410).
- `providers/aws/`: 4 new variables (`slack_alerting_enabled` bool + 3 sensitive webhook URLs), 3 SM secrets gated by toggle, `global.slackAlertingEnabled` flag in `platform-outputs.tf`.
- `bootstrap/platform-root/templates/grafana-stack.yaml`: new Application gated by `components.mimir-alertmanager-config: false` for downstream opt-out.

## Validation done on first AWS prd deployment ahead of merge

Each piece validated separately end-to-end:
- `mimirtool alertmanager load` Job: 77 lines rendered, 3 webhook URLs substituted, exit 0.
- 3 synthetic alerts (one per tier) delivered to Slack with correct color/format. `cortex_alertmanager_notifications_failed_total{slack}` stayed at 3 (historical pre-fix failures); 4 new successes after.
- `/api/datasources/uid/mimir/health`: `features.rulerApiEnabled: true`.
- `/api/datasources/proxy/uid/mimir-alertmanager/api/v2/status`: receivers visible (slack-critical, slack-warnings, slack-info, null).
- `/api/v1/ngalert/admin_config`: `{"alertmanagersChoice":"external"}`.

## Two template gotchas documented inline

1. Alertmanager runtime template engine does NOT include Sprig's `default` function. Use `or` (text/template builtin) for missing-label fallbacks. Validated by `function "default" not defined` notify error on first deployment.
2. Mimir's `-config.expand-env=true` flag interpolates env vars in the *global* mimir.yaml ONLY — NOT in the Alertmanager fallback config file. Confirmed reading `pkg/alertmanager/multitenant.go` on grafana/mimir main: `os.ReadFile()` raw. Hence the upload-Job approach with secrets inlined via `sed`.

## ⚠️ Potentially breaking — Mimir Alertmanager datasource URL

Existing AWS deployments on v0.38.0 have the URL as `http://grafana-mimir-gateway.grafana.svc.cluster.local/alertmanager`. v0.39.0 changes it to the gateway root. ArgoCD will rewrite the ConfigMap on the next sync of the `grafana` Application. No manual migration needed — the URL change only affects the Grafana proxy path for the AM config endpoint, which was returning HTTP 410 before anyway. Runtime AM endpoints (alerts, silences, status) still served correctly because Grafana with `implementation: mimir` knows to prefix `/alertmanager/api/v2/*` for those.

## Test plan

- [ ] `helm lint core/components/mimir-alertmanager-config` passes
- [ ] `helm template core/components/mimir-alertmanager-config` renders only `grafana-ngalert-external-am` Job by default (Azure path; slack disabled)
- [ ] `helm template core/components/mimir-alertmanager-config --set slack.enabled=true` renders ConfigMap + ExternalSecret + 2 Jobs (AWS path with toggle on)
- [ ] `helm template core/components/mimir-alertmanager-config --set grafanaExternalAm.enabled=false --set slack.enabled=false` renders nothing (full no-op)
- [ ] `helm template bootstrap/platform-root --set global.provider=azure` produces `Application/mimir-alertmanager-config` referencing `values-azure.yaml` with `slack.enabled=false`
- [ ] `helm template bootstrap/platform-root --set global.provider=aws --set global.slackAlertingEnabled=true --set global.secretsPathPrefix=...` produces the Application with `slack.enabled=true` and the 3 `kvSecrets.*` parameters with full SM path
- [ ] On any current AWS deployment after promote: `kubectl get applications -n argocd | grep mimir-alertmanager-config` Synced/Healthy
- [ ] On a fresh AWS deployment with `slack_alerting_enabled=true` + 3 webhook URLs: synthetic alert at each tier is delivered to the configured Slack channel
- [ ] On a fresh deployment with `slack_alerting_enabled=false`: no `ExternalSecret` and no `mimir-alertmanager-config-upload` Job appear in cluster (only `grafana-ngalert-external-am` Job runs)