### PR TITLE
feat(grafana-stack): enable Infinity datasource plugin by default (MINOR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## [0.47.0] - 2026-05-06
+
+### Added — Grafana Infinity datasource plugin enabled by default
+
+`core/components/grafana-stack/grafana-values.yaml` — adds
+`yesoreyeram-infinity-datasource` to the upstream `plugins:` list,
+alongside the existing `grafana-llm-app`, `grafana-lokioperational-app`
+and `grafana-github-datasource`.
+
+#### Why
+
+The Infinity datasource (a generic JSON/CSV/XML/HTML/GraphQL/REST
+datasource) has been carried as a downstream-only override in
+`cortex-platform-aws-us-east-1-prd/overrides/grafana/values.yaml`
+since the Bright Data integration landed (2026-04). With the
+brightdata-exporter hub-app coming online, a second consumer of the
+Infinity plugin is needed (the exporter exposes a `/api` REST surface
+the FinOps dashboard hits via Infinity), and other clients have asked
+for ad-hoc REST/JSON datasources too.
+
+Promoting the plugin to the platform default removes the bespoke
+override (one fewer entry to repeat in every downstream that wants
+Infinity-style datasources) while keeping the actual datasource
+configuration downstream — the plugin is a generic capability, the
+specific datasource declarations remain client-specific.
+
+#### Impact
+
+- `cortex-platform-aws-us-east-1-prd` removes the duplicate plugin
+  entry from `overrides/grafana/values.yaml` after bumping
+  `platform_version` (Helm list-replace semantics: the override
+  REPLACES upstream's `plugins:` list, so the upstream Infinity entry
+  is only seen once the override drops it).
+- New downstream deployments inherit Infinity automatically.
+- No new credentials / secrets / TF inputs — the plugin is
+  load-time-free; specific datasources still declare their own auth
+  in `overrides/grafana/values.yaml`.
+
 ## [0.46.1] - 2026-05-06
 
 ### Fixed — Velero memory limit insufficient for CSI snapshot flow

--- a/core/components/grafana-stack/grafana-values.yaml
+++ b/core/components/grafana-stack/grafana-values.yaml
@@ -92,6 +92,7 @@ plugins:
   - grafana-llm-app
   - grafana-lokioperational-app
   - grafana-github-datasource
+  - yesoreyeram-infinity-datasource
 
 sidecar:
   securityContext:


### PR DESCRIPTION
## Summary

Adds \`yesoreyeram-infinity-datasource\` to the platform's default Grafana \`plugins:\` list.

The Infinity datasource (generic JSON/CSV/XML/HTML/GraphQL/REST) has been carried downstream-only in \`cortex-platform-aws-us-east-1-prd/overrides/grafana/values.yaml\` since the Bright Data integration. With the brightdata-exporter hub-app coming online (a second Infinity consumer that hits the exporter's \`/api\` REST surface), this is the right moment to promote the plugin to platform default.

## What changes

- \`core/components/grafana-stack/grafana-values.yaml\` — adds the plugin entry alongside the existing 3.
- \`CHANGELOG.md\` — \`[0.47.0]\` entry under "Added".

## Non-goals

- **No** datasource configuration is being promoted upstream. Each client still declares its specific Infinity datasources downstream.
- **No** new TF inputs, secrets, or platform-secrets-grafana additions.

## Downstream impact

After bumping \`platform_version\`, each downstream that previously declared the plugin in its override (cortex prd today) drops the duplicate entry. Helm list-replace semantics for \`plugins:\` mean the override REPLACES the upstream list, so the new upstream entry only takes effect once the downstream override removes its own copy.

## Test plan

- [ ] CI: \`pre-commit\` + lint
- [ ] Post-merge: \`chore(release): v0.47.0\` direct-push → workflow auto-tag
- [ ] Manual: cortex-platform-aws-us-east-1-prd PR (Janela 1 step 2) bumps \`platform_version\`, drops local plugin, runs \`terraform apply\` + \`estabilis promote\`, verify \`/api/plugins\` in Grafana lists Infinity from the upstream provisioning ConfigMap