### PR TITLE
feat(mimir-rules): per-alert overrides via alertOverrides slot (PATCH)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog
 
+## [0.47.1] - 2026-05-06
+
+### Added — `alertOverrides` slot in `mimir-rules` chart
+
+Clients can now disable or customize platform-shipped alerts without
+forking the chart, via `overrides/mimir-rules/values.yaml`:
+
+```yaml
+alertOverrides:
+  TempoMetricsGeneratorFailures:
+    enabled: false
+  HighMemoryUsage:
+    for: 30m
+  PvcAlmostFull:
+    expr: |
+      (kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes) > 0.95
+    labels:
+      severity: info
+```
+
+#### Behavior
+
+- `enabled: false` → rule is dropped from the rendered ConfigMap
+- Any other field → SHALLOW-merged onto the upstream rule (override
+  wins on collision). Providing a complex field like `labels:` REPLACES
+  the entire labels map; caller must include every label intended.
+- Threshold tweaks: provide the complete new `expr:` string. The chart
+  does not parse PromQL — surgical edit of a single number inside an
+  expr is intentionally not supported.
+- Override key MUST match the `alert:` field exactly (case-sensitive).
+  Typo silently no-ops; cross-check with `kubectl get configmap
+  mimir-alerting-rules -n grafana -o yaml | grep "alert:"`.
+- Group-level toggles (`ruleGroups.<group>.enabled`) and
+  `customRuleGroups` keep working unchanged; `alertOverrides` is
+  independent and stacks on top.
+
+#### Files changed
+
+- `core/components/mimir-rules/templates/_helpers.tpl` — new
+  `mimir-rules.applyOverrides` helper (parse YAML → filter/merge → emit)
+- `core/components/mimir-rules/templates/configmap.yaml` — calls helper
+  for each tier file
+- `core/components/mimir-rules/values.yaml` — adds `alertOverrides: {}`
+  default (empty = upstream behavior preserved)
+- `core/components/mimir-rules/Chart.yaml` — chart version bumped
+  `0.2.0` → `0.3.0`
+
+#### Why PATCH bump (not MINOR)
+
+The new field defaults to `{}`, which produces a rendered ConfigMap
+byte-equivalent to v0.47.0 output for every existing client. Zero
+behavior change without opt-in. Per the same rationale used for default
+tweaks elsewhere in this CHANGELOG, opt-in additions with a no-op
+default land as PATCH.
+
+#### Smoke tested
+
+- `helm template` with empty overrides → 45 alerts, identical to v0.47.0
+- `helm template` with `TempoMetricsGeneratorFailures.enabled=false` →
+  44 alerts, target alert absent
+- `helm template` with `HighMemoryUsage.for=30m` → field replaced,
+  `expr`/`labels` preserved
+- Typo (`TempoMetricsGeneratorFailur`) silently no-ops as designed
+- Disabling all alerts in a group renders `groups: []` (Mimir Ruler
+  accepts; no error)
+- Group-level toggle (`ruleGroups.platformDegradation.enabled=false`)
+  still drops the entire tier file as before
+
 ## [0.47.0] - 2026-05-06
 
 ### Added — Grafana Infinity datasource plugin enabled by default

--- a/core/components/mimir-rules/Chart.yaml
+++ b/core/components/mimir-rules/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: mimir-rules
 description: Alerting rules for the Estabilis Platform — uploaded to Mimir Ruler via API
 type: application
-version: 0.2.0
+version: 0.3.0

--- a/core/components/mimir-rules/templates/_helpers.tpl
+++ b/core/components/mimir-rules/templates/_helpers.tpl
@@ -46,3 +46,70 @@ labels:
 annotations:
   {{- include "estabilis.annotations" . | nindent 2 }}
 {{- end -}}
