### PR TITLE
feat(mimir-rules): add VaultPartialFailure (Tier 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.45.0] - 2026-05-05
+
+### Added — `VaultPartialFailure` alert (Tier 2)
+
+`core/components/mimir-rules/files/tier2-degradation.yaml`. Vault runs
+as a 3-replica StatefulSet with raft consensus (quorum = 2/3). The
+existing `VaultDown` (Tier 1, critical) only fires when ALL replicas
+are at zero — full HA loss. This new alert catches the degraded state
+earlier:
+
+- 1/3 down: cluster operational but next failure breaks quorum
+- 2/3 down: quorum lost, cluster goes read-only
+
+Same `replicas_ready < spec_replicas` pattern used for
+`MimirIngesterPartialFailure` (added in v0.43.0). Tier 2 warning so
+operators can replace the failed replica before the cluster goes
+fully read-only or down.
+
+Total rules in AWS overlay: 43 → 44.
+
 ## [0.44.0] - 2026-05-05
 
 ### Added — 3 new platform alerts + Tempo /metrics scrape

--- a/core/components/mimir-rules/files/tier2-degradation.yaml
+++ b/core/components/mimir-rules/files/tier2-degradation.yaml
@@ -241,3 +241,24 @@ groups:
       description: Tempo metrics-generator on {{ $labels.pod }} is failing
         ({{ $value }}/s — collections_failed and/or spans_discarded).
         Drilldown/Traces queries may return incomplete data.
+  - alert: VaultPartialFailure
+    # Vault runs as a 3-replica StatefulSet with raft consensus; quorum
+    # is 2/3. Tier 1 (VaultDown) only fires when ALL replicas are down
+    # (full HA loss). Catch the degraded state earlier:
+    # - 1/3 down: cluster operational but next failure breaks quorum.
+    # - 2/3 down: quorum lost — cluster goes read-only.
+    # Either should be a Tier 2 warning so the operator can replace the
+    # failed replica before the remaining one(s) also fail.
+    expr: kube_statefulset_status_replicas_ready{namespace="vault", statefulset="vault"}
+      < kube_statefulset_replicas{namespace="vault", statefulset="vault"}
+    for: 5m
+    labels:
+      severity: warning
+      tier: '2'
+      component: vault
+    annotations:
+      summary: Vault HA cluster degraded
+      description: Vault has fewer ready replicas than desired
+        ({{ $value }} ready). Raft quorum is at risk — losing one more
+        replica triggers VaultDown (critical) and the cluster goes
+        read-only.


### PR DESCRIPTION
## Summary

Adds `VaultPartialFailure` (Tier 2 warning) to catch Vault HA degradation before the cluster goes fully down.

Vault runs as a 3-replica StatefulSet with raft consensus (quorum = 2/3). Existing `VaultDown` (Tier 1, critical) only fires when ALL replicas are at zero. This new alert fires when **any** replica is missing:

- **1/3 down**: cluster operational but next failure breaks quorum
- **2/3 down**: quorum lost, cluster goes read-only

Same `replicas_ready < spec_replicas` pattern used for `MimirIngesterPartialFailure` (added in v0.43.0). Tier 2 warning gives operators time to replace the failed replica before `VaultDown` (Tier 1) fires.

## Live validation (cortex prd)

```
kube_statefulset_replicas{statefulset=vault}                = 3
kube_statefulset_status_replicas_ready{statefulset=vault}   = 3
ready < desired ?                                            0 series (cluster healthy)
```

## Net effect

- Total rules in AWS overlay: 43 → 44

## Test plan
- [x] Query validated against live cortex prd
- [x] `helm template` clean
- [ ] Post-promote: alert visible with state=inactive, health=ok