### PR TITLE
fix(velero): add KMS permissions to IRSA role (PATCH)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## [0.45.1] - 2026-05-06
+
+### Fixed — Velero IAM role missing KMS permissions
+
+`providers/aws/iam.tf`. Adds an inline policy to the Velero IRSA role
+granting `kms:Decrypt` + `kms:GenerateDataKey` scoped to the
+customer-managed `s3_data` KMS key.
+
+#### Why
+
+The upstream module `terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts`
+v6.5 with `attach_velero_policy = true` builds a policy with EC2
+(snapshot management) + S3 (PutObject/GetObject/etc) but **no KMS
+actions**. The default Velero policy template assumes the backup
+bucket uses SSE-S3 (AES256), not SSE-KMS.
+
+Estabilis platform encrypts the Velero bucket with the
+customer-managed `aws_kms_key.s3_data` (see `s3.tf`). When Velero
+calls `s3:PutObject`, S3 in turn calls `kms:GenerateDataKey` carrying
+the **caller's identity** (the Velero IRSA role). IAM evaluates the
+caller's policy and finds no KMS grant → `AccessDenied`. The KMS key
+policy's `kms:ViaService` clause for the S3 service is necessary but
+not sufficient — IAM still requires the caller to have the action
+on its identity-based policy.
+
+Observed in cortex prd (the only AWS client running this code today):
+6 consecutive days of failed backups (2026-05-01 through 2026-05-06),
+each with `errors: 14` and `failureReason` containing
+`AccessDenied: ... is not authorized to perform: kms:GenerateDataKey`.
+
+#### Why scoped to one key (not `kms:*` / `Resource: *`)
+
+`aws_kms_key.s3_data` encrypts every S3 bucket in the platform that
+needs customer-managed encryption (Velero, Loki, Cost Export, Flow
+Logs). A blanket `kms:*` would let Velero touch keys it has no
+business with (e.g. the `platform_secrets` key used by Vault). The
+two scoped actions on a single key match Velero's actual need.
+
+#### Compatibility
+
+- Other Estabilis AWS clients running Velero are affected by the same
+  bug — this fix lands at the platform tag level, so they pick it up
+  on their next platform bump.
+- The fix is purely additive (new `aws_iam_role_policy`); no existing
+  resource modified, no destroy/recreate. `terraform plan` shows a
+  single resource creation.
+
 ## [0.45.0] - 2026-05-05
 
 ### Added — `VaultPartialFailure` alert (Tier 2)

--- a/providers/aws/iam.tf
+++ b/providers/aws/iam.tf
@@ -98,6 +98,35 @@ module "velero_irsa" {
   }
 }
 
+# The upstream `attach_velero_policy = true` template assumes the bucket
+# uses SSE-S3 (AES256) and DOES NOT include KMS permissions. Our S3 buckets
+# are encrypted with SSE-KMS via the customer-managed `s3_data` key
+# (see s3.tf), so Velero's `s3:PutObject` calls trigger
+# `kms:GenerateDataKey` from S3 against the caller identity. Without this
+# inline policy, every backup fails with `AccessDenied` on KMS — which is
+# exactly the failure mode observed in cortex prd before this fix
+# (6 days of `velero_backup_failure_total` firing, all errors=14).
+# Permissions are scoped to the single key by ARN; no `kms:*` or wildcard.
+resource "aws_iam_role_policy" "velero_kms" {
+  name = "velero-kms"
+  role = module.velero_irsa.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowKMSForVeleroBucketEncryption"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:GenerateDataKey",
+        ]
+        Resource = aws_kms_key.s3_data.arn
+      },
+    ]
+  })
+}
+
 # ========================== loki ==========================================
 # No upstream helper for Loki S3 access — bespoke role with the minimum
 # policy needed to read/write Loki chunks + index.


### PR DESCRIPTION
## Summary

Velero backups have been failing for 6 consecutive days in cortex prd (the only AWS client running this code today) with the same error:

```
AccessDenied: User: arn:aws:sts::093996075120:assumed-role/eks-cortex-platform-prd-us-east-1-velero/...
is not authorized to perform: kms:GenerateDataKey
on resource: arn:aws:kms:us-east-1:093996075120:key/bff975d3-de4d-4ebc-b704-44c7a27a1183
because no identity-based policy allows the kms:GenerateDataKey action
```

## Root cause

The upstream module `terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts` v6.5 with `attach_velero_policy = true` builds the Velero policy from a template that assumes the backup bucket uses **SSE-S3 (AES256)**, not **SSE-KMS**. Our buckets are encrypted with the customer-managed `aws_kms_key.s3_data` (see `s3.tf`).

When Velero calls `s3:PutObject`, S3 in turn calls `kms:GenerateDataKey` carrying the caller identity. IAM evaluates the caller's policy and finds **no KMS grant** → `AccessDenied`. The KMS key policy's `kms:ViaService` clause for the S3 service is necessary but not sufficient — IAM still requires the caller to have the action on its identity-based policy.

## Fix

Inline policy on the Velero IRSA role with **two scoped actions on a single key ARN** (least privilege):

```hcl
resource "aws_iam_role_policy" "velero_kms" {
  name = "velero-kms"
  role = module.velero_irsa.name
  policy = jsonencode({
    Statement = [{
      Effect   = "Allow"
      Action   = ["kms:Decrypt", "kms:GenerateDataKey"]
      Resource = aws_kms_key.s3_data.arn
    }]
  })
}
```

No `kms:*`, no `Resource: *`. Velero gets exactly what it needs (Decrypt for restore, GenerateDataKey for backup) on the single key that encrypts its bucket.

## Compatibility

- **Purely additive**: new resource, no existing resource modified. `terraform plan` shows one resource creation, zero changes.
- **All Estabilis AWS clients running Velero are affected** by the same bug; they pick up the fix on their next platform bump.

## Test plan

- [x] `terraform validate` clean
- [x] `terraform fmt` clean
- [ ] After cortex bump (separate PR) + `terraform apply` in cortex prd:
  - `aws iam list-role-policies --role-name eks-cortex-platform-prd-us-east-1-velero` lists `velero-kms`
  - Trigger backup: `velero backup create --from-schedule velero-platform-daily ad-hoc-test`
  - `kubectl get backup.velero.io -n velero ad-hoc-test` reaches `phase=Completed` (not Failed)
  - `VeleroBackupFailed` Mimir alert returns to `inactive`