### PR TITLE
feat(mimir-rules): close coverage gaps + 3 new Tier 1 alerts (MINOR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,78 @@
 # Changelog
 
+## [0.42.0] - 2026-05-05
+
+### Added — Coverage gaps in mimir-rules platform alerts (B1–B4 + 3 new alerts)
+
+Follow-up to v0.41.1 (broken-alert fixes). Audit identified the existing
+33-rule set reflected platform state from ~2 months ago — selectors were
+defaulted to a smaller core platform and didn't grow as the platform
+added Karpenter, Beyla, more app namespaces (21 cortex client apps),
+and ALB controller. Fixes:
+
+#### B1 — ArgoCD project filter widened (`platform` → 3 projects)
+
+`ArgocdAppOutOfSync` and `ArgocdAppDegraded` (Tier 1) checked
+`project="platform"` only, leaving 25/64 ArgoCD apps unmonitored:
+21 client apps in `platform-apps`, 3 in `platform-client-infra`.
+Switched to `project=~"platform|platform-apps|platform-client-infra"`.
+Added `{{ $labels.project }}` to the description so notifications
+identify which fleet the failing app belongs to.
+
+#### B2 — `PodCrashLoopingCritical` (Tier 1) namespace regex
+
+Added: `aws-load-balancer-controller`, `external-dns`, `karpenter`,
+`vault`, `velero`, `grafana`. These are core platform components
+whose loss makes the cluster unusable but were missing from the
+critical regex. Client app crashloops stay at Tier 2
+(`PodCrashLoopingWarning`, see below).
+
+#### B3 — `DaemonSetUnavailable` (Tier 1) daemonset regex
+
+Added: `beyla` (deployed 2026-05-04), `aws-node`, `ebs-csi-node`,
+`kube-proxy`, `eks-pod-identity-agent`. AWS/EKS-specific names are
+cross-provider safe — on Azure the metric returns no series for
+those, so the regex is harmless.
+
+#### B4 — Tier 2/3 namespace regexes for client app coverage
+
+Four alerts (`HighMemoryUsage` Tier 2, `PodCrashLoopingWarning` Tier 2,
+`HighCpuThrottling` Tier 3, `DeploymentReplicasMismatch` Tier 3) now
+include `app-.*` (matches all 21 cortex client app namespaces and any
+future ones) plus the missing platform components (alb-controller,
+karpenter, vault, etc.). Tier separation preserved: client app
+crashloops route to warning, not critical.
+
+#### Priority 2 — 3 new Tier 1 alerts for unmonitored platform components
+
+- `AwsLoadBalancerControllerDown` — ALB controller is the ingress on
+  EKS. It had zero alert coverage; cluster losing ALB controller =
+  Ingresses stop being provisioned silently.
+- `KarpenterDown` — Karpenter handles node autoscaling on EKS. Loss =
+  pending pods get no nodes, scaling stops.
+- `VaultDown` — full HA loss (all 3 replicas down). Partial-quorum
+  degradation belongs in a separate Tier 2 alert if needed (not added
+  now to keep scope tight).
+
+All three use the `kube_*_status_*` metric pattern (no scrape
+dependency) so they're cross-provider safe — on Azure clusters where
+these components aren't installed, the metric returns no series and
+the alert is silently inert.
+
+### Net effect
+
+| | Before v0.42.0 | After v0.42.0 (AWS) |
+|---|---|---|
+| Total rules | 32 (post-v0.41.1) | 35 |
+| Apps in ArgocdAppOutOfSync scope | 39/64 (project=platform only) | 64/64 |
+| Namespaces in PodCrashLooping coverage | 6 critical / 7 warning | 12 critical / 31 warning (incl. 21 app-*) |
+| DaemonSets in unavailable alert | 2 | 7 |
+| Components without ANY alert | 8+ | 5 (Trivy, OpenCost, Policy Reporter, Envoy Gateway, metrics-server) |
+
+The 5 remaining unalerted components are Tier-3-priority and left for
+a separate PR; this release covers everything that affects platform
+availability or client workload health.
+
 ## [0.41.1] - 2026-05-05
 
 ### Fixed — 4 broken Mimir alerting rules

--- a/core/components/mimir-rules/files/tier1-platform-down.yaml
+++ b/core/components/mimir-rules/files/tier1-platform-down.yaml
@@ -3,7 +3,10 @@ groups:
   interval: 1m
   rules:
   - alert: ArgocdAppOutOfSync
-    expr: argocd_app_info{sync_status!="Synced", project="platform"}
+    # project regex covers platform (core), platform-apps (client workloads)
+    # and platform-client-infra (per-client shared infra). Was scoped to
+    # `platform` only, leaving 25/64 apps unmonitored.
+    expr: argocd_app_info{sync_status!="Synced", project=~"platform|platform-apps|platform-client-infra"}
     for: 10m
     labels:
       severity: critical
@@ -11,10 +14,10 @@ groups:
       component: argocd
     annotations:
       summary: ArgoCD Application {{ $labels.name }} is out of sync
-      description: Application {{ $labels.name }} has sync status {{ $labels.sync_status
+      description: Application {{ $labels.name }} (project {{ $labels.project }}) has sync status {{ $labels.sync_status
         }} for more than 10 minutes.
   - alert: ArgocdAppDegraded
-    expr: argocd_app_info{health_status!="Healthy", health_status!="", project="platform"}
+    expr: argocd_app_info{health_status!="Healthy", health_status!="", project=~"platform|platform-apps|platform-client-infra"}
     for: 10m
     labels:
       severity: critical
@@ -22,7 +25,7 @@ groups:
       component: argocd
     annotations:
       summary: ArgoCD Application {{ $labels.name }} is degraded
-      description: Application {{ $labels.name }} has health status {{ $labels.health_status
+      description: Application {{ $labels.name }} (project {{ $labels.project }}) has health status {{ $labels.health_status
         }} for more than 10 minutes.
   - alert: ArgocdServerDown
     expr: up{job="argocd-server"} == 0
@@ -36,7 +39,14 @@ groups:
       description: ArgoCD server is not responding on {{ $labels.instance }} for more
         than 3 minutes. GitOps operations are stopped.
   - alert: PodCrashLoopingCritical
-    expr: increase(kube_pod_container_status_restarts_total{namespace=~"argocd|cert-manager|external-secrets|kyverno|cnpg-system|traefik"}[1h])
+    # Tier 1 = platform-down. Namespace regex covers core platform components
+    # whose loss makes the cluster unusable: ingress (traefik on Azure;
+    # aws-load-balancer-controller on AWS), DNS sync (external-dns), node
+    # autoscaling (karpenter on AWS), secrets (external-secrets, vault),
+    # backups (velero), policy enforcement (kyverno), DB (cnpg-system),
+    # certs (cert-manager), gitops (argocd) and observability (grafana).
+    # Client app crashloops are tracked at Tier 2 (PodCrashLoopingWarning).
+    expr: increase(kube_pod_container_status_restarts_total{namespace=~"argocd|cert-manager|external-secrets|kyverno|cnpg-system|traefik|aws-load-balancer-controller|external-dns|karpenter|vault|velero|grafana"}[1h])
       > 5
     for: 5m
     labels:
@@ -102,7 +112,11 @@ groups:
       summary: Kyverno admission controller is down
       description: Kyverno webhook is not responding. Policy enforcement is disabled.
   - alert: DaemonSetUnavailable
-    expr: kube_daemonset_status_number_unavailable{daemonset=~"grafana-alloy|node-exporter-prometheus-node-exporter"}
+    # Critical DaemonSets across both providers. Provider-specific names
+    # (aws-node, ebs-csi-node, kube-proxy, eks-pod-identity-agent) are
+    # AWS/EKS — on Azure the metric returns no series for those, so the
+    # regex is harmless cross-provider.
+    expr: kube_daemonset_status_number_unavailable{daemonset=~"grafana-alloy|node-exporter-prometheus-node-exporter|beyla|aws-node|ebs-csi-node|kube-proxy|eks-pod-identity-agent"}
       > 0
     for: 5m
     labels:
@@ -150,3 +164,49 @@ groups:
     annotations:
       summary: Pyroscope is down
       description: Pyroscope has zero ready replicas. Continuous profiling is not functioning.
+  - alert: AwsLoadBalancerControllerDown
+    # AWS-only: ALB Controller is the ingress on EKS clusters. On Azure
+    # the namespace doesn't exist and the metric returns no series, so
+    # the alert is silently inert there (cross-provider safe).
+    expr: kube_deployment_status_replicas_available{namespace="aws-load-balancer-controller", deployment="aws-load-balancer-controller"}
+      == 0
+    for: 3m
+    labels:
+      severity: critical
+      tier: '1'
+      component: aws-load-balancer-controller
+    annotations:
+      summary: AWS Load Balancer Controller is down
+      description: ALB Controller deployment has zero available replicas. New
+        Ingresses (k8s class=alb) will not be provisioned and existing ones
+        will not have their target groups updated.
+  - alert: KarpenterDown
+    # AWS-only: Karpenter handles node provisioning on EKS. Cross-provider
+    # safe (returns no series on Azure).
+    expr: kube_deployment_status_replicas_available{namespace="karpenter", deployment="karpenter"}
+      == 0
+    for: 3m
+    labels:
+      severity: critical
+      tier: '1'
+      component: karpenter
+    annotations:
+      summary: Karpenter controller is down
+      description: Karpenter has zero available replicas. Pending pods will
+        not get new nodes and existing nodes will not be deprovisioned.
+  - alert: VaultDown
+    # Vault is a StatefulSet (HA mode). Alerts only when ALL replicas are
+    # down — quorum-loss state. Partial outage (e.g. 1/3 down with quorum
+    # held) belongs in a Tier 2 degradation alert if needed.
+    expr: kube_statefulset_status_replicas_ready{namespace="vault", statefulset="vault"}
+      == 0
+    for: 3m
+    labels:
+      severity: critical
+      tier: '1'
+      component: vault
+    annotations:
+      summary: Vault is down
+      description: Vault has zero ready replicas. Secret reads/writes are
+        unavailable. Apps using Vault Agent or vault-injector will fail
+        to start.

--- a/core/components/mimir-rules/files/tier2-degradation.yaml
+++ b/core/components/mimir-rules/files/tier2-degradation.yaml
@@ -141,7 +141,10 @@ groups:
       description: Metrics collection for {{ $labels.job }} ({{ $labels.instance }})
         has been down for 10 minutes. Monitoring is blind for this component.
   - alert: HighMemoryUsage
-    expr: container_memory_working_set_bytes{namespace=~"argocd|grafana|cert-manager|kyverno|cnpg-system",
+    # Covers core platform + client app namespaces (app-*). Min limit
+    # threshold (134217728 = 128Mi) skips tiny utility pods where 95%
+    # of a small limit isn't actionable.
+    expr: container_memory_working_set_bytes{namespace=~"argocd|grafana|cert-manager|kyverno|cnpg-system|external-secrets|external-dns|aws-load-balancer-controller|karpenter|vault|velero|app-.*",
       container!=""} / container_spec_memory_limit_bytes > 0.95 and container_spec_memory_limit_bytes
       > 134217728
     for: 15m
@@ -154,7 +157,10 @@ groups:
       description: Container {{ $labels.container }} in pod {{ $labels.pod }} ({{
         $labels.namespace }}) is using over 95% of memory limit. OOM kill imminent.
   - alert: PodCrashLoopingWarning
-    expr: increase(kube_pod_container_status_restarts_total{namespace=~"grafana|velero|opencost|trivy-system|external-dns|node-exporter|kube-state-metrics"}[1h])
+    # Tier 2 = degradation. Catches client app crashloops (app-*) plus
+    # secondary platform components. Tier 1 (PodCrashLoopingCritical)
+    # covers core platform whose loss makes the cluster unusable.
+    expr: increase(kube_pod_container_status_restarts_total{namespace=~"grafana|velero|opencost|trivy-system|external-dns|node-exporter|kube-state-metrics|envoy-gateway-system|policy-reporter|metrics-server|app-.*"}[1h])
       > 5
     for: 15m
     labels:

--- a/core/components/mimir-rules/files/tier3-operational.yaml
+++ b/core/components/mimir-rules/files/tier3-operational.yaml
@@ -3,7 +3,10 @@ groups:
   interval: 1m
   rules:
   - alert: DeploymentReplicasMismatch
-    expr: kube_deployment_spec_replicas{namespace=~"argocd|grafana|cert-manager|kyverno|external-secrets|external-dns|traefik|velero"} != kube_deployment_status_available_replicas
+    # Covers core platform + client app namespaces (app-*). Tier 3 (info)
+    # signal — useful for spotting partial-outage states (e.g. 1/3 ready)
+    # that don't trigger the all-down Tier 1 alerts.
+    expr: kube_deployment_spec_replicas{namespace=~"argocd|grafana|cert-manager|kyverno|external-secrets|external-dns|traefik|velero|aws-load-balancer-controller|karpenter|vault|app-.*"} != kube_deployment_status_available_replicas
     for: 15m
     labels:
       severity: info
@@ -14,7 +17,9 @@ groups:
       description: Deployment {{ $labels.deployment }} in {{ $labels.namespace }} wants {{ $labels.spec_replicas }} replicas but only has {{ $labels.available_replicas }} available for 15 minutes.
 
   - alert: HighCpuThrottling
-    expr: rate(container_cpu_cfs_throttled_periods_total{namespace=~"argocd|grafana|cert-manager|kyverno|cnpg-system", container!=""}[5m]) / clamp_min(rate(container_cpu_cfs_periods_total[5m]), 1) > 0.5
+    # Covers core platform + client app namespaces (app-*). Throttling
+    # >50% sustained means the workload is wedged on its CPU limit.
+    expr: rate(container_cpu_cfs_throttled_periods_total{namespace=~"argocd|grafana|cert-manager|kyverno|cnpg-system|external-secrets|external-dns|aws-load-balancer-controller|karpenter|vault|velero|app-.*", container!=""}[5m]) / clamp_min(rate(container_cpu_cfs_periods_total[5m]), 1) > 0.5
     for: 15m
     labels:
       severity: info


### PR DESCRIPTION
## Summary

Follow-up to v0.41.1 (broken alerts repair). Audit identified the 33-rule set reflected platform state from ~2 months ago — selectors didn't grow with the platform (Karpenter, Beyla, ALB controller, 21 cortex client apps).

## B1–B4: Coverage gap closures

| Gap | What was missing | Fix |
|---|---|---|
| **B1** ArgoCD project filter | Only 39/64 apps monitored (`project=platform`); cortex client apps in `platform-apps` invisible | `project=~"platform\|platform-apps\|platform-client-infra"` (covers 64/64) |
| **B2** PodCrashLoopingCritical (Tier 1) ns regex | alb-controller, external-dns, karpenter, vault, velero, grafana all missing from critical | Added 6 platform ns; tier separation preserved |
| **B3** DaemonSetUnavailable (Tier 1) daemonset regex | beyla, aws-node, ebs-csi-node, kube-proxy, eks-pod-identity-agent missing | Added 5 daemonsets; AWS/EKS names harmless on Azure |
| **B4** Tier 2/3 namespace regexes | All 21 cortex apps + alb-controller/karpenter/vault outside coverage | Added `app-.*` + missing platform ns to 4 alerts: HighMemoryUsage, PodCrashLoopingWarning, HighCpuThrottling, DeploymentReplicasMismatch |

## 3 new Tier 1 alerts

| Alert | Why it matters |
|---|---|
| `AwsLoadBalancerControllerDown` | Loss = Ingresses stop being provisioned, target groups stop updating |
| `KarpenterDown` | Loss = pending pods get no nodes, autoscaling stops |
| `VaultDown` | Loss = all secret reads/writes fail, vault-injector breaks |

All three use `kube_*_status_*` metrics (no scrape dependency). On Azure clusters where these components don't exist, the metric returns no series and the alert is silently inert.

## Net effect

| | Before v0.42.0 | After v0.42.0 (AWS) |
|---|---|---|
| Total rules | 32 (post-v0.41.1) | 35 |
| Apps in ArgocdAppOutOfSync scope | 39/64 | 64/64 |
| Namespaces in PodCrashLooping | 6 critical / 7 warning | 12 critical / 31 warning |
| DaemonSets in unavailable alert | 2 | 7 |
| Components without any alert | 8+ | 5 (Trivy, OpenCost, Policy Reporter, Envoy Gateway, metrics-server) |

## Live validation (against cortex prd Mimir)

| Query | Series count |
|---|---|
| ArgocdAppOutOfSync (3-project filter) | 0 (cluster healthy) |
| PodCrashLoopingCritical ns regex | 72 |
| DaemonSetUnavailable daemonset regex | 7 |
| HighMemoryUsage ns regex | 100 |
| HighCpuThrottling ns regex | 100 |
| DeploymentReplicasMismatch ns regex | 48 |
| PodCrashLoopingWarning ns regex | 81 |
| AwsLoadBalancerControllerDown | 2 (replicas, both ready) |
| KarpenterDown | 2 |
| VaultDown | 3 |

## Test plan

- [x] All 7 expanded queries + 3 new alert queries validated against live cortex prd
- [x] `helm template` clean for both default (Azure) and AWS overlay paths
- [x] All 4 tier files YAML-lint clean
- [ ] Post-merge + cortex bump + promote: verify Mimir Ruler shows 35 rules on AWS (was 32), all health=ok