### PR TITLE
feat(mimir-rules): add 5 platform alerts (audit follow-up, MINOR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,71 @@
 # Changelog
 
+## [0.43.0] - 2026-05-05
+
+### Added — 5 new platform alerts (audit follow-up)
+
+Closes 5 of the 7 audit-listed "opportunity" gaps from the v0.41/v0.42
+audit. Each alert addresses a class of failure that was silent in the
+existing rule set.
+
+#### `CertManagerControllerDown` (Tier 1, critical)
+
+`core/components/mimir-rules/files/tier1-platform-down.yaml`. Catches
+loss of any of the 3 cert-manager deployments (controller, webhook,
+cainjector). Existing `CertificateExpiring14d`/`CertificateExpiring3d`
+(Tier 2) only catch the tail effect days after issuance/renewal stops
+— this fires within 3 minutes of controller down.
+
+#### `ArgocdApplicationSetControllerDown` (Tier 1, critical)
+
+Same file. ApplicationSet controller renders dynamic Application sets
+(e.g. `client-apps` + `hub-client-apps` cover 21 cortex client app
+namespaces). Loss = template changes don't propagate, new clusters
+don't get bootstrapped.
+
+#### `ImagePullBackOff` (Tier 2, warning)
+
+`core/components/mimir-rules/files/tier2-degradation.yaml`. Catches
+deploy-time failures invisible until now: wrong ECR tag, podre digest,
+missing IAM permissions, registry-egress NetworkPolicy gap. The
+existing `PodCrashLooping*` alerts only catch restart loops AFTER the
+container starts; this catches the state where it never starts.
+Validation against cortex prd: the metric saw 1 `ImagePullBackOff`
+event and 1 `ErrImagePull` event in the last 24h that this alert
+would have caught.
+
+#### `MimirIngesterPartialFailure` (Tier 2, warning)
+
+Same file. Tier 1 (`MimirIngesterDown`) only fires when ALL ingesters
+are down. On 2-ingester cortex prd, losing 1/2 means write
+replication is gone — single point of failure if the remaining one
+dies. New alert catches `replicas_ready < spec_replicas` for >5min.
+
+#### `PvcGrowthVelocity` (Tier 3, info)
+
+`core/components/mimir-rules/files/tier3-operational.yaml`. Predicts
+empty-in-6h via `predict_linear` over the last 6h growth rate.
+Complements the existing absolute thresholds (`PvcAlmostFull` @ 85%,
+`PvcFull` @ 95%) — a fast-filling PVC can blow past those thresholds
+between scrape intervals. Guarded with `> 70% used` so we don't alert
+on early-life PVCs whose growth rate isn't stable yet.
+
+### Net effect
+
+| | Before | After (AWS) |
+|---|---|---|
+| Total rules | 35 | 40 |
+| Tier 1 alerts | 16 | 18 |
+| Tier 2 alerts | 14 | 16 |
+| Tier 3 alerts | 5 | 6 |
+| Components without any alert | 5 | 5 (Trivy, OpenCost, Policy Reporter, Envoy Gateway, metrics-server — Tier-3 priority, deferred) |
+
+### Audit status after this release
+
+✅ Done: 4 broken alerts (v0.41.1), B1-B4 coverage gaps + 3 new alerts (v0.42.0), 5 new alerts (this release).
+
+⏳ Deferred: 4 Tier-3 components without alerts (Trivy, OpenCost, Policy Reporter, Envoy Gateway), RED metrics SLO alerts for 21 cortex client apps (scope dictates separate planning per app), Tempo metrics-generator push-error alerting (low value — Drilldown failures are user-visible immediately).
+
 ## [0.42.0] - 2026-05-05
 
 ### Added — Coverage gaps in mimir-rules platform alerts (B1–B4 + 3 new alerts)

--- a/core/components/mimir-rules/files/tier1-platform-down.yaml
+++ b/core/components/mimir-rules/files/tier1-platform-down.yaml
@@ -210,3 +210,41 @@ groups:
       description: Vault has zero ready replicas. Secret reads/writes are
         unavailable. Apps using Vault Agent or vault-injector will fail
         to start.
+  - alert: CertManagerControllerDown
+    # cert-manager has 3 deployments — controller (issuance), webhook
+    # (admission validation) and cainjector (CA bundle injection). Loss
+    # of any one is critical: certs stop being issued/renewed and
+    # admission requests for cert-manager CRs may fail. Existing
+    # CertificateExpiring* alerts are downstream — they only catch the
+    # tail effect days later.
+    expr: kube_deployment_status_replicas_available{namespace="cert-manager", deployment=~"cert-manager|cert-manager-webhook|cert-manager-cainjector"}
+      == 0
+    for: 3m
+    labels:
+      severity: critical
+      tier: '1'
+      component: cert-manager
+    annotations:
+      summary: cert-manager component {{ $labels.deployment }} is down
+      description: cert-manager component {{ $labels.deployment }} has zero
+        available replicas. Certificate issuance/renewal stopped — every
+        cert that expires in the next 14 days will silently fail to
+        renew unless this is recovered.
+  - alert: ArgocdApplicationSetControllerDown
+    # ApplicationSet controller renders dynamic Application sets (e.g.
+    # client-apps + hub-client-apps cover 21 client app namespaces in
+    # cortex prd). Loss of all replicas = ApplicationSet templates stop
+    # being reconciled, new clusters/apps don't get bootstrapped, and
+    # template changes don't propagate.
+    expr: kube_deployment_status_replicas_available{namespace="argocd", deployment="argocd-applicationset-controller"}
+      == 0
+    for: 3m
+    labels:
+      severity: critical
+      tier: '1'
+      component: argocd
+    annotations:
+      summary: ArgoCD ApplicationSet controller is down
+      description: ApplicationSet controller has zero available replicas.
+        Dynamic Application generation (client-apps, hub-client-apps,
+        etc.) is halted.

--- a/core/components/mimir-rules/files/tier2-degradation.yaml
+++ b/core/components/mimir-rules/files/tier2-degradation.yaml
@@ -182,3 +182,39 @@ groups:
       summary: No successful backup in the last 24 hours
       description: Schedule {{ $labels.schedule }} has not completed a successful
         backup in over 24 hours. Data protection is at risk.
+  - alert: ImagePullBackOff
+    # Catches deploy mistakes silent until now — wrong ECR tag, podre
+    # digest, missing IAM permissions, network egress to registry blocked.
+    # Pre-existing PodCrashLoopingCritical/Warning rules only catch
+    # restart loops AFTER the container starts; ImagePullBackOff is the
+    # state where the container never starts.
+    expr: kube_pod_container_status_waiting_reason{reason=~"ImagePullBackOff|ErrImagePull"}
+      > 0
+    for: 5m
+    labels:
+      severity: warning
+      tier: '2'
+      component: '{{ $labels.namespace }}'
+    annotations:
+      summary: Pod {{ $labels.namespace }}/{{ $labels.pod }} cannot pull image
+      description: Container {{ $labels.container }} in pod {{ $labels.pod }}
+        ({{ $labels.namespace }}) is in {{ $labels.reason }} state for over
+        5 minutes. Check the deployment image tag/digest and registry
+        permissions.
+  - alert: MimirIngesterPartialFailure
+    # Tier 1 (MimirIngesterDown) only fires when ALL ingesters are down
+    # (replicas_ready == 0). On a 2-ingester cluster (cortex prd default),
+    # losing 1/2 means write replication is gone — single point of failure
+    # if the remaining one dies. Catch this earlier as Tier 2.
+    expr: kube_statefulset_status_replicas_ready{namespace="grafana", statefulset="grafana-mimir-ingester"}
+      < kube_statefulset_replicas{namespace="grafana", statefulset="grafana-mimir-ingester"}
+    for: 5m
+    labels:
+      severity: warning
+      tier: '2'
+      component: mimir
+    annotations:
+      summary: Mimir Ingester quorum at risk
+      description: Mimir Ingester has fewer ready replicas than desired
+        ({{ $value }} ready). Write path replication is degraded — losing
+        another replica triggers MimirIngesterDown (critical).

--- a/core/components/mimir-rules/files/tier3-operational.yaml
+++ b/core/components/mimir-rules/files/tier3-operational.yaml
@@ -65,3 +65,28 @@ groups:
     annotations:
       summary: Node {{ $labels.node }} has memory pressure
       description: Node {{ $labels.node }} is under memory pressure. Pods may be evicted.
+
+  - alert: PvcGrowthVelocity
+    # Predicts whether each PVC will run out of space in the next 6 hours
+    # based on the recent 6h growth rate. Complements the existing
+    # threshold-based PvcAlmostFull (Tier 2 @ 85%) and PvcFull (Tier 2
+    # @ 95%) — those catch slow growth after the fact; this catches a
+    # fast-filling PVC before it hits 85%. Guard with > 70% used so we
+    # don't alert on early-life PVCs that haven't established a stable
+    # baseline yet (predict_linear is noisy on small fill levels).
+    expr: |
+      (kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes) > 0.7
+      and
+      predict_linear(kubelet_volume_stats_available_bytes[6h], 6 * 3600) < 0
+    for: 30m
+    labels:
+      severity: info
+      tier: '3'
+      component: storage
+    annotations:
+      summary: PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} will run out of space in 6h
+      description: PVC {{ $labels.persistentvolumeclaim }} in {{ $labels.namespace }}
+        is currently at {{ $value | humanizePercentage }} usage and projected
+        to be empty within 6 hours at the current growth rate. Plan a resize
+        or cleanup before the absolute thresholds (PvcAlmostFull @ 85%,
+        PvcFull @ 95%) fire.


