### PR TITLE
feat(mimir-rules): 3 new alerts + enable Tempo /metrics scrape (MINOR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,88 @@
 # Changelog
 
+## [0.44.0] - 2026-05-05
+
+### Added — 3 new platform alerts + Tempo /metrics scrape
+
+Closes 3 of the 4 audit-listed Tier 3 component gaps + the Tempo
+metrics-generator push-error gap. The other 2 originally-listed
+components (OpenCost, Policy Reporter) turned out to have **no
+workloads deployed** in this platform — namespaces exist but no
+Deployments/StatefulSets/DaemonSets. Skipped accordingly; alerts can
+be added in a follow-up if those components get rolled out.
+
+#### `TrivyOperatorDown` (Tier 3, info)
+
+`core/components/mimir-rules/files/tier3-operational.yaml`. Covers
+the Trivy vulnerability scanner. Tier 3 because loss of Trivy doesn't
+break running workloads; existing scan results remain valid in the
+ConfigMaps. Promote to Tier 2 if compliance reporting depends on
+scan freshness.
+
+#### `EnvoyGatewayDown` (Tier 1, critical)
+
+`core/components/mimir-rules/files/tier1-platform-down.yaml`. Single
+alert covers both the Envoy Gateway controller (Deployment
+`envoy-gateway`) AND the data-plane proxy (Deployment
+`envoy-<class-name>-<hash>`). Controller down = no config reconcile;
+data-plane down = ingress traffic stops on the affected Gateway. The
+alert matches by namespace + label `deployment` rather than exact
+name because the data-plane Deployment carries a per-cluster hash
+suffix that's stable per cluster but unique across clusters.
+
+#### `TempoMetricsGeneratorFailures` (Tier 2, warning)
+
+`core/components/mimir-rules/files/tier2-degradation.yaml`. Catches
+two failure modes of Tempo's metrics-generator (which feeds Grafana
+Drilldown/Traces): registry collection failures and spans discarded
+by the processor. Either means Drilldown silently returns incomplete
+data.
+
+**Required enabling Tempo /metrics scrape** —
+`core/components/grafana-stack/tempo-values.yaml`. Audit found ZERO
+`tempo_metrics_generator_*` metrics reaching Mimir despite Tempo
+being healthy: the Tempo pod had no `prometheus.io/scrape` annotation,
+so Alloy's `metric_pods` discovery never picked it up. Added pod
+annotations (`prometheus.io/scrape=true`, `port=3200`,
+`path=/metrics`) — same pattern already used by the `aws-load-balancer-controller`,
+`cert-manager` and `beyla` pods on this platform. Without this scrape
+fix, the new alert would be silently dead — same class as the
+formerly-broken `ExternalDnsErrors` we replaced in v0.41.1.
+
+### Skipped — no workloads to alert on
+
+- **OpenCost**: namespace `opencost` exists, no Argo Application, no
+  resources. Component not deployed in this platform.
+- **Policy Reporter**: namespace `policy-reporter` exists, no Argo
+  Application, no resources. Same situation.
+
+If/when these are deployed, equivalent `*Down` alerts can be added
+following the same `kube_deployment_status_replicas_available == 0`
+pattern.
+
+### Net effect
+
+| | Before v0.44.0 | After v0.44.0 (AWS) |
+|---|---|---|
+| Total rules | 40 | 43 |
+| Tier 1 alerts | 18 | 19 |
+| Tier 2 alerts | 16 | 17 |
+| Tier 3 alerts | 6 | 7 |
+| Tempo `/metrics` scraped | NO | YES |
+
+### Audit closure
+
+This release closes the audit started in v0.41/v0.42. Net delta from
+the original 33-rule baseline:
+- 4 broken alerts repaired (v0.41.1)
+- B1-B4 coverage gaps + 3 Tier 1 alerts (v0.42.0)
+- 5 platform alerts (v0.43.0)
+- 3 alerts + Tempo scrape (this release)
+
+= **43 functional rules** (from 32 functional + 1 broken/dead-code,
+actually 30 useful rules pre-audit) covering the platform topology as
+of 2026-05-05.
+
 ## [0.43.0] - 2026-05-05
 
 ### Added — 5 new platform alerts (audit follow-up)

