### PR TITLE
feat(beyla): platform component for eBPF auto-instrumentation

### DIFF
--- a/bootstrap/platform-root/templates/beyla.yaml
+++ b/bootstrap/platform-root/templates/beyla.yaml
@@ -1,0 +1,63 @@
+{{- if (index .Values.components "beyla") }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: beyla
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "9"
+spec:
+  project: platform
+  sources:
+    - repoURL: https://grafana.github.io/helm-charts
+      chart: beyla
+      targetRevision: "1.16.5"
+      helm:
+        releaseName: beyla
+        valueFiles:
+          - $values/core/components/beyla/values.yaml
+          - $values/core/components/beyla/values-{{ .Values.global.provider }}.yaml
+          {{- include "platform-root.overrideValueFile" (dict "component" "beyla" "root" $) | nindent 10 }}
+          {{- include "platform-root.gitopsValueFile" (dict "component" "beyla" "root" $) | nindent 10 }}
+        {{- include "platform-root.ignoreMissingValueFiles" $ | nindent 8 }}
+        valuesObject:
+          {{- /* Scheduling (ADR 0012 — issue #97). Beyla chart 1.16.5
+                puts tolerations / affinity at the top level (not under
+                a controller key like Alloy). */}}
+          {{- include "platform-root.schedulingValuesTopLevel" (dict
+                "mode" (default "auto" (index .Values.scheduling "beyla"))
+                "provider" .Values.global.provider
+             ) | nindent 10 }}
+        parameters:
+          {{- /* Cluster name passed dynamically — Beyla cannot
+                auto-detect on EKS without aws-auth ConfigMap read
+                permission. Chart 1.16.5 reads `env` as a map; the
+                ArgoCD parameter address dot-escapes the env var name. */}}
+          - name: env.BEYLA_KUBE_CLUSTER_NAME
+            value: {{ .Values.global.clusterName | default "estabilis" | quote }}
+    - repoURL: {{ .Values.platformRepoUrl }}
+      targetRevision: {{ .Values.platformVersion }}
+      ref: values
+    {{- include "platform-root.overrideSource" . | nindent 4 }}
+    {{- include "platform-root.gitopsSource" . | nindent 4 }}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: grafana
+  syncPolicy:
+    {{- /* `grafana` ns is platform-managed PSS=privileged; use the
+          privileged variant of the metadata helper to keep label
+          consistency with the rest of the observability stack. */}}
+    {{- include "platform-root.managedNamespaceMetadataExcludedPrivileged" . | nindent 4 }}
+    automated:
+      prune: true
+      selfHeal: false
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+    syncOptions:
+      - ServerSideApply=true
+      - RespectIgnoreDifferences=true
+{{- end }}

--- a/bootstrap/platform-root/values.yaml
+++ b/bootstrap/platform-root/values.yaml
@@ -183,6 +183,7 @@ components:
   alloy: true                # observability: telemetry collector (DaemonSet)
   tempo: true                # observability: distributed tracing
   pyroscope: true            # observability: continuous profiling
+  beyla: false               # observability: eBPF auto-instrumentation. Opt-in per cluster; per-pod opt-in via `estabilis.io/instrument-with-beyla: "true"` label.
   grafana-dashboards: true   # observability: pre-built dashboards
   mimir-rules: true          # observability: alerting rules
   kube-state-metrics: true   # observability: Kubernetes state metrics

--- a/core/components/beyla/values.yaml
+++ b/core/components/beyla/values.yaml
@@ -1,0 +1,143 @@
+# Grafana Beyla — eBPF auto-instrumentation (HTTP RED metrics + traces).
+#
+# Deploys a privileged DaemonSet in the `grafana` namespace alongside
+# the rest of the observability stack (Mimir/Loki/Alloy/Pyroscope/Grafana).
+# No dedicated namespace is needed — the `grafana` ns already has
+# PSS=privileged via inject-pss-labels and an AppProject `platform`
+# destination. The chart wraps `grafana/beyla` v3 (chart 1.16.5).
+#
+# Discovery is opt-in per pod via the label
+# `estabilis.io/instrument-with-beyla: "true"`. Apps without the label
+# are never traced, never produce series — zero impact.
+#
+# Lessons from PoC (2026-05-04):
+# - LimitRange override mandatory: chart `resources: {}` inherits the
+#   platform 128Mi default, BPF map allocation OOMs at startup. Explicit
+#   1Gi limit avoids `cannot allocate memory` from cilium/ebpf.
+# - `BEYLA_KUBE_CLUSTER_NAME` env var required: chart RBAC does not
+#   include `kube-system/configmaps/aws-auth`, so EKS auto-detection
+#   fails. Cluster name is wired via Helm parameter from platform-root.
+# - `/sys/fs/bpf` hostPath bind mount needed for `log_enricher` and
+#   `profile_correlation` features (Beyla writes pinned BPF maps under
+#   /sys/fs/bpf/otel; without the mount it warns and disables those
+#   correlations).
+# - Fargate excluded via nodeAffinity: no eBPF support there; Beyla
+#   would CrashLoop on those nodes. Workload pods on Fargate fall out
+#   of Beyla coverage and that's acceptable for the rollout.
+# - Architecture restricted to amd64: workload Beyla images don't have
+#   tested arm64 paths in v3.9.x; revisit when arm64 nodes enter the
+#   pool.
+
+commonLabels:
+  estabilis.io/component: beyla
+
+# --- Image pinning (require-image-digest policy) ---
+# Multi-arch index digest for grafana/beyla:3.9.7 (released 2026-05-03).
+# Tag is set via the chart's `image.tag` field; digest is appended
+# automatically by the chart so the pull resolves to a specific
+# manifest list across linux/amd64 and linux/arm64.
+image:
+  tag: "3.9.7"
+  digest: "sha256:d978d84eff1d54e1a185c6f4efe515b546e6754517c1834361ef57559e5628ed"
+
+# --- Beyla container runtime ---
+# Defaults from chart 1.16.5 are: privileged: true, hostPID: true.
+# We keep both — required for eBPF + /proc visibility into other pods.
+# The `grafana` ns has PSS=privileged so this passes admission.
+
+# Override LimitRange default (128Mi → 1Gi). PoC validated this is the
+# minimum that works for ~60 process tracers per node. Tune downward
+# only after long-running cardinality + memory observation.
+resources:
+  requests:
+    cpu: 100m
+    memory: 512Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+# Annotation for the Alloy `metric_pods` discovery (after the relabel
+# fix from PR #148 lands). Lets Alloy scrape Beyla's internal_metrics
+# without manual scrape config. Application metrics flow via OTLP
+# (otel_metrics_export below), not via Prometheus scrape.
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "8080"
+  prometheus.io/path: "/internal/metrics"
+
+# Required environment — cluster name (chart cannot auto-detect on EKS
+# due to missing aws-auth read permission). Chart 1.16.5 reads `env`
+# as a map (key:value), not a list of name/value objects. The cluster
+# name value is overridden at runtime by the bootstrap template via
+# helm.parameters (see bootstrap/platform-root/templates/beyla.yaml).
+env:
+  BEYLA_KUBE_METADATA_ENABLE: "true"
+  BEYLA_KUBE_CLUSTER_NAME: "estabilis"
+
+# /sys/fs/bpf mount — required for log enricher + profile correlation.
+# Chart fields are `volumes` / `volumeMounts` (k8s-native list shape).
+volumes:
+  - name: bpffs
+    hostPath:
+      path: /sys/fs/bpf
+      type: DirectoryOrCreate
+volumeMounts:
+  - name: bpffs
+    mountPath: /sys/fs/bpf
+    mountPropagation: Bidirectional
+
+# Exclude Fargate (no eBPF) and require amd64 (no validated arm64 path).
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: eks.amazonaws.com/compute-type
+              operator: NotIn
+              values: [fargate]
+            - key: kubernetes.io/arch
+              operator: In
+              values: [amd64]
+
+# --- Beyla configuration (River) ---
+# Discovery filter is by pod LABEL (not namespace) — apps opt in by
+# adding `estabilis.io/instrument-with-beyla: "true"` to their pod
+# labels. Excludes the `grafana` namespace itself so Beyla doesn't
+# instrument the observability stack and create a feedback loop.
+config:
+  create: true
+  data:
+    log_level: INFO
+    discovery:
+      instrument:
+        - k8s_pod_labels:
+            estabilis.io/instrument-with-beyla: "true"
+      exclude_instrument:
+        - k8s_namespace: grafana
+    routes:
+      unmatched: heuristic
+    # OTLP push for metrics + traces (Alloy receives both; the receiver
+    # routes them to Mimir/Tempo respectively after PR #148 fix).
+    otel_metrics_export:
+      endpoint: http://grafana-alloy.grafana.svc.cluster.local:4317
+      protocol: grpc
+      insecure: true
+    otel_traces_export:
+      endpoint: http://grafana-alloy.grafana.svc.cluster.local:4317
+      protocol: grpc
+      insecure: true
+    # Internal metrics — Beyla self-monitoring (BPF map sizes, ringbuf
+    # drops, instrumentation counts). Scraped via the Prometheus
+    # annotation discovery in Alloy (post-PR #148).
+    internal_metrics:
+      prometheus:
+        port: 8080
+        path: /internal/metrics
+
+# --- Cleanup of chart defaults that conflict with PSS=privileged ns ---
+# Chart sets controller.podSecurityContext: {} which is fine; we don't
+# override containerSecurityContext because the chart already sets
+# privileged: true at the right level.
+
+controller:
+  type: daemonset


### PR DESCRIPTION
## Summary

Adds **Beyla v3.9.7** as an opt-in platform component for eBPF-based HTTP RED metrics + traces. Apps opt in per-pod via the label `estabilis.io/instrument-with-beyla: "true"` — zero impact on apps that don't.

## Design highlights (validated in PoC 2026-05-04)

- Deploys to existing `grafana` namespace (PSS=privileged + quota + AppProject already in place — zero platform-side changes).
- Official `grafana/beyla` chart 1.16.5 wrapped via the standard valueFiles pattern.
- Image pinned by digest: `sha256:d978d84eff1d54e1a185c6f4efe515b546e6754517c1834361ef57559e5628ed`.
- Explicit `resources.limits.memory: 1Gi` — chart `resources: {}` would inherit the platform 128Mi LimitRange default and BPF map allocation OOMs at startup.
- `BEYLA_KUBE_CLUSTER_NAME` injected via helm.parameters from `global.clusterName` (chart RBAC doesn't include `kube-system/aws-auth` for auto-detection).
- `/sys/fs/bpf` hostPath bind mount for `log_enricher` + `profile_correlation` features.
- `nodeAffinity` excludes Fargate (no eBPF) and requires `amd64`.
- OTLP push to in-cluster Alloy `:4317` (depends on PR #148 — Alloy OTLP receiver fix).
- Sync-wave 9 — after grafana-stack (wave 8).

## Files

- `core/components/beyla/values.yaml` (158 lines) — chart values
- `bootstrap/platform-root/templates/beyla.yaml` (60 lines) — Application gated by `components.beyla`
- `bootstrap/platform-root/values.yaml` — adds `beyla: false` to observability defaults

## Test plan

- [x] `helm template platform-root` with `components.beyla=true` renders the Application (PSS=privileged, destination=grafana, sync-wave 9).
- [x] `helm template platform-root` without the flag renders nothing (gate works).
- [x] `helm template grafana/beyla -f core/components/beyla/values.yaml` renders DaemonSet with: privileged: true, env (BEYLA_KUBE_*), volumes (bpffs + cgroup + config), nodeAffinity (no fargate, amd64), resources (1Gi limit).
- [ ] After deploy + promote on a cluster: confirm Beyla discovers a pod with the opt-in label and HTTP RED metrics reach Mimir end-to-end.

## Dependencies

- Requires Estabilis/estabilis-platform#148 (Alloy OTLP receiver fix) **already merged**. Without it the OTLP metrics path doesn't reach Mimir.

## Closes

Closes Estabilis/estabilis-platform-tools#207