### PR DESCRIPTION
## Summary

Adds 5 new alerts closing the v0.41/v0.42 audit's "opportunity" list — each addresses a class of failure that was silent in the existing rule set.

| Alert | Tier | Catches |
|---|---|---|
| **`CertManagerControllerDown`** | 1 critical | Any of the 3 cert-manager deployments (controller/webhook/cainjector) at 0 replicas. Pre-existing `CertificateExpiring*` only catches tail effect days later |
| **`ArgocdApplicationSetControllerDown`** | 1 critical | ApplicationSet controller down — `client-apps`/`hub-client-apps` stop rendering, 21 client apps stop reconciling |
| **`ImagePullBackOff`** | 2 warning | Container stuck in `ImagePullBackOff` or `ErrImagePull` for 5min. Existing `PodCrashLooping*` only catches restart loops AFTER container starts |
| **`MimirIngesterPartialFailure`** | 2 warning | `replicas_ready < spec_replicas` on Mimir ingester. Existing `MimirIngesterDown` (Tier 1) fires only at 0 replicas — losing 1/2 ingesters is SPOF |
| **`PvcGrowthVelocity`** | 3 info | `predict_linear` projects PVC will be empty in next 6h (guarded by `>70%` used). Complements absolute thresholds |

## Live validation (cortex prd Mimir)