--- a/core/components/grafana-stack/tempo-values.yaml
+++ b/core/components/grafana-stack/tempo-values.yaml
@@ -9,6 +9,15 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
+# Pod-level annotations enable Alloy's metric_pods discovery to scrape
+# Tempo's /metrics endpoint. Without these, Alloy doesn't know to look,
+# so all tempo_* metrics (including tempo_metrics_generator_*) are
+# absent from Mimir — making any alert based on them silently dead.
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "3200"
+  prometheus.io/path: "/metrics"
+
 tempo:
   retention: 720h
   metricsGenerator:

--- a/core/components/mimir-rules/files/tier1-platform-down.yaml
+++ b/core/components/mimir-rules/files/tier1-platform-down.yaml
@@ -248,3 +248,24 @@ groups:
       description: ApplicationSet controller has zero available replicas.
         Dynamic Application generation (client-apps, hub-client-apps,
         etc.) is halted.
+  - alert: EnvoyGatewayDown
+    # Catches both the controller (deployment "envoy-gateway") AND any
+    # data-plane proxy deployment ("envoy-<class-name>-...") going to
+    # zero replicas. Controller down = no config reconcile; data plane
+    # down = ingress traffic stops on the affected Gateway. The
+    # generated data-plane name has a per-cluster hash suffix (e.g.
+    # "envoy-envoy-gateway-system-cortex-shared-8f6fbb84"), so we match
+    # by namespace rather than exact name.
+    expr: kube_deployment_status_replicas_available{namespace="envoy-gateway-system"}
+      == 0
+    for: 3m
+    labels:
+      severity: critical
+      tier: '1'
+      component: envoy-gateway
+    annotations:
+      summary: Envoy Gateway component {{ $labels.deployment }} is down
+      description: Envoy Gateway component {{ $labels.deployment }} has zero
+        available replicas. Either the controller (no new config applies)
+        or a data-plane proxy (ingress traffic stops on the affected
+        Gateway resource).

--- a/core/components/mimir-rules/files/tier2-degradation.yaml
+++ b/core/components/mimir-rules/files/tier2-degradation.yaml
@@ -218,3 +218,26 @@ groups:
       description: Mimir Ingester has fewer ready replicas than desired
         ({{ $value }} ready). Write path replication is degraded — losing
         another replica triggers MimirIngesterDown (critical).
+  - alert: TempoMetricsGeneratorFailures
+    # Tempo's metrics-generator (local-blocks + service-graphs +
+    # span-metrics processors) feeds Grafana Drilldown/Traces. Failures
+    # in the registry collection cycle (which exports Prometheus-format
+    # metrics out of the in-memory series store) or spans being
+    # discarded by the processor mean Drilldown queries silently return
+    # incomplete data. Requires tempo /metrics scrape annotations
+    # (tempo-values.yaml `podAnnotations` block) — without scrape, the
+    # metric simply doesn't exist and the alert is inert.
+    expr: |
+      rate(tempo_metrics_generator_registry_collections_failed_total[5m]) > 0
+      or
+      rate(tempo_metrics_generator_spans_discarded_total[5m]) > 0
+    for: 10m
+    labels:
+      severity: warning
+      tier: '2'
+      component: tempo
+    annotations:
+      summary: Tempo metrics-generator is dropping data
+      description: Tempo metrics-generator on {{ $labels.pod }} is failing
+        ({{ $value }}/s — collections_failed and/or spans_discarded).
+        Drilldown/Traces queries may return incomplete data.

--- a/core/components/mimir-rules/files/tier3-operational.yaml
+++ b/core/components/mimir-rules/files/tier3-operational.yaml
@@ -90,3 +90,20 @@ groups:
         to be empty within 6 hours at the current growth rate. Plan a resize
         or cleanup before the absolute thresholds (PvcAlmostFull @ 85%,
         PvcFull @ 95%) fire.
