### PR TITLE
feat(snapshot-controller): EKS managed addon + Application wiring (MINOR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## [0.46.0] - 2026-05-06
+
+### Added — CSI snapshot-controller EKS managed addon + VolumeSnapshotClass wiring
+
+`providers/aws/eks.tf` adds `snapshot-controller` to `local.default_addons`
+(installs the `volumesnapshots/volumesnapshotcontents/volumesnapshotclasses`
+CRDs and the controller Deployment that reconciles them — managed by AWS,
+upgrade lifecycle stays on the EKS control plane).
+
+`bootstrap/platform-root/templates/snapshot-controller.yaml` (new) creates
+an ArgoCD Application that pulls from `estabilis-platform-gitops`
+v0.39.10's new `components/snapshot-controller` chart. AWS-only,
+sync wave 6 (before velero in wave 7), `components.snapshot-controller`
+toggle in `bootstrap/platform-root/values.yaml`.
+
+`bootstrap/platform-root/templates/_helpers.tpl` — `componentsForwarding`
+helper now lists `snapshot-controller` as AWS-only so it gets stripped
+from the components map propagated to network-policies / resource-quotas
+on Azure clusters (preventing OutOfSync drift).
+
+#### Why
+
+Velero CSI backups silently skip PV snapshotting unless a
+VolumeSnapshotClass carries the `velero.io/csi-volumesnapshot-class:
+"true"` discovery label. Observed on cortex prd 2026-05-05 after
+v0.45.1 fixed the KMS gap: 14 PVs landed in `PartiallyFailed` phase
+because no VSC existed at all. The CSI external-snapshotter (CRDs +
+controller) is the prerequisite that unlocks the proper backup flow.
+
+The community converged on the EKS managed addon as the canonical
+install path (per AWS docs and Kubernetes SIG-Storage). It tracks
+upstream releases (v8.5.0-eksbuild.4 today, paired with K8s 1.31+),
+upgrades cleanly via the EKS control plane, and follows the same
+opinionated treatment as the other 5 platform-managed addons (vpc-cni,
+coredns, kube-proxy, eks-pod-identity-agent, aws-ebs-csi-driver).
+
+The VolumeSnapshotClass itself (with the velero label) is shipped via
+estabilis-platform-gitops v0.39.10 — paired release.
+
+#### How
+
+Existing AWS clients on platform v0.46.0+:
+1. `terraform init -upgrade && terraform apply` (creates the addon)
+2. `estabilis promote <client> -d <deployment> --force-refresh`
+   (rolls the new `snapshot-controller` Application into platform-root)
+
+Verification:
+- `kubectl get crds | grep snapshot.storage.k8s.io` → 6 CRDs
+- `kubectl get volumesnapshotclass ebs-csi-aws` → exists, with the velero label
+- Trigger an ad-hoc backup: phase=Completed (no PartiallyFailed) and items list includes PVs
+
+Azure clients are unaffected — addon block + Application both gated
+on `global.provider == "aws"`.
+
 ## [0.45.1] - 2026-05-06
 
 ### Fixed — Velero IAM role missing KMS permissions

--- a/bootstrap/platform-root/templates/_helpers.tpl
+++ b/bootstrap/platform-root/templates/_helpers.tpl
@@ -408,12 +408,13 @@ tolerations:
     - bootstrap/platform-root/templates/aws-load-balancer-controller.yaml
     - bootstrap/platform-root/templates/karpenter.yaml (also gates karpenter-resources)
     - bootstrap/platform-root/templates/metrics-server.yaml
+    - bootstrap/platform-root/templates/snapshot-controller.yaml
 
   Output: a `components:` block ready to nest under valuesObject.
 */ -}}
 {{- define "platform-root.componentsForwarding" -}}
 {{- /* Vault is intentionally NOT in this list — it's multi-provider (AWS + Azure) and gated separately on (provider in (aws|azure)) in vault.yaml. */ -}}