| Query | Result |
|---|---|
| CertManagerControllerDown | 3 series (3 deployments tracked, all =1 ready) |
| ArgocdApplicationSetControllerDown | 1 series (=2 ready) |
| ImagePullBackOff | 0 series now; metric historically saw 1× ImagePullBackOff + 1× ErrImagePull in last 24h that would have fired |
| MimirIngesterPartialFailure ready/spec | both =2 (would fire if 1 fails) |
| PvcGrowthVelocity | 0 PVCs >70% used; 0 predicted-empty-in-6h |

## Net effect

| | Before | After (AWS) |
|---|---|---|
| Total rules | 35 | 40 |
| Tier 1 alerts | 16 | 18 |
| Tier 2 alerts | 14 | 16 |
| Tier 3 alerts | 5 | 6 |

## Audit status after this PR

✅ Broken alerts (v0.41.1) + B1-B4 + 3 new (v0.42.0) + 5 new (this PR)
⏳ Deferred: 4 Tier-3 components (Trivy, OpenCost, Policy Reporter, Envoy Gateway), per-app RED metrics SLO alerts (separate planning)

## Test plan

- [x] All 5 queries validated against live cortex prd Mimir
- [x] `helm template` clean (40 alerts in AWS render)
- [x] All 4 tier files YAML-lint clean
- [ ] Post-merge + cortex bump + promote: 40 rules in /api/v1/rules; 5 new alerts state=inactive, health=ok