+
+{{/*
+mimir-rules.applyOverrides — render a tier file with `alertOverrides`
+applied.
+
+Input dict:
+  tier      — basename of the tier file (e.g. "tier2-degradation")
+  overrides — .Values.alertOverrides map
+  files     — pass `.Files` (renderer needs context to call `Files.Get`)
+
+Behavior per rule (matched by `alert:` field):
+  - override `enabled: false` → rule is dropped from output
+  - any other override field  → shallow-merged onto the rule (override
+    wins on conflict); providing a complex field like `labels:` REPLACES
+    the entire labels map — caller provides the complete intended value
+  - rule with no matching override → emitted unchanged
+
+Group-level: a group whose rules are all dropped is omitted (avoids
+empty `rules: []` blocks that Mimir Ruler logs as warnings).
+
+Returns: YAML string of `groups:` ready to be indented into the
+ConfigMap data section.
+*/}}
+{{- define "mimir-rules.applyOverrides" -}}
+{{- $tier := .tier -}}
+{{- $overrides := .overrides | default dict -}}
+{{- $files := .files -}}
+{{- $raw := $files.Get (printf "files/%s.yaml" $tier) -}}
+{{- $parsed := fromYaml $raw -}}
+{{- $newGroups := list -}}
+{{- range $group := $parsed.groups -}}
+  {{- $newRules := list -}}
+  {{- range $rule := $group.rules -}}
+    {{- $name := index $rule "alert" -}}
+    {{- $override := dict -}}
+    {{- if and $name (hasKey $overrides $name) -}}
+      {{- $override = index $overrides $name -}}
+    {{- end -}}
+    {{- $disabled := false -}}
+    {{- if and $override (hasKey $override "enabled") -}}
+      {{- if eq (index $override "enabled") false -}}
+        {{- $disabled = true -}}
+      {{- end -}}
+    {{- end -}}
+    {{- if not $disabled -}}
+      {{- $merged := dict -}}
+      {{- range $k, $v := $rule -}}
+        {{- $_ := set $merged $k $v -}}
+      {{- end -}}
+      {{- range $k, $v := $override -}}
+        {{- if ne $k "enabled" -}}
+          {{- $_ := set $merged $k $v -}}
+        {{- end -}}
+      {{- end -}}
+      {{- $newRules = append $newRules $merged -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if gt (len $newRules) 0 -}}
+    {{- $newGroup := dict "name" $group.name "rules" $newRules -}}
+    {{- if hasKey $group "interval" -}}
+      {{- $_ := set $newGroup "interval" $group.interval -}}
+    {{- end -}}
+    {{- $newGroups = append $newGroups $newGroup -}}
+  {{- end -}}
+{{- end -}}
+{{- dict "groups" $newGroups | toYaml -}}
+{{- end -}}

--- a/core/components/mimir-rules/templates/configmap.yaml
+++ b/core/components/mimir-rules/templates/configmap.yaml
@@ -5,17 +5,18 @@ metadata:
   namespace: grafana
   {{- include "estabilis.metadata" . | nindent 2 }}
 data:
+  {{- $overrides := .Values.alertOverrides | default dict }}
   {{- if .Values.ruleGroups.platformDown.enabled }}
   tier1-platform-down.yaml: |
-{{ .Files.Get "files/tier1-platform-down.yaml" | indent 4 }}
+{{ include "mimir-rules.applyOverrides" (dict "tier" "tier1-platform-down" "overrides" $overrides "files" .Files) | indent 4 }}
   {{- end }}
   {{- if .Values.ruleGroups.platformDegradation.enabled }}
   tier2-degradation.yaml: |
-{{ .Files.Get "files/tier2-degradation.yaml" | indent 4 }}
+{{ include "mimir-rules.applyOverrides" (dict "tier" "tier2-degradation" "overrides" $overrides "files" .Files) | indent 4 }}
   {{- end }}
   {{- if .Values.ruleGroups.platformOperational.enabled }}
   tier3-operational.yaml: |
-{{ .Files.Get "files/tier3-operational.yaml" | indent 4 }}
+{{ include "mimir-rules.applyOverrides" (dict "tier" "tier3-operational" "overrides" $overrides "files" .Files) | indent 4 }}
   {{- /* Traefik rules are scoped to clusters that actually use Traefik
          as the ingress controller. AWS clusters use the AWS Load
          Balancer Controller (ALB) — `traefik_*` metrics are empty there
@@ -24,7 +25,7 @@ data:
          leave true on Azure where Traefik is the default ingress. */}}
   {{- if .Values.ruleGroups.platformOperational.traefik }}
   tier3-traefik.yaml: |
-{{ .Files.Get "files/tier3-traefik.yaml" | indent 4 }}
+{{ include "mimir-rules.applyOverrides" (dict "tier" "tier3-traefik" "overrides" $overrides "files" .Files) | indent 4 }}
   {{- end }}
   {{- end }}
   {{- range $name, $group := .Values.customRuleGroups }}

--- a/core/components/mimir-rules/values.yaml
+++ b/core/components/mimir-rules/values.yaml
@@ -27,6 +27,45 @@ ruleGroups:
 #             summary: "My app is down"
 customRuleGroups: {}
 