+
+  - alert: TrivyOperatorDown
+    # Tier 3 (info) — vulnerability scanner. Loss = scans stop but
+    # cluster keeps functioning; existing scan results stay valid.
+    # Promote to Tier 2 if compliance reporting depends on freshness.
+    expr: kube_deployment_status_replicas_available{namespace="trivy-system", deployment="trivy-operator"}
+      == 0
+    for: 10m
+    labels:
+      severity: info
+      tier: '3'
+      component: trivy
+    annotations:
+      summary: Trivy operator is down
+      description: Trivy operator deployment has zero available replicas.
+        Vulnerability scans on new images and re-scans of existing
+        workloads have stopped.


### PR DESCRIPTION
## Summary

Closes 3 of the 4 audit-listed Tier 3 component gaps + the Tempo metrics-generator push-error gap. Also fixes a silent scrape gap (Tempo /metrics not scraped) discovered while validating the Tempo MG alert.

## New alerts

| Alert | Tier | Catches |
|---|---|---|
| **`TrivyOperatorDown`** | 3 info | Trivy operator (vulnerability scanner) at 0 replicas |
| **`EnvoyGatewayDown`** | 1 critical | Either envoy-gateway controller OR envoy data-plane proxy at 0 replicas (matched by namespace, single rule covers both) |
| **`TempoMetricsGeneratorFailures`** | 2 warning | Tempo's metrics-generator dropping data — registry collection failures OR spans discarded. Drilldown silently returns incomplete data |

## Tempo /metrics scrape (required for the MG alert)

Audit found that **ZERO `tempo_metrics_generator_*` metrics were reaching Mimir** despite Tempo running healthy. Root cause: the Tempo pod had no `prometheus.io/scrape` annotation, so Alloy's `metric_pods` discovery never reached it. Same class as the formerly-broken `ExternalDnsErrors` we replaced in v0.41.1.

Fix: `core/components/grafana-stack/tempo-values.yaml` adds `podAnnotations: { prometheus.io/scrape: "true", port: "3200", path: "/metrics" }` — same pattern as `aws-load-balancer-controller`, `cert-manager`, `beyla` pods.

Without this fix, `TempoMetricsGeneratorFailures` would be silently dead.

## Skipped — no workloads deployed

- **OpenCost**: namespace `opencost` exists but no Argo Application, no Deployments/StatefulSets. Component never rolled out in this platform.
- **Policy Reporter**: same situation.

If they get deployed later, equivalent `*Down` alerts can be added with the standard `kube_deployment_status_replicas_available == 0` pattern.

## Live validation (cortex prd Mimir)

| Query | Result |
|---|---|
| TrivyOperatorDown | 1 series (1 ready) |
| EnvoyGatewayDown | 2 series — `envoy-gateway` (=1) + `envoy-...-cortex-shared-...` (=2) |
| TempoMetricsGeneratorFailures | 0 series now (metric not scraped); will start emitting after promote enables scrape |

## Net effect

| | Before | After (AWS) |
|---|---|---|
| Total rules | 40 | 43 |
| Tier 1 alerts | 18 | 19 |
| Tier 2 alerts | 16 | 17 |
| Tier 3 alerts | 6 | 7 |
| Tempo `/metrics` scraped | NO | YES |

## Audit closure

This closes the multi-PR audit started in v0.41:
- v0.41.1: 4 broken alerts repaired
- v0.42.0: B1-B4 coverage gaps + 3 Tier 1 alerts (ALB/Karpenter/Vault)
- v0.43.0: 5 platform alerts (CertManager/AppSet/ImagePullBackOff/MimirPartial/PvcVelocity)
- v0.44.0 (this PR): 3 alerts + Tempo scrape

= **43 functional rules** covering the platform topology as of 2026-05-05.

## Test plan

- [x] All 3 new queries validated against live cortex prd Mimir
- [x] `helm template` renders 43 alerts; tempo-values.yaml renders pod annotations correctly
- [x] All 4 tier files YAML-lint clean
- [ ] Post-merge + cortex bump + promote: verify
  - 43 rules in /api/v1/rules
  - 3 new alerts state=inactive, health=ok
  - Tempo pod has scrape annotations and tempo_metrics_generator_* metrics flow into Mimir