### PR TITLE
fix(mimir-alertmanager-config): drop unused 'null' receiver

### DIFF
--- a/core/components/mimir-alertmanager-config/Chart.yaml
+++ b/core/components/mimir-alertmanager-config/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: mimir-alertmanager-config
 description: Tenant Alertmanager configuration uploader for the platform's Mimir deployment, plus Grafana NGAlert routing setup
 type: application
-version: 0.1.0
+version: 0.1.1

--- a/core/components/mimir-alertmanager-config/files/alertmanager.yaml.tpl
+++ b/core/components/mimir-alertmanager-config/files/alertmanager.yaml.tpl
@@ -111,7 +111,3 @@ receivers:
           {{`  • {{ .Annotations.summary }}`}}
           {{`{{ end }}`}}
 {{- end }}
-  # `null` receiver is mandatory in Alertmanager configs even when nothing
-  # routes there — the Mimir AM config validator complains about
-  # unreachable receivers but accepts a placeholder.
-  - name: 'null'


### PR DESCRIPTION
Drop the unused `- name: 'null'` receiver from the AM config template. The validator only enforces the inverse direction (referenced receivers must be defined); unused receivers are allowed but show in Grafana UI as a confusing 4th contact point. Chart `0.1.0 -> 0.1.1`. Validated live on the first AWS prd deployment.

## Test plan
- [ ] `helm template core/components/mimir-alertmanager-config --set slack.enabled=true` renders only 3 receivers (slack-critical/warnings/info).
- [ ] After promote: `mimirtool alertmanager load` accepts the new config (no validation error about missing null).
- [ ] Grafana UI Contact Points (Mimir Alertmanager dropdown) shows exactly 3 entries.