+# ============================================================================
+# Per-alert overrides (v0.47.1+) — disable or customize platform-shipped
+# alerts without forking the chart.
+#
+# Override key MUST match the `alert:` field exactly (case-sensitive). A
+# typo silently no-ops because the chart cannot validate against names
+# that don't exist in your installed version. Cross-check via:
+#   kubectl get configmap mimir-alerting-rules -n grafana -o yaml \
+#     | grep "alert:"
+#
+# Behavior:
+#   - `enabled: false`       → rule is dropped from the rendered ConfigMap
+#   - any other field        → SHALLOW-merged onto the upstream rule.
+#                              Override wins on collision. Providing a
+#                              complex field like `labels:` REPLACES the
+#                              entire labels map (you must include every
+#                              label you want, not just the changed one).
+#
+# Threshold tweaks: provide the complete new `expr:` string. The chart
+# does not parse PromQL; surgical edit of a single number inside an expr
+# is intentionally not supported.
+#
+# Group-level toggles (ruleGroups.<group>.enabled) and customRuleGroups
+# continue to work as before; alertOverrides is independent and stacks
+# on top.
+#
+# Example — disable a noisy alert + adjust other fields:
+#   alertOverrides:
+#     TempoMetricsGeneratorFailures:
+#       enabled: false
+#     HighMemoryUsage:
+#       for: 30m
+#     PvcAlmostFull:
+#       expr: |
+#         (kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes) > 0.95
+#       for: 30m
+# ============================================================================
+alertOverrides: {}
+
 # Upload mechanism for rules — defaults to OFF.
 #
 # When enabled=false (default, used on Azure):


### PR DESCRIPTION
## Summary

New `alertOverrides` slot in `core/components/mimir-rules/values.yaml`. Clients can disable or customize any platform-shipped alert without forking the chart, via `overrides/mimir-rules/values.yaml`.

```yaml
alertOverrides:
  TempoMetricsGeneratorFailures:
    enabled: false
  HighMemoryUsage:
    for: 30m
  PvcAlmostFull:
    expr: |
      (kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes) > 0.95
    labels:
      severity: info
```

## Behavior

- `enabled: false` → rule dropped from rendered ConfigMap
- Any other field → SHALLOW-merged onto upstream rule (override wins on collision). Complex fields like `labels:` are REPLACED whole; caller provides every label intended.
- Threshold tweaks: provide complete new `expr:` string (no surgical PromQL editing).
- Override key MUST match `alert:` field exactly. Typo silently no-ops.

## Why PATCH bump (v0.47.0 → v0.47.1)

`alertOverrides: {}` default produces a ConfigMap byte-equivalent to v0.47.0 — zero behavior change without opt-in. Same rationale used elsewhere in CHANGELOG for additive-with-no-op-default features.

## Files

- `templates/_helpers.tpl` — new `mimir-rules.applyOverrides` helper (Files.Get → fromYaml → filter/merge → toYaml)
- `templates/configmap.yaml` — calls helper per tier
- `values.yaml` — `alertOverrides: {}` default + extensive docs
- `Chart.yaml` — chart 0.2.0 → 0.3.0 (chart MINOR is consistent; platform PATCH)

## Existing mechanisms preserved

| Capability | Mechanism | Status |
|---|---|---|
| Group-level on/off (18+ alerts at once) | `ruleGroups.<group>.enabled` | unchanged |
| Add new alerts independently | `customRuleGroups.<group>.rules` | unchanged |
| **Per-alert disable** | `alertOverrides.<Name>.enabled: false` | **NEW** |
| **Per-alert customize any field** | `alertOverrides.<Name>.<field>` | **NEW** |

## Smoke tests passed

- Backward compat: empty overrides → 45 alerts, byte-identical to v0.47.0
- Disable single: 44 alerts, target absent
- Field merge: `for: 30m` replaces field, `expr`/`labels` preserved
- Typo: silent no-op
- Disable all of group: emits `groups: []` (Mimir Ruler accepts)
- Group toggle: still drops entire tier file as before
- YAML round-trip: parses cleanly via `yaml.safe_load_all`

## Test plan

- [x] 7 helm template smoke tests (above)
- [ ] After merge → cortex v1.15.43 → promote → verify TempoMetricsGeneratorFailures absent from `kubectl get cm mimir-alerting-rules`
- [ ] Mimir Ruler reload → alert absent from `/prometheus/api/v1/alerts`