### PR TITLE
feat(platform-root): clientHubAppExtraSourceRepos slot for platform-client-infra (MINOR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [0.48.0] - 2026-05-07
+
+### Added — `clientHubAppExtraSourceRepos` slot for the `platform-client-infra` AppProject
+
+New override slot in `bootstrap/platform-root/values.yaml`:
+
+```yaml
+clientHubAppExtraSourceRepos:
+  - "https://github.com/<org>/<client>-projects.git"
+  - "https://github.com/<org>/<client>-policies.git"
+```
+
+Appends additional repos to the `platform-client-infra` AppProject's `sourceRepos` list, beyond the default single entry (`clientGitopsRepoUrl`). Mirrors the existing `platformAppsExtraSourceRepos` / `workloadAppsExtraSourceRepos` pattern from ADR 0027 — no wildcards, every host must be explicit so AppProject scope-creep is auditable in code review.
+
+#### Why
+
+When a client splits gitops content across multiple repos — e.g. a dedicated provisioning repo (`<client>-projects`) for declarative project bootstrap (ADR 0033 Phase 4) alongside the runtime gitops repo (`<client>-gitops`) for app values — the second repo must be a permitted source of the same AppProject that authorizes hub-app Applications. Without this slot, the hardcoded `sourceRepos: [{{ .Values.clientGitopsRepoUrl }}]` rejected any Application sourced from the additional repo.
+
+The four governance dimensions of `platform-client-infra` are now uniformly extensible via wrapper override:
+
+| Dimension | Override slot |
+|-----------|---------------|
+| Source repos | `clientHubAppExtraSourceRepos` (this PR) |
+| Destination namespaces | `clientHubAppNamespaces` |
+| Cluster-scoped resource kinds | `clientHubAppExtraClusterResources` |
+| Namespace-scoped resource kinds | `*/*` (always permitted) |
+
+This is a MINOR bump because it adds a new override slot (no behavior change for clients who do not opt in — empty list default).
+
 ## [0.47.1] - 2026-05-06
 
 ### Added — `alertOverrides` slot in `mimir-rules` chart

--- a/bootstrap/platform-root/templates/argocd-project.yaml
+++ b/bootstrap/platform-root/templates/argocd-project.yaml
@@ -282,6 +282,15 @@ spec:
     {{- if .Values.global.sharedAcrLoginServer }}
     - {{ printf "%s/charts" .Values.global.sharedAcrLoginServer | quote }}
     {{- end }}
+    {{- /* ADR 0017 extension — additional source repos when the client
+           splits gitops content across multiple repos (e.g. a per-project
+           provisioning repo alongside the runtime gitops repo). Mirrors
+           platformAppsExtraSourceRepos / workloadAppsExtraSourceRepos
+           pattern. Appended via wrapper override at
+           overrides/platform-root/values.yaml.clientHubAppExtraSourceRepos. */}}
+    {{- range .Values.clientHubAppExtraSourceRepos }}
+    - {{ . | quote }}
+    {{- end }}
   destinations:
     - server: https://kubernetes.default.svc
       namespace: argocd

--- a/bootstrap/platform-root/values.yaml
+++ b/bootstrap/platform-root/values.yaml
@@ -323,6 +323,23 @@ clientApps:
 # Default empty — no extras beyond the baseline.
 clientHubAppExtraClusterResources: []
 
+# ---------------------------------------------------------------------------
+# Extra sourceRepos for the `platform-client-infra` AppProject (ADR 0017).
+# ---------------------------------------------------------------------------
+# By default `platform-client-infra` accepts only `clientGitopsRepoUrl`
+# (the client's gitops repo) as a source. When the client splits gitops
+# content across multiple repos — e.g. a per-project provisioning repo
+# alongside the runtime gitops repo — declare the additional repos here:
+#
+#   clientHubAppExtraSourceRepos:
+#     - "https://github.com/<org>/<client>-projects.git"
+#     - "https://github.com/<org>/<client>-policies.git"
+#
+# Mirrors the platformAppsExtraSourceRepos / workloadAppsExtraSourceRepos
+# pattern. No wildcards — every repo must be explicit (auditable in
+# review). Operator-managed via overrides/platform-root/values.yaml.
+clientHubAppExtraSourceRepos: []
+
 # Scheduling policy per component (ADR 0012 — tracked in
 # Estabilis/estabilis-platform-tools#97). Empty by default — each
 # Application template uses its opinionated mode ("auto" for most,


### PR DESCRIPTION
## Summary

Adds an extension slot to the `platform-client-infra` AppProject's `sourceRepos` list, mirroring the existing `platformAppsExtraSourceRepos` / `workloadAppsExtraSourceRepos` pattern from ADR 0027.

## Why

The `platform-client-infra` AppProject (ADR 0017) currently hardcodes `sourceRepos: [{{ .Values.clientGitopsRepoUrl }}]`. When a client splits gitops content across multiple repos — e.g. a dedicated provisioning repo (`<client>-projects`) for declarative project bootstrap (Estabilis/estabilis-platform-tools ADR 0033 Phase 4) alongside the runtime gitops repo (`<client>-gitops`) — the second repo must be a permitted source of the same AppProject that authorizes hub-app Applications. Without this slot, ArgoCD rejects any Application sourced from the additional repo.

## Behavior

```yaml
# bootstrap/platform-root/values.yaml (default)
clientHubAppExtraSourceRepos: []
```

```yaml
# overrides/platform-root/values.yaml in client downstream
clientHubAppExtraSourceRepos:
  - "https://github.com/<org>/<client>-projects.git"
  - "https://github.com/<org>/<client>-policies.git"
```

Renders the AppProject with the appended source repos:

```yaml
apiVersion: argoproj.io/v1alpha1
kind: AppProject
metadata:
  name: platform-client-infra
spec:
  sourceRepos:
    - "https://github.com/<org>/<client>-gitops.git"      # default
    - "https://github.com/<org>/<client>-projects.git"    # added
    - "https://github.com/<org>/<client>-policies.git"    # added
  ...
```

## Governance

The four governance dimensions of `platform-client-infra` are now uniformly extensible via wrapper override:

| Dimension | Override slot |
|-----------|---------------|
| Source repos | `clientHubAppExtraSourceRepos` (this PR) |
| Destination namespaces | `clientHubAppNamespaces` |
| Cluster-scoped resource kinds | `clientHubAppExtraClusterResources` |
| Namespace-scoped resource kinds | `*/*` (always permitted) |

No wildcards — every repo must be explicit so AppProject scope-creep is auditable in code review (same convention as `platformAppsExtraSourceRepos`).

## Verification

```
helm template platform-root bootstrap/platform-root \
  --set clientGitopsRepoUrl=...gitops.git \
  --set clientGitopsRepoRevision=main \
  --set 'clientHubAppExtraSourceRepos[0]=...projects.git' \
  --set 'clientHubAppExtraSourceRepos[1]=...policies.git' \
  ...
| grep -A 10 'name: platform-client-infra'
```

Renders:
```
spec:
  description: Client-authored infrastructure Applications on the platform hub (ADR 0017)
  sourceRepos:
    - "https://example.com/gitops.git"
    - "https://example.com/projects.git"
    - "https://example.com/policies.git"
```

## SemVer

MINOR — new override slot, default empty list, zero behavior change for clients who do not opt in.

## Downstream consumer

Cortex prd will consume immediately as part of ADR 0033 Phase 4 (separate `Cortex-Innovation/cortex-projects` repo for Project XR claims). Estimated bump: estabilis-platform v0.47.1 → v0.48.0 in cortex prd downstream `terraform.tfvars`.