-{{- $awsOnly := list "aws-load-balancer-controller" "karpenter" "karpenter-resources" "metrics-server" -}}
+{{- $awsOnly := list "aws-load-balancer-controller" "karpenter" "karpenter-resources" "metrics-server" "snapshot-controller" -}}
 components:
   {{- range $k, $v := .Values.components }}
   {{- if and (has $k $awsOnly) (ne $.Values.global.provider "aws") }}

--- a/bootstrap/platform-root/templates/snapshot-controller.yaml
+++ b/bootstrap/platform-root/templates/snapshot-controller.yaml
@@ -1,0 +1,67 @@
+{{- /*
+  snapshot-controller — VolumeSnapshotClass(es) for the in-cluster CSI
+  snapshot-controller.
+
+  The controller deployment + CRDs (volumesnapshots, volumesnapshotcontents,
+  volumesnapshotclasses + the volumegroup* triplet) are NOT in this chart;
+  they come from the EKS managed addon `snapshot-controller`, provisioned
+  in providers/aws/eks.tf via local.default_addons. This Application only
+  ships the VolumeSnapshotClass that Velero needs (label
+  `velero.io/csi-volumesnapshot-class: "true"` is the discovery hook).
+
+  Velero CSI backups silently skip PV snapshotting when no VSC carries
+  that label (observed on cortex prd 2026-05-05 — backups completed with
+  phase=PartiallyFailed and 14 PVs went unsnapshotted). Sync wave 6
+  guarantees the VSC exists before velero (wave 7) takes its first
+  scheduled backup.
+
+  AWS-only for now — the EKS managed addon is the canonical install path
+  per AWS + Kubernetes SIG-Storage docs. Azure (AKS) ships an analogous
+  built-in for `disk.csi.azure.com`; will add when there is a workload
+  demanding CSI snapshots there.
+*/ -}}
+{{- if eq .Values.global.provider "aws" }}
+{{- if ne (index .Values.components "snapshot-controller") false }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: snapshot-controller
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "6"
+spec:
+  project: platform
+  sources:
+    - repoURL: {{ .Values.platformGitopsRepoUrl }}
+      targetRevision: {{ .Values.platformGitopsVersion }}
+      path: components/snapshot-controller
+      helm:
+        valueFiles:
+          - $values/components/snapshot-controller/values.yaml
+          - $values/components/snapshot-controller/values-{{ .Values.global.provider }}.yaml
+          {{- include "platform-root.overrideValueFile" (dict "component" "snapshot-controller" "root" $) | nindent 10 }}
+          {{- include "platform-root.gitopsValueFile" (dict "component" "snapshot-controller" "root" $) | nindent 10 }}
+        {{- include "platform-root.ignoreMissingValueFiles" $ | nindent 8 }}
+        {{- include "platform-root.provenanceParametersBlock" $ | nindent 8 }}
+    - repoURL: {{ .Values.platformGitopsRepoUrl }}
+      targetRevision: {{ .Values.platformGitopsVersion }}
+      ref: values
+    {{- include "platform-root.overrideSource" . | nindent 4 }}
+    {{- include "platform-root.gitopsSource" . | nindent 4 }}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+    syncOptions:
+      - ServerSideApply=true
+{{- end }}
+{{- end }}

--- a/bootstrap/platform-root/values.yaml
+++ b/bootstrap/platform-root/values.yaml
@@ -171,6 +171,7 @@ components:
   argocd-image-updater: false # optional: auto-update container images via registry polling (opt-in)
   policy-reporter: false     # optional: kubernetes policy report dashboards (disabled by default — opt-in)
   metrics-server: true       # optional: AWS-only — Resource Metrics API server (kubectl top, HPA). Azure AKS provides natively
+  snapshot-controller: true  # optional: AWS-only — VolumeSnapshotClass for Velero CSI backups (snapshot-controller addon installs CRDs+Deployment via providers/aws/eks.tf)
   karpenter: true            # optional: AWS-only — node autoscaler. Activates when global.autoscaler is `karpenter` or `hybrid`
   karpenter-resources: true  # optional: AWS-only — default NodePool + EC2NodeClass. Same activation as karpenter
   aws-load-balancer-controller: true  # optional: AWS-only — provisions ALB/NLB from Ingress/Service. Activates when global.ingressController == "alb"

--- a/providers/aws/eks.tf
+++ b/providers/aws/eks.tf
@@ -84,11 +84,25 @@ locals {
       most_recent              = true
       service_account_role_arn = module.ebs_csi_irsa.arn
     }
+    # CSI external-snapshotter — provides VolumeSnapshot/VolumeSnapshotContent/
+    # VolumeSnapshotClass CRDs and the snapshot-controller Deployment that
+    # reconciles them. Required by Velero's CSI plugin to snapshot
+    # PVs (without it, backups complete with phase=PartiallyFailed and
+    # PV data is not captured — observed on cortex prd 2026-05-05).
+    #
+    # Cluster-scoped, opinionated defaults from AWS — same `most_recent`
+    # treatment as the other 5 addons. The matching VolumeSnapshotClass
+    # (with the velero discovery label) is shipped via
+    # estabilis-platform-gitops/components/snapshot-controller (consumed
+    # by bootstrap/platform-root/templates/snapshot-controller.yaml).
+    snapshot-controller = {
+      most_recent = true
+    }
   }
 
   # Merge instead of substitute. Operators set var.cluster_addons to override
   # individual addons (e.g. enable amazon-cloudwatch-observability) without
