### PR TITLE
feat(tempo): enable local-blocks processor for TraceQL metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## [0.41.0] - 2026-05-04
+
+### Added — TraceQL metrics support (Grafana Drilldown/Traces)
+
+Tempo single-binary chart bumped `1.10.3 → 1.24.4` (Tempo `2.5.0 →
+2.9.0`) to enable the `local-blocks` processor on the metrics-generator,
+required by Grafana's Drilldown/Traces app for TraceQL metrics
+queries (`{ } | rate()` style).
+
+The previous `extraConfig.overrides.defaults.metrics_generator.processors`
+block on chart 1.10 was a no-op because the template hard-coded the
+processor list when `metricsGenerator.enabled=true`. Chart >=1.16
+templatizes both `tempo.metricsGenerator.processor` and
+`tempo.overrides.defaults`, so the local-blocks wiring is now actually
+applied.
+
+Three files touched:
+
+- `bootstrap/platform-root/templates/grafana-stack.yaml` — bump chart
+  pin to `1.24.4`.
+- `core/components/grafana-stack/tempo-values.yaml` — drop dead
+  `extraConfig` block, add `tempo.metricsGenerator.processor.local_blocks.flush_to_storage=true`,
+  add `tempo.overrides.defaults.metrics_generator.processors` with
+  `[service-graphs, span-metrics, local-blocks]`. Resources bumped
+  `128Mi/512Mi → 1Gi/3Gi` requests/limits — `local-blocks` ingests live
+  traces in memory before flushing, and Tempo 2.9 with all three
+  processors OOM-killed on 512Mi during validation.
+- `core/components/grafana-stack/grafana-values.yaml` — Tempo
+  datasource URL `:3100 → :3200` (chart 1.20+ default
+  `tempo.server.http_listen_port`).
+
+Validated live in cortex prd cluster before commit:
+`grafana-tempo-0` Ready/0-restarts on `tempo:2.9.0`, CM contains
+`local-blocks` in the processors list and `processor.local_blocks.flush_to_storage:
+true`, datasource health=OK, Drilldown/Traces no longer raises
+"localblocks processor not found", `rate()` TraceQL metric returns
+`series` with `samples` structure.
+
+### Compatibility
+
+- **Tempo URL `:3100 → :3200`**: only the in-cluster Grafana datasource
+  references this URL. Alloy/Beyla push traces via OTLP gRPC `:4317`
+  (unchanged). Downstreams that reference Tempo by URL outside this
+  chart need to update.
+- **Memory bump**: clients that overrode `tempo.resources` to a tighter
+  limit (e.g. cortex AWS prd at 100Mi/512Mi) will OOM after this bump
+  unless the override is widened or removed.
+
 ## [0.40.0] - 2026-05-04
 
 Two changes shipped together — one bug fix and one new opt-in

--- a/bootstrap/platform-root/templates/grafana-stack.yaml
+++ b/bootstrap/platform-root/templates/grafana-stack.yaml
@@ -304,7 +304,7 @@ spec:
   sources:
     - repoURL: https://grafana.github.io/helm-charts
       chart: tempo
-      targetRevision: "1.10.3"
+      targetRevision: "1.24.4"
       helm:
         valueFiles:
           - $values/core/components/grafana-stack/tempo-values.yaml

--- a/core/components/grafana-stack/grafana-values.yaml
+++ b/core/components/grafana-stack/grafana-values.yaml
@@ -68,7 +68,9 @@ datasources:
         uid: tempo
         type: tempo
         access: proxy
-        url: http://grafana-tempo.grafana.svc.cluster.local:3100
+        # Chart tempo>=1.20 defaults tempo.server.http_listen_port to 3200
+        # (was 3100 on chart 1.10). Service follows the binary port.
+        url: http://grafana-tempo.grafana.svc.cluster.local:3200
         jsonData:
           tracesToLogsV2:
             datasourceUid: loki

--- a/core/components/grafana-stack/tempo-values.yaml
+++ b/core/components/grafana-stack/tempo-values.yaml
@@ -14,27 +14,35 @@ tempo:
   metricsGenerator:
     enabled: true
     remoteWriteUrl: "http://grafana-mimir-gateway.grafana.svc.cluster.local/api/v1/push"
+    # local-blocks processor is required by Grafana Drilldown/Traces (TraceQL
+    # metrics queries). flush_to_storage=true persists the metric blocks to
+    # the trace backend so queries survive ingester restarts.
+    processor:
+      local_blocks:
+        flush_to_storage: true
+  # Tempo standard overrides — chart >=1.16 templatizes this path; the legacy
+  # extraConfig.overrides.defaults block on chart 1.10 was a no-op because the
+  # template hard-coded the processor list when metricsGenerator.enabled=true.
+  overrides:
+    defaults:
+      metrics_generator:
+        processors:
+          - service-graphs
+          - span-metrics
+          - local-blocks
   resources:
     requests:
-      cpu: 50m
-      memory: 128Mi
+      cpu: 100m
+      memory: 1Gi
     limits:
-      cpu: 200m
-      memory: 512Mi
+      cpu: 1500m
+      memory: 3Gi
   securityContext:
     readOnlyRootFilesystem: false
     allowPrivilegeEscalation: false
     runAsNonRoot: true
     capabilities:
       drop: [ALL]
-  extraConfig:
-    overrides:
-      defaults:
-        metrics_generator:
-          processors:
-            - service-graphs
-            - span-metrics
-            - local-blocks
 
 persistence:
   enabled: true


### PR DESCRIPTION
## Summary

Bump Tempo chart `1.10.3 → 1.24.4` (Tempo `2.5.0 → 2.9.0`) and migrate the
metrics-generator config to chart-templated paths so the `local-blocks`
processor actually applies. The previous `extraConfig.overrides.defaults`
block on chart 1.10 was a no-op because the template hard-coded the
processor list when `metricsGenerator.enabled=true`.

Required by Grafana Drilldown/Traces app, which uses TraceQL metrics
queries (`{ } | rate()`).

## Changes

- `bootstrap/platform-root/templates/grafana-stack.yaml` — chart pin `1.10.3 → 1.24.4`
- `core/components/grafana-stack/tempo-values.yaml`:
  - drop dead `extraConfig.overrides.defaults` block
  - add `tempo.metricsGenerator.processor.local_blocks.flush_to_storage: true`
  - add `tempo.overrides.defaults.metrics_generator.processors: [service-graphs, span-metrics, local-blocks]`
  - resources `128Mi/512Mi → 1Gi/3Gi` (local-blocks ingests live traces in memory)
- `core/components/grafana-stack/grafana-values.yaml` — Tempo datasource URL `:3100 → :3200` (chart 1.20+ default `http_listen_port`)

## Compatibility

- **URL `:3100 → :3200`** — only the in-cluster Grafana datasource references this URL. Alloy/Beyla push traces via OTLP gRPC `:4317` (unchanged).
- **Memory bump** — clients that overrode `tempo.resources` to a tighter limit will OOM unless the override is widened or removed.

## Test plan

- [x] `helm template tempo:1.24.4 -f tempo-values.yaml` renders with `local_blocks` + `flush_to_storage: true` and `processors: [service-graphs, span-metrics, local-blocks]`
- [x] Validated live in cortex prd cluster (chart 1.24.4 + values applied directly via Argo Application patch):
  - Pod Ready, 0 restarts on `tempo:2.9.0`
  - CM contains `local-blocks` in processors list
  - Datasource health = OK
  - Drilldown/Traces no longer raises "localblocks processor not found"
  - `rate()` TraceQL metric returns `series` with `samples` structure