### PR TITLE
fix(grafana-alloy): metric_pods relabel + route OTLP metrics & logs

### DIFF
--- a/core/components/grafana-stack/alloy-values.yaml
+++ b/core/components/grafana-stack/alloy-values.yaml
@@ -62,11 +62,23 @@ alloy:
           action        = "keep"
         }
 
+        // Build __address__ as <pod_ip>:<annotation_port>. The previous
+        // form ("${1}:$0" with only the port annotation as source label)
+        // resolved to "<port>:<port>" because both backrefs pointed at
+        // the same captured value, leaving the address unreachable.
         rule {
-          source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_port"]
+          source_labels = ["__address__", "__meta_kubernetes_pod_annotation_prometheus_io_port"]
+          regex         = "([^:]+)(?::\\d+)?;(\\d+)"
+          replacement   = "$1:$2"
           target_label  = "__address__"
+          action        = "replace"
+        }
+
+        // Honor prometheus.io/path annotation when present.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_path"]
           regex         = "(.+)"
-          replacement   = "${1}:$0"
+          target_label  = "__metrics_path__"
           action        = "replace"
         }
       }
@@ -1094,10 +1106,13 @@ alloy:
       }
 
       // =====================================================================
-      // Trace collection (OTLP → Tempo)
+      // OTLP collection — traces → Tempo, metrics → Mimir, logs → Loki
       // =====================================================================
+      // The receiver previously routed traces only; metrics and logs were
+      // dropped silently. Workloads emitting OTLP metrics (e.g. Beyla,
+      // OpenTelemetry-instrumented apps) now reach Mimir, and OTLP logs
+      // reach Loki.
 
-      // Receive traces via OTLP (gRPC :4317 and HTTP :4318)
       otelcol.receiver.otlp "default" {
         grpc {
           endpoint = "0.0.0.0:4317"
@@ -1106,12 +1121,14 @@ alloy:
           endpoint = "0.0.0.0:4318"
         }
         output {
-          traces = [otelcol.processor.batch.default.input]
+          traces  = [otelcol.processor.batch.traces.input]
+          metrics = [otelcol.processor.batch.metrics.input]
+          logs    = [otelcol.processor.batch.logs.input]
         }
       }
 
-      // Batch traces before sending to Tempo
-      otelcol.processor.batch "default" {
+      // --- Traces → Tempo ---
+      otelcol.processor.batch "traces" {
         timeout         = "5s"
         send_batch_size = 1024
         output {
@@ -1119,7 +1136,6 @@ alloy:
         }
       }
 
-      // Export traces to Tempo
       otelcol.exporter.otlp "tempo" {
         client {
           endpoint = "grafana-tempo.grafana.svc.cluster.local:4317"
@@ -1128,6 +1144,32 @@ alloy:
             insecure_skip_verify = true
           }
         }
+      }
+
+      // --- Metrics → Mimir (via existing prometheus.remote_write "mimir") ---
+      otelcol.processor.batch "metrics" {
+        timeout         = "5s"
+        send_batch_size = 1024
+        output {
+          metrics = [otelcol.exporter.prometheus.mimir.input]
+        }
+      }
+
+      otelcol.exporter.prometheus "mimir" {
+        forward_to = [prometheus.remote_write.mimir.receiver]
+      }
+
+      // --- Logs → Loki (via existing loki.write "default") ---
+      otelcol.processor.batch "logs" {
+        timeout         = "5s"
+        send_batch_size = 1024
+        output {
+          logs = [otelcol.exporter.loki.default.input]
+        }
+      }
+
+      otelcol.exporter.loki "default" {
+        forward_to = [loki.write.default.receiver]
       }
 
       // =====================================================================


### PR DESCRIPTION
## Summary

Fixes two pre-existing bugs in the hub Alloy config (`core/components/grafana-stack/alloy-values.yaml`) that silently dropped data:

- **metric_pods relabel** wrote `__address__="<port>:<port>"` because both backrefs in `replacement = "${1}:$0"` resolved to the same captured port value. Any pod relying on `prometheus.io/scrape=true` annotation never had its `/metrics` reached.
- **OTLP receiver** routed only traces. Metrics and logs sent to `grafana-alloy:4317` were dropped at the receiver output. Discovered while running an eBPF auto-instrumentation PoC (Beyla) — Beyla `/metrics` was healthy locally but never reached Mimir.

## Changes

1. **Relabel fix** — replaced port-only source rule with the canonical Prometheus pattern combining `__address__` + annotation port. Also added support for `prometheus.io/path` to match upstream convention.
2. **OTLP routing** — added 2 batch processors (`metrics`, `logs`) + 2 new exporters (`otelcol.exporter.prometheus` → existing `prometheus.remote_write.mimir`; `otelcol.exporter.loki` → existing `loki.write.default`). Trace processor renamed `"default"` → `"traces"` for symmetry; trace endpoint unchanged.

## Test plan

- [x] `helm template alloy grafana/alloy --version 1.6.2 -f alloy-values.yaml` renders cleanly.
- [x] `alloy fmt` on rendered config: exit 0.
- [x] `alloy run` on rendered config: only expected `unable to load in-cluster configuration` errors (we're outside the cluster); all OTel + relabel components resolved correctly.
- [ ] After deploy + promote on a real cluster: confirm a pod with `prometheus.io/scrape=true` annotation has metrics in Mimir within scrape interval.
- [ ] After deploy + promote: confirm Beyla emitting OTLP metrics to `grafana-alloy:4317` reaches Mimir end-to-end.

## Follow-up

Same bug exists in `estabilis-platform-gitops/values/workload/alloy.yaml` (workload Alloy). Will open separate PR after this lands. No workload clusters in production yet, so lower urgency.

Closes Estabilis/estabilis-platform-tools#206