-  # losing the 5 platform defaults. User-provided keys win on collision.
+  # losing the 6 platform defaults. User-provided keys win on collision.
   effective_addons = merge(local.default_addons, var.cluster_addons)
 
   # Fargate profiles — kube-system is always included (addons land here),


### PR DESCRIPTION
## Summary

- `providers/aws/eks.tf` — adds `snapshot-controller` to `local.default_addons` (EKS managed addon, AWS-managed lifecycle).
- `bootstrap/platform-root/templates/snapshot-controller.yaml` (new) — ArgoCD Application that pulls the VolumeSnapshotClass from estabilis-platform-gitops v0.39.10. AWS-only, sync wave 6.
- `_helpers.tpl` componentsForwarding adds `snapshot-controller` to the AWS-only filter.
- `values.yaml` toggle `components.snapshot-controller: true`.

## Why

Velero CSI backups silently skip PV snapshotting unless a VolumeSnapshotClass carries the `velero.io/csi-volumesnapshot-class: "true"` label. After PR #156 (v0.45.1) fixed the IAM/KMS gap, cortex prd backups still landed in `PartiallyFailed` because the cluster had no VSC at all (the snapshot-controller and CRDs were never installed).

## Why EKS managed addon (not piraeus chart, not raw manifests)

AWS docs + Kubernetes SIG-Storage docs both endorse the EKS managed addon as the canonical install for this component on EKS. Same opinionated treatment as the existing 5 platform-managed addons. Tracks upstream releases (v8.5.0-eksbuild.4, K8s 1.31+ compatible).

## Pairing

- **estabilis-platform-gitops v0.39.10** (#41 — already merged, tag pushed) ships the `components/snapshot-controller` chart with the AWS VolumeSnapshotClass.

## Test plan

- [x] `helm template` for `global.provider=aws` renders the snapshot-controller Application
- [x] `helm template` for `global.provider=azure` does NOT render it
- [x] `terraform fmt -check` passes
- [ ] After merge → cortex bump (PR coming next) → `terraform apply` → verify addon shows in `aws eks list-addons`
- [ ] `kubectl get crds | grep snapshot.storage.k8s.io` → 6 CRDs
- [ ] `kubectl get volumesnapshotclass ebs-csi-aws` → exists with velero label
- [ ] Velero ad-hoc backup → phase=Completed, items include PVs

## Versioning rationale

MINOR (v0.45.1 → v0.46.0) — adds new platform component (default-on for AWS), new managed addon, new helm template. Backward-compatible: Azure clusters are not affected; AWS clusters with `components.snapshot-controller: false` skip the App; existing addons are unchanged.