### PR TITLE
fix(velero): bump memory limit 512Mi → 1Gi for CSI backup (PATCH)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [0.46.1] - 2026-05-06
+
+### Fixed — Velero memory limit insufficient for CSI snapshot flow
+
+`core/components/velero/values.yaml` — bumps the velero container
+memory request 128Mi → 256Mi and limit 512Mi → 1Gi.
+
+#### Why
+
+First real CSI backup test on cortex prd after v0.46.0 (snapshot-
+controller addon + VolumeSnapshotClass) consistently OOMKilled at
+~35-40s (exitCode 137). Velero v1.17.1 with `--features=EnableCSI`
+holds:
+
+- Cluster-wide resource discovery state (kopia uploader walks every
+  resource in scope, ~1k-4k objects on a typical cortex-sized cluster)
+- 12+ in-flight CSI VolumeSnapshot reconciles (one per PVC)
+- AWS S3 multi-part upload buffers
+- Plugin RPC channels to velero-plugin-for-aws
+
+512Mi was sufficient for the no-CSI flow shipped by v0.46.0 but tight
+once the snapshot-controller component started being exercised. 1Gi
+gives ~2× headroom over observed peak. Memory peak after fix: spike
+during backup phase, ~51Mi steady-state idle.
+
+Request bumped to 256Mi so Karpenter reserves accurately for the
+steady state plus CSI baseline (avoids node bin-packing surprises
+during multi-cluster backup windows).
+
+#### Lineage
+
+This is the patch I expected per the "ship vX.Y.0 expecting patch
+vX.Y.1 after first real consumer apply" rule — design-time review
+(brutal-code-critic) catches structural issues but cannot anticipate
+runtime memory pressure on a specific cluster's workload mix.
+
 ## [0.46.0] - 2026-05-06
 
 ### Added — CSI snapshot-controller EKS managed addon + VolumeSnapshotClass wiring

--- a/core/components/velero/values.yaml
+++ b/core/components/velero/values.yaml
@@ -87,13 +87,22 @@ affinity:
               operator: In
               values: ["regular"]
 
+# 2026-05-06 — bumped memory limit 512Mi → 1Gi after first real CSI
+# backup test on cortex prd OOMKilled at ~35s (exitCode 137) under
+# velero v1.17.1 with `--features=EnableCSI` against 12 PVs. Process
+# memory peaks during cluster-wide resource discovery + CSI plugin
+# work (snapshot lifecycle reconcile, VolumeSnapshot watcher, S3
+# multi-part upload buffers); 512Mi is sufficient for backup-without-CSI
+# but tight for CSI flow on a non-trivial workload count. 1Gi gives
+# ~2× headroom over observed peak; request bumped 128Mi → 256Mi so
+# Karpenter reserves accurately for steady state.
 resources:
   requests:
     cpu: 50m
-    memory: 128Mi
+    memory: 256Mi
   limits:
     cpu: 200m
-    memory: 512Mi
+    memory: 1Gi
 
 initContainers:
   - name: velero-plugin-for-azure


### PR DESCRIPTION
## Summary

`core/components/velero/values.yaml` — bumps velero container memory request `128Mi → 256Mi` and limit `512Mi → 1Gi`.

## Why

First real CSI backup test on cortex prd after v0.46.0 (snapshot-controller addon shipped) consistently OOMKilled at ~35-40s (exitCode 137). Velero v1.17.1 with `--features=EnableCSI` holds:

- Cluster-wide resource discovery state (~1-4k objects)
- N in-flight CSI VolumeSnapshot reconciles (12 PVCs in cortex)
- AWS S3 multi-part upload buffers
- Plugin RPC channels to velero-plugin-for-aws

Validated on cortex prd: after applying the bump (kubectl patch deployment direto, then bake here), backup completed in 295s with 12/12 CSI snapshots, 0 errors, 0 warnings. Steady-state idle ~51Mi.

## Lineage

This is the "first real consumer apply" patch expected per the brutal-critic discipline — review catches structural issues but cannot anticipate runtime memory pressure on a specific cluster's workload mix.

## Test plan

- [x] cortex prd backup completed in 295s with 12/12 CSI snapshots after the kubectl patch
- [ ] After merge → cortex bump v1.15.40 → `estabilis promote` (no terraform apply needed — pure helm values change)
- [ ] Re-enable selfHeal on cortex velero App
- [ ] Confirm next scheduled backup (02:00 UTC) completes