### PR TITLE
feat(spec): upstart.yaml v3 + cleanup.yaml v1 declarative specs (ADR 0036 Phase A)

### DIFF
--- a/.github/workflows/spec-validation.yaml
+++ b/.github/workflows/spec-validation.yaml
@@ -1,0 +1,109 @@
+name: spec-validation
+
+# Validates the declarative bootstrap/cleanup specs against their JSON
+# Schemas (ADR 0036 §4.11 Layer 2 CI gate). Two-sided test:
+#
+#   1. spec/upstart/schema/tests/good/*.yaml  → must validate
+#   2. spec/upstart/schema/tests/bad/*.yaml   → must FAIL validation
+#   3. spec/cleanup/schema/tests/good/*.yaml  → must validate
+#   4. spec/cleanup/schema/tests/bad/*.yaml   → must FAIL validation
+#
+# Plus the production specs themselves (spec/upstart/upstart*.yaml,
+# spec/cleanup/cleanup*.yaml) must validate.
+#
+# This is intentionally STRICTER than the pre-commit check-jsonschema hook,
+# which only validates the production files. The fixtures guard the schema
+# itself: if someone weakens a rule (e.g. drops additionalProperties: false),
+# at least one bad/ fixture starts passing and CI flags it.
+
+on:
+  pull_request:
+    paths:
+      - "spec/**"
+      - ".github/workflows/spec-validation.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "spec/**"
+      - ".github/workflows/spec-validation.yaml"
+
+concurrency:
+  group: spec-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install check-jsonschema
+        run: pip install --quiet check-jsonschema==0.30.0
+
+      - name: Validate production upstart specs (must pass)
+        run: |
+          set -euo pipefail
+          check-jsonschema \
+            --schemafile spec/upstart/schema/upstart.v3.schema.json \
+            spec/upstart/upstart.yaml \
+            spec/upstart/upstart.aws.yaml \
+            spec/upstart/upstart.azure.yaml
+
+      - name: Validate production cleanup specs (must pass)
+        run: |
+          set -euo pipefail
+          check-jsonschema \
+            --schemafile spec/cleanup/schema/cleanup.v1.schema.json \
+            spec/cleanup/cleanup.yaml \
+            spec/cleanup/cleanup.aws.yaml \
+            spec/cleanup/cleanup.azure.yaml
+
+      - name: Validate good fixtures (must pass)
+        run: |
+          set -euo pipefail
+          for f in spec/upstart/schema/tests/good/*.yaml; do
+            check-jsonschema --schemafile spec/upstart/schema/upstart.v3.schema.json "$f"
+          done
+          for f in spec/cleanup/schema/tests/good/*.yaml; do
+            check-jsonschema --schemafile spec/cleanup/schema/cleanup.v1.schema.json "$f"
+          done
+
+      - name: Validate bad fixtures (must FAIL)
+        run: |
+          set -uo pipefail
+          fails=0
+          for f in spec/upstart/schema/tests/bad/*.yaml; do
+            if check-jsonschema \
+                 --schemafile spec/upstart/schema/upstart.v3.schema.json \
+                 "$f" > /dev/null 2>&1; then
+              echo "::error file=$f::Expected validation failure, but file PASSED — schema rule has been weakened."
+              fails=$((fails + 1))
+            else
+              echo "  ok (rejected as expected): $f"
+            fi
+          done
+          for f in spec/cleanup/schema/tests/bad/*.yaml; do
+            if check-jsonschema \
+                 --schemafile spec/cleanup/schema/cleanup.v1.schema.json \
+                 "$f" > /dev/null 2>&1; then
+              echo "::error file=$f::Expected validation failure, but file PASSED — schema rule has been weakened."
+              fails=$((fails + 1))
+            else
+              echo "  ok (rejected as expected): $f"
+            fi
+          done
+          if [ "$fails" -gt 0 ]; then
+            echo
+            echo "$fails fixture(s) that should fail validation are now PASSING."
+            echo "The schema has been weakened. Either:"
+            echo "  - Restore the schema rule that the fixture targets, OR"
+            echo "  - Delete the obsolete bad/ fixture and commit the schema change deliberately."
+            exit 1
+          fi

--- a/.github/workflows/spec-validation.yaml
+++ b/.github/workflows/spec-validation.yaml
@@ -1,30 +1,30 @@
 name: spec-validation
 
 # Validates the declarative bootstrap/cleanup specs against their JSON
-# Schemas (ADR 0036 §4.11 Layer 2 CI gate). Two-sided test:
+# Schemas (ADR 0036 §4.11 Layer 2 CI gate).
 #
-#   1. spec/upstart/schema/tests/good/*.yaml  → must validate
-#   2. spec/upstart/schema/tests/bad/*.yaml   → must FAIL validation
-#   3. spec/cleanup/schema/tests/good/*.yaml  → must validate
-#   4. spec/cleanup/schema/tests/bad/*.yaml   → must FAIL validation
+# Delegates to scripts/validate-specs.sh — the SAME script the local
+# pre-commit hook calls (.pre-commit-config.yaml). Zero drift between
+# local and CI.
 #
-# Plus the production specs themselves (spec/upstart/upstart*.yaml,
-# spec/cleanup/cleanup*.yaml) must validate.
-#
-# This is intentionally STRICTER than the pre-commit check-jsonschema hook,
-# which only validates the production files. The fixtures guard the schema
-# itself: if someone weakens a rule (e.g. drops additionalProperties: false),
-# at least one bad/ fixture starts passing and CI flags it.
+# Four checks:
+#   1. Production upstart specs validate.
+#   2. Production cleanup specs validate.
+#   3. spec/{upstart,cleanup}/schema/tests/good/*.yaml validate.
+#   4. spec/{upstart,cleanup}/schema/tests/bad/*.yaml MUST FAIL — any that
+#      passes means a schema rule has been removed/relaxed.
 
 on:
   pull_request:
     paths:
       - "spec/**"
+      - "scripts/validate-specs.sh"
       - ".github/workflows/spec-validation.yaml"
   push:
     branches: [main]
     paths:
       - "spec/**"
+      - "scripts/validate-specs.sh"
       - ".github/workflows/spec-validation.yaml"
 
 concurrency:
@@ -47,63 +47,5 @@ jobs:
       - name: Install check-jsonschema
         run: pip install --quiet check-jsonschema==0.30.0
 
-      - name: Validate production upstart specs (must pass)
-        run: |
-          set -euo pipefail
-          check-jsonschema \
-            --schemafile spec/upstart/schema/upstart.v3.schema.json \
-            spec/upstart/upstart.yaml \
-            spec/upstart/upstart.aws.yaml \
-            spec/upstart/upstart.azure.yaml
-
-      - name: Validate production cleanup specs (must pass)
-        run: |
-          set -euo pipefail
-          check-jsonschema \
-            --schemafile spec/cleanup/schema/cleanup.v1.schema.json \
-            spec/cleanup/cleanup.yaml \
-            spec/cleanup/cleanup.aws.yaml \
-            spec/cleanup/cleanup.azure.yaml
-
-      - name: Validate good fixtures (must pass)
-        run: |
-          set -euo pipefail
-          for f in spec/upstart/schema/tests/good/*.yaml; do
-            check-jsonschema --schemafile spec/upstart/schema/upstart.v3.schema.json "$f"
-          done
-          for f in spec/cleanup/schema/tests/good/*.yaml; do
-            check-jsonschema --schemafile spec/cleanup/schema/cleanup.v1.schema.json "$f"
-          done
-
-      - name: Validate bad fixtures (must FAIL)
-        run: |
-          set -uo pipefail
-          fails=0
-          for f in spec/upstart/schema/tests/bad/*.yaml; do
-            if check-jsonschema \
-                 --schemafile spec/upstart/schema/upstart.v3.schema.json \
-                 "$f" > /dev/null 2>&1; then
-              echo "::error file=$f::Expected validation failure, but file PASSED — schema rule has been weakened."
-              fails=$((fails + 1))
-            else
-              echo "  ok (rejected as expected): $f"
-            fi
-          done
-          for f in spec/cleanup/schema/tests/bad/*.yaml; do
-            if check-jsonschema \
-                 --schemafile spec/cleanup/schema/cleanup.v1.schema.json \
-                 "$f" > /dev/null 2>&1; then
-              echo "::error file=$f::Expected validation failure, but file PASSED — schema rule has been weakened."
-              fails=$((fails + 1))
-            else
-              echo "  ok (rejected as expected): $f"
-            fi
-          done
-          if [ "$fails" -gt 0 ]; then
-            echo
-            echo "$fails fixture(s) that should fail validation are now PASSING."
-            echo "The schema has been weakened. Either:"
-            echo "  - Restore the schema rule that the fixture targets, OR"
-            echo "  - Delete the obsolete bad/ fixture and commit the schema change deliberately."
-            exit 1
-          fi
+      - name: Run spec validation
+        run: bash scripts/validate-specs.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,29 @@ repos:
       - id: gitleaks
 
   # ---------------------------------------------------------------------------
+  # spec/ declarative specs — JSON Schema validation gate (ADR 0036 §4.11).
+  # The schema files are the source-of-truth contract for upstart v3 and
+  # cleanup v1; any PR that fails this gate is blocked. Per ADR §4.11
+  # strictness mode, additionalProperties: false in the schemas means
+  # unknown fields are hard errors (no silent acceptance, no warn-only).
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.30.0
+    hooks:
+      - id: check-jsonschema
+        name: Validate spec/upstart/*.yaml against upstart v3 schema
+        files: ^spec/upstart/(upstart|upstart\.aws|upstart\.azure)\.yaml$
+        args:
+          - --schemafile
+          - spec/upstart/schema/upstart.v3.schema.json
+      - id: check-jsonschema
+        name: Validate spec/cleanup/*.yaml against cleanup v1 schema
+        files: ^spec/cleanup/(cleanup|cleanup\.aws|cleanup\.azure)\.yaml$
+        args:
+          - --schemafile
+          - spec/cleanup/schema/cleanup.v1.schema.json
+
+  # ---------------------------------------------------------------------------
   # Commit message — enforce Conventional Commits so CHANGELOG + release
   # tagging stay machine-parseable.
   # ---------------------------------------------------------------------------

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,26 +72,35 @@ repos:
 
   # ---------------------------------------------------------------------------
   # spec/ declarative specs — JSON Schema validation gate (ADR 0036 §4.11).
-  # The schema files are the source-of-truth contract for upstart v3 and
-  # cleanup v1; any PR that fails this gate is blocked. Per ADR §4.11
-  # strictness mode, additionalProperties: false in the schemas means
-  # unknown fields are hard errors (no silent acceptance, no warn-only).
+  #
+  # Delegates to scripts/validate-specs.sh — the SAME script the CI workflow
+  # (.github/workflows/spec-validation.yaml) calls. Zero drift between local
+  # and CI.
+  #
+  # Four checks (all must pass for the commit to proceed):
+  #   1. Production upstart specs validate against upstart v3 schema.
+  #   2. Production cleanup specs validate against cleanup v1 schema.
+  #   3. spec/{upstart,cleanup}/schema/tests/good/*.yaml validate.
+  #   4. spec/{upstart,cleanup}/schema/tests/bad/*.yaml MUST FAIL — schema
+  #      weakening regression alarm. A "bad" fixture passing means a schema
+  #      rule was removed/relaxed.
+  #
+  # Per ADR §4.11 strictness mode, additionalProperties: false in the schemas
+  # means unknown fields are hard errors (no silent acceptance, no warn-only).
+  # Pre-commit creates an isolated venv with check-jsonschema 0.30.0 (the
+  # entry uses `bash scripts/validate-specs.sh`; the python venv's PATH
+  # provides check-jsonschema to the script).
   # ---------------------------------------------------------------------------
-  - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.30.0
+  - repo: local
     hooks:
-      - id: check-jsonschema
-        name: Validate spec/upstart/*.yaml against upstart v3 schema
-        files: ^spec/upstart/(upstart|upstart\.aws|upstart\.azure)\.yaml$
-        args:
-          - --schemafile
-          - spec/upstart/schema/upstart.v3.schema.json
-      - id: check-jsonschema
-        name: Validate spec/cleanup/*.yaml against cleanup v1 schema
-        files: ^spec/cleanup/(cleanup|cleanup\.aws|cleanup\.azure)\.yaml$
-        args:
-          - --schemafile
-          - spec/cleanup/schema/cleanup.v1.schema.json
+      - id: validate-specs
+        name: Validate spec/** declarative specs (JSON Schemas + good/bad fixtures)
+        entry: bash scripts/validate-specs.sh
+        language: python
+        additional_dependencies:
+          - check-jsonschema==0.30.0
+        files: ^spec/.*$
+        pass_filenames: false
 
   # ---------------------------------------------------------------------------
   # Commit message — enforce Conventional Commits so CHANGELOG + release

--- a/scripts/validate-specs.sh
+++ b/scripts/validate-specs.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# =============================================================================
+# validate-specs.sh — single source of truth for spec/** JSON Schema gates.
+# =============================================================================
+#
+# Called by:
+#   - .pre-commit-config.yaml      (local hook, on commit touching spec/**)
+#   - .github/workflows/spec-validation.yaml  (CI, on PR + push to main)
+#
+# Both consumers invoke the same script so local and CI cannot drift.
+#
+# Four checks, all must pass:
+#   1. Production upstart specs (3 files) validate against upstart v3 schema.
+#   2. Production cleanup specs (3 files) validate against cleanup v1 schema.
+#   3. tests/good/*.yaml must validate (positive fixtures).
+#   4. tests/bad/*.yaml must FAIL validation (negative fixtures — the
+#      schema-weakening regression alarm). Any bad/* that passes means a
+#      schema rule has been removed/relaxed — CI/commit blocked.
+#
+# Requires: check-jsonschema in PATH (pip install check-jsonschema==0.30.0).
+#           When called from pre-commit, the hook env supplies it.
+# =============================================================================
+
+set -uo pipefail
+
+# Resolve repo root regardless of cwd (pre-commit hooks set cwd to repo root,
+# but be defensive).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+UPSTART_SCHEMA="spec/upstart/schema/upstart.v3.schema.json"
+CLEANUP_SCHEMA="spec/cleanup/schema/cleanup.v1.schema.json"
+
+if ! command -v check-jsonschema >/dev/null 2>&1; then
+  echo "ERROR: check-jsonschema not found in PATH."
+  echo "Install: pip install check-jsonschema==0.30.0"
+  exit 2
+fi
+
+fails=0
+
+# -----------------------------------------------------------------------------
+# Step 1 — production upstart specs MUST validate.
+# -----------------------------------------------------------------------------
+echo "==> 1. Production upstart specs (must pass)"
+for f in spec/upstart/upstart.yaml spec/upstart/upstart.aws.yaml spec/upstart/upstart.azure.yaml; do
+  if check-jsonschema --schemafile "$UPSTART_SCHEMA" "$f" > /dev/null 2>&1; then
+    echo "  ok  $f"
+  else
+    echo "  FAIL $f"
+    check-jsonschema --schemafile "$UPSTART_SCHEMA" "$f" 2>&1 | sed 's/^/    /'
+    fails=$((fails + 1))
+  fi
+done
+
+# -----------------------------------------------------------------------------
+# Step 2 — production cleanup specs MUST validate.
+# -----------------------------------------------------------------------------
+echo "==> 2. Production cleanup specs (must pass)"
+for f in spec/cleanup/cleanup.yaml spec/cleanup/cleanup.aws.yaml spec/cleanup/cleanup.azure.yaml; do
+  if check-jsonschema --schemafile "$CLEANUP_SCHEMA" "$f" > /dev/null 2>&1; then
+    echo "  ok  $f"
+  else
+    echo "  FAIL $f"
+    check-jsonschema --schemafile "$CLEANUP_SCHEMA" "$f" 2>&1 | sed 's/^/    /'
+    fails=$((fails + 1))
+  fi
+done
+
+# -----------------------------------------------------------------------------
+# Step 3 — good fixtures MUST validate.
+# -----------------------------------------------------------------------------
+echo "==> 3. Good fixtures (must pass)"
+for f in spec/upstart/schema/tests/good/*.yaml; do
+  [ -e "$f" ] || continue
+  if check-jsonschema --schemafile "$UPSTART_SCHEMA" "$f" > /dev/null 2>&1; then
+    echo "  ok  $f"
+  else
+    echo "  FAIL $f"
+    check-jsonschema --schemafile "$UPSTART_SCHEMA" "$f" 2>&1 | sed 's/^/    /'
+    fails=$((fails + 1))
+  fi
+done
+for f in spec/cleanup/schema/tests/good/*.yaml; do
+  [ -e "$f" ] || continue
+  if check-jsonschema --schemafile "$CLEANUP_SCHEMA" "$f" > /dev/null 2>&1; then
+    echo "  ok  $f"
+  else
+    echo "  FAIL $f"
+    check-jsonschema --schemafile "$CLEANUP_SCHEMA" "$f" 2>&1 | sed 's/^/    /'
+    fails=$((fails + 1))
+  fi
+done
+
+# -----------------------------------------------------------------------------
+# Step 4 — bad fixtures MUST FAIL. Any that pass mean schema was weakened.
+# -----------------------------------------------------------------------------
+echo "==> 4. Bad fixtures (must FAIL — regression alarm)"
+for f in spec/upstart/schema/tests/bad/*.yaml; do
+  [ -e "$f" ] || continue
+  if check-jsonschema --schemafile "$UPSTART_SCHEMA" "$f" > /dev/null 2>&1; then
+    echo "  REGRESSION $f passed validation, but is in tests/bad/ and should FAIL."
+    echo "             Schema rule it targets has been weakened. Either:"
+    echo "               - restore the schema rule, OR"
+    echo "               - delete this fixture if the rule is gone deliberately."
+    fails=$((fails + 1))
+  else
+    echo "  ok  $f (rejected as expected)"
+  fi
+done
+for f in spec/cleanup/schema/tests/bad/*.yaml; do
+  [ -e "$f" ] || continue
+  if check-jsonschema --schemafile "$CLEANUP_SCHEMA" "$f" > /dev/null 2>&1; then
+    echo "  REGRESSION $f passed validation, but is in tests/bad/ and should FAIL."
+    echo "             Schema rule it targets has been weakened. Either:"
+    echo "               - restore the schema rule, OR"
+    echo "               - delete this fixture if the rule is gone deliberately."
+    fails=$((fails + 1))
+  else
+    echo "  ok  $f (rejected as expected)"
+  fi
+done
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "All spec validations passed."
+  exit 0
+else
+  echo "$fails check(s) failed."
+  exit 1
+fi

--- a/spec/.argocdignore
+++ b/spec/.argocdignore
@@ -1,0 +1,11 @@
+# Defense-in-depth: ensure ArgoCD never accidentally renders files under
+# spec/ as Application manifests. This directory is a SOURCE OF TRUTH for
+# the upstart/cleanup renderers (Python in-process, Argo Workflows future),
+# NOT a kustomize/helm/manifests path.
+#
+# Existing ApplicationSets target platforms/{deploymentId}/* and
+# bootstrap/platform-root/ — never spec/. A future ApplicationSet pattern
+# that does target spec/ would be a deliberate, reviewable change AND would
+# need to override this ignore file. See ADR 0036 §3.1.
+
+*

--- a/spec/cleanup/cleanup.aws.yaml
+++ b/spec/cleanup/cleanup.aws.yaml
@@ -1,0 +1,49 @@
+# Estabilis Platform — Cleanup Spec (v1, AWS overlay)
+# =============================================================================
+# AWS-specific cleanup phases that must INTERLEAVE with the base ordering:
+#   - Phase 3 (Karpenter CRs)         goes between base Phase 2 and Phase 5
+#   - Phase 4 (uninstall karpenter)   goes between Phase 3 and Phase 5
+#   - Phase 4.5 (terminate EC2)       goes between Phase 4 and Phase 5
+#
+# These three phases all carry `provider: aws` and execute only when this
+# overlay merges. Insertion order in the merged spec is governed by overlay
+# semantics (engine inserts in declaration order between matching base
+# phases — see ADR 0036 §6.7).
+#
+# Schema:  spec/cleanup/schema/cleanup.v1.schema.json
+# Source:  estabilis-platform-tools/scripts/cleanup-k8s-restart.sh (Phases 3, 4, 4.5)
+# -----------------------------------------------------------------------------
+
+version: "1"
+
+cleanup:
+  order:
+
+    # Phase 3 — Karpenter custom resources with custom finalizers.
+    # cortex prd 2026-04-29 issue: the karpenter-resources chart (rendered
+    # from estabilis-platform-gitops) injects
+    # `app.kubernetes.io/name: karpenter-resources` as a finalizer that
+    # vanilla Karpenter controller does NOT remove. NodePools and
+    # EC2NodeClasses end up stuck Terminating forever. Patch finalizers []
+    # explicitly.
+    - phase: finalize-karpenter-crs
+      action: remove-finalizers-and-delete
+      kinds: [EC2NodeClass, NodePool, NodeClaim]
+      provider: aws
+
+    # Phase 4 — Helm uninstall karpenter controller + CRD chart.
+    - phase: uninstall-karpenter
+      action: helm-uninstall
+      releases: [karpenter, karpenter-crd]
+      namespace: karpenter
+      provider: aws
+
+    # Phase 4.5 — Terminate orphan EC2 nodes. Without the controller,
+    # consolidation no longer runs; nodes provisioned by Karpenter would
+    # idle forever consuming AWS billing. Filter by the Karpenter discovery
+    # tag (tag:karpenter.sh/nodepool=*) to target only platform-provisioned
+    # instances, never EKS-managed system nodes.
+    - phase: terminate-aws-instances
+      action: aws-ec2-terminate
+      filter: tag:karpenter.sh/nodepool=*
+      provider: aws

--- a/spec/cleanup/cleanup.azure.yaml
+++ b/spec/cleanup/cleanup.azure.yaml
@@ -1,0 +1,16 @@
+# Estabilis Platform — Cleanup Spec (v1, Azure overlay)
+# =============================================================================
+# AKS managed node pools mean there are no Karpenter equivalents to clean up
+# and no orphan VMs to terminate (the pool lifecycle is owned by Azure
+# Resource Manager + Terraform). This overlay exists for symmetry with the
+# AWS overlay and as the binding site for future Azure-only cleanup deltas
+# (e.g. Workload Identity federated credentials if those start carrying
+# cluster-bound state).
+#
+# Schema:  spec/cleanup/schema/cleanup.v1.schema.json
+# -----------------------------------------------------------------------------
+
+version: "1"
+
+cleanup:
+  order: []

--- a/spec/cleanup/cleanup.yaml
+++ b/spec/cleanup/cleanup.yaml
@@ -1,0 +1,88 @@
+# Estabilis Platform — Cleanup Specification (v1, BASE / provider-agnostic)
+# =============================================================================
+# Declarative teardown of the platform stack INSIDE the cluster, WITHOUT
+# destroying terraform state or cloud-managed resources (EKS/AKS, IAM/AAD
+# roles, KMS/Key Vault, S3/Storage Account, ConfigMap platform-infrastructure).
+#
+# Source-of-truth for what `cleanup-k8s-restart.sh` does — the engine MUST
+# match this ordering (Phase 1 helm-uninstall argocd BEFORE Phase 2 finalizer
+# removal — otherwise active argocd-application-controller re-adds finalizers
+# patched out by the drain phase).
+#
+# Schema:  spec/cleanup/schema/cleanup.v1.schema.json
+# Design:  estabilis-platform-tools/docs/adr/0036-upstart-yaml-v3-declarative-bootstrap.md §6.7
+# Source:  estabilis-platform-tools/scripts/cleanup-k8s-restart.sh (Phases 1-8)
+#
+# Idempotent: re-run safely. No "is already gone" failure modes.
+# -----------------------------------------------------------------------------
+
+version: "1"
+
+cleanup:
+  order:
+
+    # Phase 1 — Helm uninstall argocd FIRST so argocd-application-controller
+    # stops. Otherwise the active controller re-adds the finalizer
+    # `resources-finalizer.argocd.argoproj.io` during Phase 2's patch and
+    # the script fails silently. --no-hooks avoids the foregroundDeletion
+    # deadlock from the chart's PostSync hooks.
+    - phase: uninstall-argocd
+      action: helm-uninstall
+      release: argocd
+      namespace: argocd
+      no-hooks: true
+
+    # Phase 2 — Drain ArgoCD-owned objects (Applications, AppProjects,
+    # ApplicationSets). All carry finalizers; controller is now gone, so
+    # patch [] and delete proceed cleanly.
+    - phase: drain-argocd-objects
+      action: remove-finalizers-and-delete
+      kinds: [Application, AppProject, ApplicationSet]
+      namespace: argocd
+
+    # Phase 5 — Defensive finalizer patch on platform custom resources.
+    # Some CRs (kyverno PolicyExceptions, CNPG Clusters, ESO ExternalSecrets,
+    # cert-manager Certificates, traefik IngressRoutes, Velero Restores)
+    # carry controller finalizers. Namespace deletion in Phase 6 would
+    # otherwise hang on these. kinds-from reads from template.yaml's
+    # nuke_crd_prefixes list (cross-provider, 12 prefixes).
+    - phase: finalize-orphan-crs
+      action: remove-finalizers
+      kinds-from: nuke_crd_prefixes
+
+    # Phase 6 — Delete component namespaces (base 13 + overlay deltas).
+    # exclude-system protects kube-*, default, argocd from accidental wipe.
+    # The argocd namespace is intentionally preserved here so the
+    # platform-infrastructure ConfigMap + Secret (terraform-managed) survive.
+    - phase: delete-platform-namespaces
+      action: delete-namespaces
+      namespaces-from: bootstrap.init.namespaces
+      exclude-system: true
+
+    # Phase 6.5 — Orphan resources in `default` namespace. If a wave's
+    # apply-crds step ever forgot the yq filter (cortex prd 2026-04-30
+    # postmortem), `helm template --include-crds | kubectl apply -f -`
+    # installs the FULL helm release in `default`. Phase 6.5 cleans up
+    # any such residue without nuking the namespace itself.
+    - phase: cleanup-default-namespace
+      action: delete-all-resources
+      target-namespace: default
+      keep:
+        - kubernetes Service
+        - default ServiceAccount
+
+    # Phase 7 — Orphan ValidatingWebhookConfigurations and
+    # MutatingWebhookConfigurations. Criteria are OR'd — a webhook matching
+    # ANY one is removed. service-missing: webhook.clientConfig.service
+    # points to a Service that no longer exists. webhooks-list-empty: spec
+    # has `webhooks: []`. validating-failed: failurePolicy=Fail and the
+    # backing service is gone (cluster operations would be blocked).
+    - phase: remove-orphan-webhooks
+      action: delete-webhooks
+      kinds:
+        - ValidatingWebhookConfiguration
+        - MutatingWebhookConfiguration
+      criteria:
+        - service-missing
+        - webhooks-list-empty
+        - validating-failed

--- a/spec/cleanup/schema/cleanup.v1.schema.json
+++ b/spec/cleanup/schema/cleanup.v1.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://estabilis.io/schemas/cleanup.v1.schema.json",
+  "title": "Estabilis cleanup.yaml v1",
+  "description": "Declarative cluster cleanup specification. Mirrors scripts/cleanup-k8s-restart.sh phases 1 → 7 (idempotent teardown of the platform stack WITHOUT destroying terraform state or cloud-managed resources). Separate from upstart.yaml because the engine is distinct (no ArgoCD orchestration, requires cloud-CLI subprocess calls and finalizer manipulation) and the lifecycle is independent (operator runs cleanup many times per day, no version coupling to upstart).",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version"],
+  "$comment": "Overlays (cleanup.{aws,azure}.yaml) may carry only the order[] delta; merged-spec validation post-merge enforces top-level required-set.",
+
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "1"
+    },
+
+    "cleanup": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "order": {
+          "type": "array",
+          "description": "Phases executed sequentially. Ordering is SEMANTIC and critical — Phase `uninstall-argocd` MUST come BEFORE Phase `drain-argocd-objects`, otherwise the active argocd-application-controller re-adds finalizers patched out by the drain phase and the script fails silently. Empty array is allowed in overlays (Azure overlay carries no provider-specific cleanup phases).",
+          "items": { "$ref": "#/$defs/cleanupPhase" }
+        }
+      }
+    }
+  },
+
+  "$defs": {
+
+    "cleanupPhase": {
+      "type": "object",
+      "required": ["phase", "action"],
+      "additionalProperties": false,
+      "properties": {
+        "phase":  {
+          "type": "string",
+          "minLength": 1,
+          "description": "Phase identifier (kebab-case). Stable across overlays — used by overlay merge to identify same phase."
+        },
+        "action": {
+          "type": "string",
+          "enum": [
+            "helm-uninstall",
+            "remove-finalizers-and-delete",
+            "remove-finalizers",
+            "aws-ec2-terminate",
+            "delete-namespaces",
+            "delete-all-resources",
+            "delete-webhooks"
+          ]
+        },
+        "provider": {
+          "type": "string",
+          "enum": ["aws", "azure"],
+          "description": "Optional provider gate. When present, phase runs only when overlay matches. Omit for provider-agnostic phases."
+        },
+        "release": {
+          "type": "string",
+          "description": "Helm release name (for action: helm-uninstall)."
+        },
+        "releases": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Multiple helm releases to uninstall in this phase (alternative to `release:`)."
+        },
+        "namespace": { "type": "string" },
+        "no-hooks":  { "type": "boolean", "description": "helm uninstall --no-hooks (avoids foregroundDeletion deadlock). Default false." },
+        "kinds": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Resource kinds to act on (e.g. [Application, AppProject, ApplicationSet])."
+        },
+        "kinds-from": {
+          "type": "string",
+          "description": "Symbolic reference for a list of kinds defined elsewhere. Current values: `nuke_crd_prefixes` (reads from estabilis-platform-tools/template.yaml:61-73 — kyverno.io, cnpg.io, external-secrets.io, cert-manager.io, traefik.io, aquasecurity.github.io, velero.io, monitoring.grafana.com, argoproj.io, wgpolicyk8s.io)."
+        },
+        "filter": {
+          "type": "string",
+          "description": "AWS resource filter (for action: aws-ec2-terminate). Example: tag:karpenter.sh/nodepool=*"
+        },
+        "namespaces-from": {
+          "type": "string",
+          "description": "Symbolic reference for the namespace list. Current values: `bootstrap.init.namespaces` (reads merged base+overlay namespace list from upstart.yaml v3)."
+        },
+        "exclude-system": {
+          "type": "boolean",
+          "description": "When true, never delete kube-*, default, argocd namespaces (cleanup hygiene)."
+        },
+        "target-namespace": { "type": "string", "description": "Single namespace operand (for action: delete-all-resources)." },
+        "keep": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Resources to KEEP when deleting all (e.g. [`kubernetes Service`, `default ServiceAccount`])."
+        },
+        "criteria": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["service-missing", "webhooks-list-empty", "validating-failed", "mutating-failed"]
+          },
+          "description": "Webhook deletion criteria (for action: delete-webhooks). At least one must match for the webhook to be removed."
+        }
+      }
+    }
+  }
+}

--- a/spec/cleanup/schema/tests/bad/action-not-enum.yaml
+++ b/spec/cleanup/schema/tests/bad/action-not-enum.yaml
@@ -1,0 +1,6 @@
+# NEGATIVE: action enum doesn't include 'delete-stuff'.
+version: "1"
+cleanup:
+  order:
+    - phase: bad
+      action: delete-stuff

--- a/spec/cleanup/schema/tests/bad/criteria-invalid.yaml
+++ b/spec/cleanup/schema/tests/bad/criteria-invalid.yaml
@@ -1,0 +1,9 @@
+# NEGATIVE: criteria enum is closed; 'unknown-criterion' rejected.
+version: "1"
+cleanup:
+  order:
+    - phase: bad-webhooks
+      action: delete-webhooks
+      kinds: [ValidatingWebhookConfiguration]
+      criteria:
+        - unknown-criterion

--- a/spec/cleanup/schema/tests/bad/missing-version.yaml
+++ b/spec/cleanup/schema/tests/bad/missing-version.yaml
@@ -1,0 +1,3 @@
+# NEGATIVE: top-level version is required.
+cleanup:
+  order: []

--- a/spec/cleanup/schema/tests/bad/provider-not-enum.yaml
+++ b/spec/cleanup/schema/tests/bad/provider-not-enum.yaml
@@ -1,0 +1,8 @@
+# NEGATIVE: provider enum is [aws, azure]; 'gcp' rejected.
+version: "1"
+cleanup:
+  order:
+    - phase: bad-provider
+      action: helm-uninstall
+      release: foo
+      provider: gcp

--- a/spec/cleanup/schema/tests/bad/unknown-field-in-phase.yaml
+++ b/spec/cleanup/schema/tests/bad/unknown-field-in-phase.yaml
@@ -1,0 +1,8 @@
+# NEGATIVE: cleanupPhase has additionalProperties: false.
+version: "1"
+cleanup:
+  order:
+    - phase: bad
+      action: helm-uninstall
+      release: argocd
+      typo-field: oops

--- a/spec/cleanup/schema/tests/good/empty-overlay.yaml
+++ b/spec/cleanup/schema/tests/good/empty-overlay.yaml
@@ -1,0 +1,4 @@
+# Overlay with no provider-specific phases — matches the Azure overlay shape.
+version: "1"
+cleanup:
+  order: []

--- a/spec/cleanup/schema/tests/good/minimal-base.yaml
+++ b/spec/cleanup/schema/tests/good/minimal-base.yaml
@@ -1,0 +1,9 @@
+# Minimal-but-complete cleanup spec.
+version: "1"
+cleanup:
+  order:
+    - phase: uninstall-argocd
+      action: helm-uninstall
+      release: argocd
+      namespace: argocd
+      no-hooks: true

--- a/spec/upstart/schema/tests/bad/helm-install-missing-version.yaml
+++ b/spec/upstart/schema/tests/bad/helm-install-missing-version.yaml
@@ -1,0 +1,12 @@
+# NEGATIVE: helmInstall requires chart, repo, version, namespace.
+# Missing `version:` means floating tag — disallowed.
+# Expected: $.bootstrap.pre[0].helm-install: 'version' is a required property
+version: "3"
+
+bootstrap:
+  pre:
+    - name: bad
+      helm-install:
+        chart: example
+        repo: oci://example.com/foo
+        namespace: example

--- a/spec/upstart/schema/tests/bad/missing-version.yaml
+++ b/spec/upstart/schema/tests/bad/missing-version.yaml
@@ -1,0 +1,4 @@
+# NEGATIVE: top-level `version` field is the only mandatory key in every file.
+# Expected: $: 'version' is a required property
+bootstrap:
+  pre: []

--- a/spec/upstart/schema/tests/bad/step-mutual-exclusion.yaml
+++ b/spec/upstart/schema/tests/bad/step-mutual-exclusion.yaml
@@ -1,0 +1,19 @@
+# NEGATIVE: preStep has oneOf [helm-install, helm-template-apply, kubectl-apply, script].
+# Mutual exclusion — declaring both helm-install AND kubectl-apply is ambiguous.
+# Expected: $.bootstrap.pre[0]: is valid against more than one of the schemas listed in oneOf
+version: "3"
+
+bootstrap:
+  pre:
+    - name: ambiguous
+      helm-install:
+        chart: foo
+        repo: oci://example.com/foo
+        version: "1.0"
+        namespace: foo
+      kubectl-apply:
+        manifest: |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: bar

--- a/spec/upstart/schema/tests/bad/unknown-field-in-pre-step.yaml
+++ b/spec/upstart/schema/tests/bad/unknown-field-in-pre-step.yaml
@@ -1,0 +1,13 @@
+# NEGATIVE: additionalProperties: false on preStep — unknown field rejected.
+# Expected validation path: $.bootstrap.pre[0]: Additional properties are not allowed
+version: "3"
+
+bootstrap:
+  pre:
+    - name: bad-step
+      helm-install:
+        chart: foo
+        repo: oci://example.com/foo
+        version: "1.0"
+        namespace: foo
+      unknown-field: should-fail

--- a/spec/upstart/schema/tests/bad/values-file-path-traversal.yaml
+++ b/spec/upstart/schema/tests/bad/values-file-path-traversal.yaml
@@ -1,0 +1,12 @@
+# NEGATIVE: values-file pattern rejects `..` traversal and absolute paths.
+# Pattern: ^(?!\.\./)(?!/)[A-Za-z0-9._/-]+$
+# Expected: $.bootstrap.argocd.values-file: '../../../etc/passwd' does not match
+version: "3"
+
+bootstrap:
+  argocd:
+    chart: argo-cd
+    repo: oci://ghcr.io/argoproj/argo-helm
+    version: "9.5.6"
+    namespace: argocd
+    values-file: ../../../etc/passwd

--- a/spec/upstart/schema/tests/bad/wait-mode-invalid.yaml
+++ b/spec/upstart/schema/tests/bad/wait-mode-invalid.yaml
@@ -1,0 +1,10 @@
+# NEGATIVE: waitMode enum is [healthy, synced, applied, phase-running].
+# "frozen" is not a member.
+# Expected: $.waves[0].apps[0].wait: 'frozen' is not one of [...]
+version: "3"
+
+waves:
+  - name: TLS
+    apps:
+      - name: cert-manager
+        wait: frozen

--- a/spec/upstart/schema/tests/bad/wave-extends-and-insert-before.yaml
+++ b/spec/upstart/schema/tests/bad/wave-extends-and-insert-before.yaml
@@ -1,0 +1,11 @@
+# NEGATIVE: wave-level allOf prohibits combining `extends:` with
+# `insert-before:` / `insert-after:` — semantically a wave either EXTENDS an
+# existing one OR INSERTS as new; cannot be both.
+# Expected: $.waves[0]: not allowed (allOf branch)
+version: "3"
+
+waves:
+  - extends: Platform Secrets
+    insert-before: Policies
+    apps:
+      - { name: vault }

--- a/spec/upstart/schema/tests/bad/wrong-version-const.yaml
+++ b/spec/upstart/schema/tests/bad/wrong-version-const.yaml
@@ -1,0 +1,6 @@
+# NEGATIVE: version is const "3"; engine rejects "1" and "2" so the schema
+# must too (or operators bypass the engine).
+# Expected: $.version: '2' was expected
+version: "2"
+bootstrap:
+  pre: []

--- a/spec/upstart/schema/tests/good/minimal-base.yaml
+++ b/spec/upstart/schema/tests/good/minimal-base.yaml
@@ -1,0 +1,42 @@
+# Minimal-but-complete base spec — every required field present at file level,
+# all enums populated with valid values. Equivalent in shape to upstart.yaml
+# but trimmed to the smallest possible spec the schema accepts.
+version: "3"
+
+bootstrap:
+  pre: []
+  argocd:
+    chart: argo-cd
+    repo: oci://ghcr.io/argoproj/argo-helm
+    version: "9.5.6"
+    namespace: argocd
+    values-file: spec/upstart/values/argocd-seed.yaml
+  init:
+    namespaces:
+      - cert-manager
+    appproject:
+      name: platform
+      namespace: argocd
+      sourceRepos:
+        - https://example.com/repo
+      destinations:
+        - { server: https://kubernetes.default.svc, namespace: "*" }
+    platform-root:
+      name: platform-root
+      namespace: argocd
+      project: default
+      sources:
+        - repoURL: https://example.com/repo
+          targetRevision: v1.0.0
+          path: bootstrap/platform-root
+  wait:
+    platform-root-apps:
+      min-count: 1
+      stable-rounds: 1
+      timeout: 60
+      check-interval: 3
+
+waves:
+  - name: TLS
+    apps:
+      - { name: cert-manager }

--- a/spec/upstart/schema/tests/good/overlay-aws-shape.yaml
+++ b/spec/upstart/schema/tests/good/overlay-aws-shape.yaml
@@ -1,0 +1,38 @@
+# Partial overlay — only version + bootstrap.pre + a wave with directives.
+# Mirrors the shape of upstart.aws.yaml but trimmed. Validates that the
+# schema accepts overlay-style partials (no requirement on full top-level
+# blocks per file; merged-spec required-set is enforced post-merge by the
+# renderer, not by the JSON Schema gate).
+version: "3"
+
+bootstrap:
+  pre:
+    - name: example-pre
+      helm-install:
+        chart: example
+        repo: oci://public.ecr.aws/example
+        version: "1.0.0"
+        namespace: example
+
+waves:
+  - name: AWS Wave 0
+    insert-before: TLS & Certificates
+    verify-and-resync: true
+    apps:
+      - { name: aws-load-balancer-controller }
+    verify:
+      - check: apiservice-available
+        name: v1beta1.metrics.k8s.io
+
+  - extends: Platform Secrets
+    apps:
+      - name: vault
+        wait: phase-running
+    manual-marker-after:
+      name: vault-init
+      message: "Initialize vault manually before advancing."
+      skip-when:
+        kubectl:
+          kind: Secret
+          namespace: vault
+          name: vault-root-token

--- a/spec/upstart/schema/upstart.v3.schema.json
+++ b/spec/upstart/schema/upstart.v3.schema.json
@@ -1,0 +1,589 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://estabilis.io/schemas/upstart.v3.schema.json",
+  "title": "Estabilis upstart.yaml v3",
+  "description": "Declarative bootstrap specification for the Estabilis Platform. Consumed by N renderers (Python in-process, Argo Workflows, documentation generator). See ADR 0036 (estabilis-platform-tools/docs/adr/0036-upstart-yaml-v3-declarative-bootstrap.md) for design rationale.",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version"],
+
+  "$comment": "Top-level required list intentionally narrow: only `version` is mandatory in every file. Overlays (upstart.{aws,azure}.yaml) are partial deltas that contribute fields the base supplies elsewhere. The renderer applies post-merge validation: after deep-merge of base + overlay + local, the resulting spec MUST include `bootstrap`, `bootstrap.argocd`, `bootstrap.init`, `bootstrap.wait`, and `waves`. Schema-level checks here cover structural correctness of fields-as-present.",
+
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "3",
+      "description": "Schema version. Engine rejects '1' and '2' with instruction to run `estabilis migrate upstart`. Future bumps (3.1, 3.2) follow semver-minor for additive fields and require explicit migration on majors."
+    },
+
+    "bootstrap": {
+      "type": "object",
+      "additionalProperties": false,
+      "$comment": "Sub-blocks (argocd, init, wait) are required post-merge but NOT in each individual file (overlays may omit). The renderer enforces post-merge required-set.",
+      "properties": {
+        "pre": {
+          "type": "array",
+          "description": "Steps executed BEFORE ArgoCD is installed. Empty in base (provider-agnostic). AWS overlay carries Karpenter CRDs + controller + resources. Azure overlay empty (AKS managed node pools).",
+          "items": { "$ref": "#/$defs/preStep" }
+        },
+        "argocd":   { "$ref": "#/$defs/argocdInstall" },
+        "repos":    {
+          "type": "array",
+          "description": "Repository credentials registered as ArgoCD Secrets. Entries with empty url or token are silently skipped (matches kubernetes.py:_create_repo_credentials).",
+          "items": { "$ref": "#/$defs/repoCredential" }
+        },
+        "init":     { "$ref": "#/$defs/bootstrapInit" },
+        "wait":     { "$ref": "#/$defs/bootstrapWait" }
+      }
+    },
+
+    "defaults": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Defaults inherited by waves and apps unless overridden. Universal `ServerSideApply=true` resolves cortex prd 2026-04-29 CSA-vs-SSA toggle bug (proposal 0002 §1.1 issues #3 and #4).",
+      "properties": {
+        "timeout":      { "type": "integer", "minimum": 30, "maximum": 1800, "default": 300 },
+        "wait":         { "$ref": "#/$defs/waitMode" },
+        "sync-options": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["CreateNamespace=true", "ServerSideApply=true", "RespectIgnoreDifferences=true", "Validate=false", "ApplyOutOfSyncOnly=true", "PrunePropagationPolicy=foreground", "Replace=true"] },
+          "uniqueItems": true
+        },
+        "retry": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "limit":   { "type": "integer", "minimum": 0, "maximum": 10 },
+            "backoff": { "type": "string", "enum": ["linear", "exponential"] },
+            "factor":  { "type": "number",  "minimum": 1, "maximum": 10 }
+          }
+        }
+      }
+    },
+
+    "waves": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Sequential ArgoCD Application sync stages. Each wave executes 6 phases (apply-CRDs → trigger-sync → force-reconcile → wait-healthy → optional hardening-resync → verify-checks). Apps within a wave sync in parallel. Wave-level dependencies are expressed by array order, NOT by depends-on field (removed from schema by design — see ADR 0036 §3.5 decision #5).",
+      "items": { "$ref": "#/$defs/wave" }
+    },
+
+    "post": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Post-last-wave operations. Per ADR 0029, `prune` is decided per-App in chart/ApplicationSet templates by risk taxonomy — NOT by this block. `enable-auto-sync` is a defensive fallback for Apps arriving without any `automated:` block.",
+      "properties": {
+        "enable-auto-sync": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["apps"],
+          "properties": {
+            "apps":      { "$ref": "#/$defs/appSelector" },
+            "self-heal": { "type": "boolean", "default": true },
+            "prune":     { "type": "boolean", "default": false, "description": "Defensive fallback only — chart-emitted prune decisions are respected as-is (ADR 0029)." }
+          }
+        },
+        "manual-markers": {
+          "type": "array",
+          "description": "Genuinely post-everything operations. Today: empty in all known specs. Wave-inline markers use waves[].manual-marker-after instead (see §4.8 vault-init).",
+          "items": { "$ref": "#/$defs/manualMarker" }
+        }
+      }
+    }
+  },
+
+  "$defs": {
+
+    "waitMode": {
+      "type": "string",
+      "enum": ["healthy", "synced", "applied", "phase-running"],
+      "description": "healthy: wait Application health=Healthy AND sync=Synced (default for ArgoCD-managed apps). synced: wait sync=Synced only. applied: kubectl apply returned 0 (no readiness check). phase-running: wait pod phase=Running (used for Vault where Sealed pods are not Ready by design — see ADR 0036 §4.8)."
+    },
+
+    "appSelector": {
+      "oneOf": [
+        { "type": "string", "const": "all", "description": "All apps in the cluster." },
+        { "type": "array", "items": { "type": "string" }, "description": "Explicit list of app names." },
+        { "type": "object", "additionalProperties": false, "required": ["except"], "properties": { "except": { "type": "array", "items": { "type": "string" } } } }
+      ]
+    },
+
+    "preStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name":               { "type": "string", "minLength": 1, "description": "Step identifier for logging and resume state." },
+        "skip-when":          { "$ref": "#/$defs/skipWhen" },
+        "helm-install":       { "$ref": "#/$defs/helmInstall" },
+        "helm-template-apply":{ "$ref": "#/$defs/helmTemplateApply" },
+        "kubectl-apply":      { "$ref": "#/$defs/kubectlApply" },
+        "script":             { "$ref": "#/$defs/script" }
+      },
+      "oneOf": [
+        { "required": ["helm-install"] },
+        { "required": ["helm-template-apply"] },
+        { "required": ["kubectl-apply"] },
+        { "required": ["script"] }
+      ],
+      "description": "Pre-bootstrap step. Exactly one of helm-install / helm-template-apply / kubectl-apply / script must be present (oneOf discriminator)."
+    },
+
+    "helmInstall": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["chart", "repo", "version", "namespace"],
+      "properties": {
+        "chart":     { "type": "string", "minLength": 1 },
+        "repo":      { "type": "string", "minLength": 1, "description": "OCI URL (oci://...) or HTTPS Helm classic repo (https://...). Engine selects --repo flag or OCI ref accordingly." },
+        "version":   { "type": "string", "minLength": 1, "description": "Helm chart version. Pinned (no floating tags). Variables ${X} supported." },
+        "namespace": { "type": "string", "minLength": 1 },
+        "values":    { "type": "object", "description": "Helm values dict. Strings may reference variables ${X}. Engine resolves before passing to helm." },
+        "values-file": { "type": "string", "pattern": "^(?!\\.\\./)(?!/)[A-Za-z0-9._/-]+$", "description": "Path relative to estabilis-platform repo checkout. NO `..` traversal. NO absolute paths." },
+        "set": { "type": "object", "description": "Helm --set parameters (string-only, applied after values-file)." }
+      }
+    },
+
+    "helmTemplateApply": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["chart-from-git"],
+      "properties": {
+        "chart-from-git": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["repo", "ref", "path"],
+          "properties": {
+            "repo": { "type": "string", "minLength": 1, "description": "Git URL of the chart's host repo (e.g. estabilis-platform-gitops)." },
+            "ref":  { "type": "string", "minLength": 1, "description": "Tag, branch, or commit SHA. Engine performs shallow clone." },
+            "path": { "type": "string", "minLength": 1, "description": "Path within the cloned repo to the chart directory." }
+          }
+        },
+        "set":       { "type": "object", "description": "Helm --set parameters injected at template time." },
+        "namespace": { "type": "string", "description": "Optional target namespace; engine passes via --namespace to helm template + kubectl apply -n." }
+      },
+      "description": "Render a chart living in another git repo and kubectl apply --server-side --force-conflicts. Engine clones shallow at ref, renders helm template with --set, applies, cleans up temp clone. Inherent idempotency via SSA."
+    },
+
+    "kubectlApply": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["manifest"],
+      "properties": {
+        "manifest":  { "type": "string", "description": "Inline YAML manifest (raw string). Engine pipes to kubectl apply --server-side." },
+        "namespace": { "type": "string" }
+      }
+    },
+
+    "script": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["run"],
+      "properties": {
+        "run":      { "type": "string", "minLength": 1, "description": "Shell command. Engine executes via subprocess; non-zero exit fails the step. Escape hatch — prefer typed step (helm-install / kubectl-apply) when possible." },
+        "interpreter": { "type": "string", "enum": ["sh", "bash"], "default": "sh" }
+      }
+    },
+
+    "skipWhen": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Step is skipped silently if condition resolves true. Used for non-idempotent steps that must not re-run (e.g. vault-init).",
+      "properties": {
+        "kubectl": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind"],
+          "properties": {
+            "kind":      { "type": "string", "minLength": 1 },
+            "name":      { "type": "string" },
+            "namespace": { "type": "string" },
+            "jsonpath":  { "type": "string" },
+            "equals":    { "type": "string" }
+          },
+          "description": "Engine runs `kubectl get <kind> <name> -n <namespace>`. Skip when resource exists (and matches jsonpath==equals if provided)."
+        },
+        "file": {
+          "type": "string",
+          "description": "Engine checks file existence on disk relative to cwd. Skip when file exists."
+        }
+      },
+      "oneOf": [
+        { "required": ["kubectl"] },
+        { "required": ["file"] }
+      ]
+    },
+
+    "argocdInstall": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["chart", "repo", "version", "namespace", "values-file"],
+      "properties": {
+        "chart":       { "type": "string", "const": "argo-cd" },
+        "repo":        { "type": "string", "minLength": 1 },
+        "version":     { "type": "string", "minLength": 1 },
+        "namespace":   { "type": "string", "minLength": 1 },
+        "values-file": { "type": "string", "pattern": "^(?!\\.\\./)(?!/)[A-Za-z0-9._/-]+$", "description": "Path relative to estabilis-platform repo checkout — e.g. 'spec/upstart/values/argocd-seed.yaml'. Engine resolves the absolute path." },
+        "pre-create-secrets": {
+          "type": "array",
+          "description": "Secrets created BEFORE helm install argocd. Required for argocd-redis (so the chart's redisSecretInit Job stays disabled, avoiding the finalizer deadlock from earlier ArgoCD versions).",
+          "items": { "$ref": "#/$defs/preCreateSecret" }
+        }
+      }
+    },
+
+    "preCreateSecret": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "type", "data"],
+      "properties": {
+        "name":      { "type": "string", "minLength": 1 },
+        "namespace": { "type": "string", "default": "argocd" },
+        "type":      { "type": "string", "enum": ["Opaque", "kubernetes.io/dockerconfigjson", "kubernetes.io/tls", "kubernetes.io/basic-auth"] },
+        "data":      { "type": "object", "additionalProperties": { "type": "string" }, "description": "Map of key → value (raw string). Engine base64-encodes when writing the Secret. Values commonly reference ${_X} private variables." }
+      }
+    },
+
+    "repoCredential": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "url"],
+      "properties": {
+        "name":  { "type": "string", "minLength": 1 },
+        "url":   { "type": "string", "description": "Git repository URL. If empty after variable resolution, the engine silently skips this entry (matches kubernetes.py:_create_repo_credentials behavior)." },
+        "token": { "type": "string", "description": "Personal access token. If empty after variable resolution, the engine silently skips." },
+        "label": { "type": "string", "description": "Label applied to the resulting Secret for ArgoCD discovery (e.g. 'config-repo', 'client-gitops')." },
+        "username": { "type": "string", "default": "x-access-token" }
+      }
+    },
+
+    "bootstrapInit": {
+      "type": "object",
+      "additionalProperties": false,
+      "$comment": "Sub-fields (namespaces, appproject, platform-root) are required post-merge but NOT in each individual file — AWS overlay declares only namespaces[] to append to the base list.",
+      "properties": {
+        "namespaces": {
+          "type": "array",
+          "items":  { "type": "string", "pattern": "^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$" },
+          "minItems": 1,
+          "uniqueItems": true,
+          "description": "Component namespaces pre-created before ArgoCD waves to avoid hook race conditions. Base list (13) lives here; provider overlays append (3 in AWS overlay: aws-load-balancer-controller, metrics-server, vault)."
+        },
+        "appproject":    { "$ref": "#/$defs/appProject" },
+        "platform-root": { "$ref": "#/$defs/platformRootApplication" }
+      }
+    },
+
+    "appProject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "namespace", "sourceRepos", "destinations"],
+      "properties": {
+        "name":      { "type": "string", "minLength": 1 },
+        "namespace": { "type": "string", "default": "argocd" },
+        "sourceRepos": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1,
+          "description": "Placeholder AppProject. Chart sync via platform-root immediately overwrites with the full ADR 0028 taxonomy (platform-core / platform-observability / platform-security / client / hub)."
+        },
+        "destinations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["server", "namespace"],
+            "properties": {
+              "server":    { "type": "string" },
+              "namespace": { "type": "string" }
+            }
+          },
+          "minItems": 1
+        },
+        "clusterResourceWhitelist": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["group", "kind"],
+            "properties": {
+              "group": { "type": "string" },
+              "kind":  { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+
+    "platformRootApplication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "namespace", "project", "sources"],
+      "properties": {
+        "name":      { "type": "string", "const": "platform-root" },
+        "namespace": { "type": "string", "default": "argocd" },
+        "project":   { "type": "string", "default": "default" },
+        "sources": {
+          "type": "array",
+          "minItems": 1,
+          "items":   { "$ref": "#/$defs/applicationSource" }
+        },
+        "syncPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "syncOptions": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "automated": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "prune":    { "type": "boolean" },
+                "selfHeal": { "type": "boolean" }
+              }
+            }
+          }
+        }
+      }
+    },
+
+    "applicationSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repoURL", "targetRevision"],
+      "properties": {
+        "repoURL":        { "type": "string", "minLength": 1 },
+        "targetRevision": { "type": "string", "minLength": 1, "description": "Per ADR 0020, cluster-own content uses branch tracking (e.g. 'main'); external deps stay pinned (vX.Y.Z). Use ${configRepoRevision:-${configRepoVersion}} for transitional backcompat." },
+        "path":           { "type": "string" },
+        "ref":            { "type": "string", "description": "Names a source for cross-source references (e.g. ref: values, ref: overrides). Mutually informational with path." },
+        "helm": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "valueFiles":              { "type": "array", "items": { "type": "string" } },
+            "ignoreMissingValueFiles": { "type": "boolean" },
+            "parameters": {
+              "description": "Either the string 'auto' (engine injects all params from resolve_platform_params + provenance) or an explicit array of {name, value, forceString}.",
+              "oneOf": [
+                { "type": "string", "const": "auto" },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["name", "value"],
+                    "properties": {
+                      "name":        { "type": "string" },
+                      "value":       { "type": "string" },
+                      "forceString": { "type": "boolean" }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "condition": {
+          "type": "string",
+          "description": "Renderer-evaluated gate. Source is rendered only when the expression resolves truthy. Supports POSIX ${VAR:+truthy} idiom for is-set checks. Example: ${configRepoUrl:+true} → render only when configRepoUrl is non-empty."
+        }
+      }
+    },
+
+    "bootstrapWait": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["platform-root-apps"],
+      "properties": {
+        "platform-root-apps": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["min-count", "stable-rounds", "timeout", "check-interval"],
+          "properties": {
+            "min-count":      { "type": "integer", "minimum": 1,   "description": "Minimum child Applications platform-root must materialize before waves begin." },
+            "stable-rounds":  { "type": "integer", "minimum": 1,   "description": "Number of consecutive polls where count is stable AND ≥ min-count before declaring convergence." },
+            "timeout":        { "type": "integer", "minimum": 30,  "description": "Total seconds before the wait gives up and fails the bootstrap." },
+            "check-interval": { "type": "integer", "minimum": 1,   "description": "Seconds between polls." }
+          }
+        }
+      }
+    },
+
+    "wave": {
+      "type": "object",
+      "additionalProperties": false,
+      "oneOf": [
+        { "required": ["name"] },
+        { "required": ["extends"] }
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Wave identifier. Stable across overlays (used as the binding key for `extends:`)."
+        },
+        "extends": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Overlay-only directive. Names a base wave to merge with. Arrays (apps, verify) APPEND; scalars overwrite. Engine validates the base wave exists before merging."
+        },
+        "insert-before": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Overlay-only directive. Insert this wave at the position of the named base wave; the named wave (and all subsequent) shift down."
+        },
+        "insert-after": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Overlay-only directive. Insert this wave AFTER the named base wave."
+        },
+        "timeout": {
+          "type": "integer",
+          "minimum": 30,
+          "maximum": 1800,
+          "description": "Wave-level default timeout for apps that don't declare their own."
+        },
+        "apply-crds": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/applyCrdsChart" },
+          "description": "CRD apply phase. Engine pipes `helm template <chart>` through `yq 'select(.kind == \"CustomResourceDefinition\")'` then `kubectl apply --server-side --force-conflicts`. The yq filter is MANDATORY (cortex prd 2026-04-30 postmortem — `helm template --include-crds` does NOT filter and installs full Helm release in `default` namespace; see ADR 0036 §6.6)."
+        },
+        "apps": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/waveApp" },
+          "description": "Apps synced in parallel within this wave. Order is informational only; engine batches the sync triggers."
+        },
+        "verify": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/verifyCheck" },
+          "description": "Checks executed after all apps in the wave are Healthy, before advancing."
+        },
+        "verify-and-resync": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, after wait-Healthy converges the engine re-triggers sync explicitly on every app in the wave. Catches the `Synced/Healthy parcial` regression (cortex prd 2026-04-30 — Service/metrics-server permanently OutOfSync forever because Phase 9 had already disabled auto-sync). Canonical use: AWS overlay Wave 0."
+        },
+        "manual-marker-after": {
+          "$ref": "#/$defs/manualMarker",
+          "description": "Inline manual marker between this wave and the next. Engine prompts operator; honors skip-when. Wave-inline placement is preferred for non-idempotent operations bound to a specific wave (e.g. vault-init after Vault is Running)."
+        },
+        "manual-marker-before": {
+          "$ref": "#/$defs/manualMarker",
+          "description": "Inline manual marker BEFORE this wave starts."
+        }
+      },
+      "allOf": [
+        {
+          "if": { "required": ["insert-before"] },
+          "then": { "not": { "required": ["insert-after"] } }
+        },
+        {
+          "if": { "required": ["extends"] },
+          "then": { "not": { "anyOf": [ { "required": ["insert-before"] }, { "required": ["insert-after"] } ] } }
+        }
+      ]
+    },
+
+    "waveApp": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name":     { "type": "string", "minLength": 1, "description": "ArgoCD Application name (must match the App emitted by the platform-root chart)." },
+        "optional": { "type": "boolean", "default": false, "description": "When true and the App is absent from ArgoCD (chart conditional gated it off), the engine skips silently. When false (default) and the App is absent, the wave fails." },
+        "timeout":  { "type": "integer", "minimum": 30, "maximum": 1800, "description": "Per-app wait timeout. Overrides wave timeout, defaults timeout." },
+        "wait":     { "$ref": "#/$defs/waitMode", "description": "Override wait mode for this app. Vault uses 'phase-running' (Sealed pods are not Ready by design)." }
+      }
+    },
+
+    "applyCrdsChart": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["chart", "repo", "version"],
+      "properties": {
+        "chart":   { "type": "string", "minLength": 1 },
+        "repo":    { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 }
+      }
+    },
+
+    "verifyCheck": {
+      "type": "object",
+      "required": ["check"],
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "required": ["check", "name", "namespace"],
+          "properties": {
+            "check":     { "const": "webhook-ready" },
+            "name":      { "type": "string" },
+            "namespace": { "type": "string" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["check", "name", "namespace"],
+          "properties": {
+            "check":     { "const": "secret-exists" },
+            "name":      { "type": "string" },
+            "namespace": { "type": "string" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["check", "apiVersion", "kind", "name", "namespace", "jsonpath", "expected"],
+          "properties": {
+            "check":      { "const": "resource-ready" },
+            "apiVersion": { "type": "string" },
+            "kind":       { "type": "string" },
+            "name":       { "type": "string" },
+            "namespace":  { "type": "string" },
+            "jsonpath":   { "type": "string" },
+            "expected":   { "type": "string" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["check", "name"],
+          "properties": {
+            "check": { "const": "apiservice-available" },
+            "name":  { "type": "string", "description": "APIService name, e.g. v1beta1.metrics.k8s.io" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["check"],
+          "properties": {
+            "check":     { "const": "ingress-hostname-resolved" },
+            "name":      { "type": "string" },
+            "namespace": { "type": "string" },
+            "host":      { "type": "string" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["check", "name", "namespace"],
+          "properties": {
+            "check":     { "const": "deployment-ready" },
+            "name":      { "type": "string" },
+            "namespace": { "type": "string" }
+          }
+        }
+      ]
+    },
+
+    "manualMarker": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "message"],
+      "properties": {
+        "name":      { "type": "string", "minLength": 1, "description": "Identifier for logging and resume state." },
+        "message":   { "type": "string", "minLength": 1, "description": "Instructional text shown to the operator." },
+        "skip-when": { "$ref": "#/$defs/skipWhen" }
+      }
+    }
+  }
+}

--- a/spec/upstart/upstart.aws.yaml
+++ b/spec/upstart/upstart.aws.yaml
@@ -1,0 +1,133 @@
+# Estabilis Platform — Bootstrap Spec (v3, AWS overlay)
+# =============================================================================
+# Deep-merged on top of spec/upstart/upstart.yaml.
+#
+# Provider deltas captured here reflect real operational structure observed in
+# cortex prd 2026-04-29 / 2026-04-30 bootstrap sessions (postmortems in
+# estabilis-platform-tools/docs/runbooks/cortex/). Schema directives used:
+#   - bootstrap.pre[]                  : Karpenter pre-bootstrap (3 steps)
+#   - bootstrap.init.namespaces[]      : appended namespaces (engine merges arrays)
+#   - waves[].insert-before            : insert Wave 0 before base Wave 1
+#   - waves[].extends                  : extend base "Platform Secrets" with Vault
+#   - waves[].insert-before            : insert "Ingresses" before "Policies"
+#   - waves[].verify-and-resync        : hardening re-sync pass (Synced/Healthy parcial fix)
+#   - waves[].apps[].wait: phase-running : Vault Sealed pods aren't Ready by design
+#   - waves[].manual-marker-after      : inline vault-init between Wave 6 and Wave 7
+#
+# Schema:  spec/upstart/schema/upstart.v3.schema.json
+# Design:  estabilis-platform-tools/docs/adr/0036-upstart-yaml-v3-declarative-bootstrap.md §4.8
+# -----------------------------------------------------------------------------
+
+version: "3"
+
+bootstrap:
+  # Karpenter pre-bootstrap. Replaces the manual Phase 1.5 procedure
+  # documented in docs/runbooks/cortex/cortex-aws-prd-upstart-replay.md.
+  # All 3 steps are inherently idempotent (helm upgrade --install, kubectl
+  # apply --server-side) — no skip-when needed.
+  pre:
+    - name: karpenter-crd
+      helm-install:
+        chart: karpenter-crd
+        repo: oci://public.ecr.aws/karpenter
+        version: "${karpenterVersion:-1.12.0}"
+        namespace: karpenter
+
+    - name: karpenter
+      helm-install:
+        chart: karpenter
+        repo: oci://public.ecr.aws/karpenter
+        version: "${karpenterVersion:-1.12.0}"
+        namespace: karpenter
+        values:
+          settings:
+            clusterName: "${global.clusterName:?required}"
+            interruptionQueue: "${global.karpenterQueueName:?required}"
+          serviceAccount:
+            annotations:
+              eks.amazonaws.com/role-arn: "${global.karpenterControllerRole:?required}"
+
+    # NodePool + EC2NodeClass live in the estabilis-platform-gitops repo
+    # because they are tunable per-cluster (instance types, disk size, tags)
+    # without forcing an estabilis-platform tag bump.
+    - name: karpenter-resources
+      helm-template-apply:
+        chart-from-git:
+          repo: "${platformGitopsRepoUrl}"
+          ref: "${platformGitopsVersion}"
+          path: components/karpenter-resources
+        namespace: karpenter
+        set:
+          clusterName: "${global.clusterName}"
+          nodeRole: "${global.karpenterNodeRoleName}"
+          discoveryTagKey: "${global.karpenterDiscoveryTagKey}"
+
+  init:
+    # Appended to base list (engine merges arrays in base+overlay path).
+    # Karpenter namespace is already created by bootstrap.pre[0] helm
+    # install --create-namespace. traefik-internal and estabilis-system
+    # stay JIT via CreateNamespace=true.
+    namespaces:
+      - aws-load-balancer-controller
+      - metrics-server
+      - vault
+
+waves:
+  # ─── Wave 0 INSERTED before base Wave 1 ────────────────────────────────────
+  # ALB controller and metrics-server are AWS cluster fundamentals — required
+  # before cert-manager (cert-manager-webhook needs metrics-server APIService
+  # to satisfy its readiness check on managed-by metrics).
+  #
+  # verify-and-resync: true ⇒ after wait-Healthy converges, engine re-triggers
+  # sync. Catches the Synced/Healthy parcial bug observed cortex prd
+  # 2026-04-30: ArgoCD reported Synced/Healthy with partial source render;
+  # Service/metrics-server permanently OutOfSync because Phase 9 already
+  # disabled auto-sync. With re-sync the engine catches resources that
+  # rendered post-convergence.
+  - name: AWS Cluster Fundamentals
+    insert-before: TLS & Certificates
+    verify-and-resync: true
+    apps:
+      - { name: aws-load-balancer-controller }
+      - { name: metrics-server }
+    verify:
+      - check: apiservice-available
+        name: v1beta1.metrics.k8s.io
+
+  # ─── Extend base "Platform Secrets" with Vault + inline vault-init ────────
+  # extends: arrays append. Base wave's platform-secrets app and secret-exists
+  # verifies are preserved unchanged; we add Vault and the manual marker.
+  - extends: Platform Secrets
+    apps:
+      - name: vault
+        # Sealed pods are 0/1 Ready by design. Generic wait-Healthy would
+        # deadlock — switch to phase-running so the engine advances as soon
+        # as the pod is scheduled and the container is up. The manual
+        # marker that follows handles the seal/init.
+        wait: phase-running
+    manual-marker-after:
+      name: vault-init
+      message: |
+        Vault não foi inicializado.
+        Em produção: rode `scripts/26-vault-init.sh` (idempotente — recusa
+        re-init se já initialized=true; emite 5 recovery keys ANOTE OFFLINE
+        ANTES do script terminar — não há segunda chance).
+      skip-when:
+        kubectl:
+          kind: Secret
+          namespace: vault
+          name: vault-root-token
+
+  # ─── Wave "Ingresses" INSERTED before "Policies" ──────────────────────────
+  # All entries are optional: true because exposure is gated by the
+  # *_exposures.external boolean in terraform.tfvars per ADR 0014. If a
+  # chart conditional doesn't emit the App, the engine silently skips.
+  - name: Ingresses
+    insert-before: Policies
+    apps:
+      - { name: argocd-ingress, optional: true }
+      - { name: grafana-ingress, optional: true }
+      - { name: loki-ingress, optional: true }
+      - { name: vault-ingress, optional: true }
+    verify:
+      - check: ingress-hostname-resolved

--- a/spec/upstart/upstart.azure.yaml
+++ b/spec/upstart/upstart.azure.yaml
@@ -1,0 +1,22 @@
+# Estabilis Platform — Bootstrap Spec (v3, Azure overlay)
+# =============================================================================
+# Deep-merged on top of spec/upstart/upstart.yaml.
+#
+# Azure runs on AKS managed node pools — no Karpenter equivalent, no pre-
+# bootstrap helm installs needed. The base spec already covers all known
+# Azure-only behavior (it was originally derived from templates/azure/
+# upstart.yaml v2). This overlay exists for symmetry with the AWS overlay
+# and as the binding site for future Azure-only deltas (e.g. a workload
+# identity bootstrap step if AAD federation grows requirements).
+#
+# Schema:  spec/upstart/schema/upstart.v3.schema.json
+# Design:  estabilis-platform-tools/docs/adr/0036-upstart-yaml-v3-declarative-bootstrap.md §4.2
+# -----------------------------------------------------------------------------
+
+version: "3"
+
+bootstrap:
+  # Empty by design — AKS managed pools don't require an autoscaler bootstrap.
+  # Kept as explicit "nothing to do here" so future readers know the parity
+  # with AWS was a deliberate decision, not an oversight.
+  pre: []

--- a/spec/upstart/upstart.yaml
+++ b/spec/upstart/upstart.yaml
@@ -1,0 +1,277 @@
+# Estabilis Platform — Bootstrap Specification (v3, BASE / provider-agnostic)
+# =============================================================================
+# This is the canonical declarative source of truth for Estabilis Platform
+# bootstrap. Multiple renderers consume it:
+#   - Python in-process (estabilis-autopilot bootstrap, estabilis bootstrap)
+#   - Argo WorkflowTemplate generator (estabilis render-workflow, phase 2)
+#   - Documentation generator (reserved)
+#
+# Schema:  spec/upstart/schema/upstart.v3.schema.json
+# Design:  estabilis-platform-tools/docs/adr/0036-upstart-yaml-v3-declarative-bootstrap.md
+#
+# Merge order (Kustomize-style base + overlay):
+#   spec/upstart/upstart.yaml              ← this file (provider-agnostic)
+#   spec/upstart/upstart.{aws,azure}.yaml  ← provider overlay
+#   <client-repo>/upstart.local.yaml        ← client deltas (optional)
+#
+# Last write wins on scalar conflicts. Arrays are replaced unless the wave
+# carries `extends: <base-wave-name>` — in which case `apps[]` and `verify[]`
+# arrays APPEND to the base wave.
+#
+# Variables follow POSIX shell convention:
+#   ${X}            → require X to be resolved
+#   ${X:-default}   → fall back to literal `default` if X is empty
+#   ${X:?required}  → fail pre-execution if X is empty
+#   ${X:+word}      → render `word` if X is set (used by source conditionals)
+#
+# All ${X} references are validated against the resolver chain
+# (params.resolve_platform_params) BEFORE any side effect.
+# -----------------------------------------------------------------------------
+
+version: "3"
+
+bootstrap:
+  # No pre-bootstrap steps in the provider-agnostic base. AWS overlay carries
+  # Karpenter CRD + controller + NodePool/EC2NodeClass; Azure overlay is empty
+  # (AKS managed node pools).
+  pre: []
+
+  argocd:
+    chart: argo-cd
+    repo: oci://ghcr.io/argoproj/argo-helm
+    version: "${_argocd_chart_version:-9.5.6}"
+    namespace: argocd
+    values-file: spec/upstart/values/argocd-seed.yaml
+    pre-create-secrets:
+      - name: argocd-redis
+        namespace: argocd
+        type: Opaque
+        data:
+          auth: "${_argocd_redis_password:?required}"
+
+  repos:
+    - name: repo-config-downstream
+      url: "${configRepoUrl}"
+      token: "${_config_repo_token}"
+      label: config-repo
+    - name: repo-client-gitops
+      url: "${clientGitopsRepoUrl}"
+      token: "${_client_gitops_repo_token}"
+      label: client-gitops
+
+  init:
+    # 13 base namespaces — historically loaded from
+    # estabilis-platform-tools/template.yaml:77-90 and consumed by
+    # kubernetes.py:_precreate_component_namespaces. Pre-created BEFORE
+    # ArgoCD waves to avoid hook race conditions on the first sync cycle.
+    # AWS overlay appends 3 (aws-load-balancer-controller, metrics-server, vault).
+    namespaces:
+      - cert-manager
+      - kyverno
+      - external-secrets
+      - external-dns
+      - grafana
+      - traefik
+      - cnpg-system
+      - opencost
+      - velero
+      - trivy-system
+      - kube-state-metrics
+      - node-exporter
+      - policy-reporter
+
+    # Placeholder AppProject — chart sync via platform-root immediately
+    # overwrites with the full ADR 0028 taxonomy (5 AppProjects). The
+    # placeholder exists to unblock the first platform-root sync, which
+    # references `project: platform`.
+    appproject:
+      name: platform
+      namespace: argocd
+      sourceRepos:
+        - "${platformRepoUrl}"
+        - "${configRepoUrl}"
+        - https://argoproj.github.io/argo-helm
+        - https://charts.jetstack.io
+        - https://kyverno.github.io/kyverno
+        - https://charts.external-secrets.io
+        - https://kubernetes-sigs.github.io/external-dns
+        - https://grafana.github.io/helm-charts
+        - https://traefik.github.io/charts
+        - https://aquasecurity.github.io/helm-charts
+        - https://opencost.github.io/opencost-helm-chart
+        - https://cloudnative-pg.github.io/charts
+        - https://vmware-tanzu.github.io/helm-charts
+        - https://prometheus-community.github.io/helm-charts
+      destinations:
+        - { server: https://kubernetes.default.svc, namespace: "*" }
+      clusterResourceWhitelist:
+        - { group: "*", kind: "*" }
+
+    platform-root:
+      name: platform-root
+      namespace: argocd
+      project: default
+      sources:
+        - repoURL: "${platformRepoUrl}"
+          targetRevision: "${platformVersion}"
+          path: bootstrap/platform-root
+          helm:
+            valueFiles:
+              - $values/bootstrap/platform-root/values.yaml
+            ignoreMissingValueFiles: true
+            # 'auto' is a renderer directive: inject every resolved key from
+            # params.resolve_platform_params (minus internals prefixed `_`)
+            # plus the provenance four-key block (ADR 0005 L1). JSON-valued
+            # parameters are auto-base64-encoded with forceString: true
+            # (ADR 0014).
+            parameters: auto
+        - repoURL: "${platformRepoUrl}"
+          targetRevision: "${platformVersion}"
+          ref: values
+        # The overrides source is rendered only when configRepoUrl is set.
+        # ADR 0020: targetRevision tracks branch for cluster-own content
+        # (configRepoRevision); configRepoVersion remains as transitional
+        # fallback during clients' migration to branch tracking. Revision wins.
+        - repoURL: "${configRepoUrl}"
+          targetRevision: "${configRepoRevision:-${configRepoVersion}}"
+          ref: overrides
+          condition: "${configRepoUrl:+true}"
+      syncPolicy:
+        syncOptions:
+          - CreateNamespace=true
+
+  wait:
+    platform-root-apps:
+      min-count: 25
+      stable-rounds: 5
+      timeout: 360
+      check-interval: 3
+
+defaults:
+  timeout: 300
+  wait: healthy
+  sync-options:
+    - CreateNamespace=true
+    # Universal ServerSideApply=true resolves cortex prd 2026-04-29 CSA-vs-SSA
+    # toggle bug (proposal 0002 §1.1 issues #3 and #4). Replaces the
+    # upstart.py:1206 heuristic ("if 'crds' in name or name == 'kyverno'").
+    - ServerSideApply=true
+  retry:
+    limit: 3
+    backoff: exponential
+    factor: 2
+
+waves:
+  - name: TLS & Certificates
+    apps:
+      - { name: cert-manager }
+    verify:
+      - check: webhook-ready
+        name: cert-manager-webhook
+        namespace: cert-manager
+
+  - name: Certificate Issuers & Policy Engine
+    apps:
+      - { name: cert-manager-config }
+      - { name: kyverno, timeout: 300 }
+
+  - name: Operator CRDs
+    apply-crds:
+      - chart: external-secrets
+        repo: https://charts.external-secrets.io
+        version: "${externalSecretsCrdVersion:-2.4.1}"
+      - chart: cloudnative-pg
+        repo: https://cloudnative-pg.github.io/charts
+        version: "${cnpgCrdVersion:-0.28.0}"
+
+  - name: Secrets Management
+    apps:
+      - { name: external-secrets }
+    verify:
+      - check: webhook-ready
+        name: external-secrets-webhook
+        namespace: external-secrets
+
+  - name: Operators & Secret Store
+    timeout: 360
+    apps:
+      - { name: cnpg-operator, timeout: 360 }
+      - { name: cluster-secret-store }
+      - { name: kyverno-exceptions }
+
+  - name: Platform Secrets
+    timeout: 300
+    apps:
+      - { name: platform-secrets }
+    verify:
+      - check: secret-exists
+        name: grafana-db-credentials
+        namespace: cnpg-system
+      - check: secret-exists
+        name: grafana-admin-credentials
+        namespace: grafana
+
+  - name: Database
+    apps:
+      - { name: cnpg-cluster, timeout: 480 }
+    verify:
+      - check: resource-ready
+        apiVersion: postgresql.cnpg.io/v1
+        kind: Cluster
+        name: platform-postgres
+        namespace: cnpg-system
+        jsonpath: "{.status.phase}"
+        expected: "Cluster in healthy state"
+
+  - name: Networking & Ingress
+    timeout: 300
+    apps:
+      - { name: external-dns, optional: true }
+      - { name: external-dns-config, optional: true }
+      - { name: traefik, optional: true }
+      - { name: velero, optional: true }
+
+  - name: Observability & Monitoring
+    apps:
+      - { name: grafana-db }
+      - { name: grafana }
+      - { name: grafana-loki, optional: true }
+      - { name: grafana-mimir, optional: true }
+      - { name: grafana-alloy, optional: true }
+      - { name: grafana-tempo, optional: true }
+      - { name: grafana-pyroscope, optional: true }
+      - { name: opencost, optional: true }
+      - { name: opencost-presync, optional: true }
+      - { name: trivy-operator, optional: true }
+      - { name: kube-state-metrics, optional: true }
+      - { name: node-exporter, optional: true }
+      - { name: velero-config, optional: true }
+
+  - name: Post-Deploy
+    apps:
+      - { name: grafana-dashboards, optional: true }
+      - { name: alloy-rbac, optional: true }
+      - { name: mimir-rules, optional: true }
+      - { name: loki-ingress, optional: true }
+
+  - name: Policies
+    apps:
+      - { name: kyverno-policies }
+      - { name: network-policies, optional: true }
+      - { name: resource-quotas, optional: true }
+
+post:
+  # Defensive fallback only. Per ADR 0029, prune is decided per-App in the
+  # chart/ApplicationSet template by risk taxonomy (Safe / Coupled /
+  # CRD-owning / Foundational). Chart-emitted automated{} blocks are
+  # respected as-is; this block only fires for Apps arriving WITHOUT any
+  # automated{} block (legacy hand-rolled, custom ApplicationSets).
+  enable-auto-sync:
+    apps: all
+    self-heal: true
+    prune: false
+
+  # Genuinely post-everything operations. Today empty — wave-inline manual
+  # markers (waves[].manual-marker-after) handle the vault-init case in the
+  # AWS overlay.
+  manual-markers: []

--- a/spec/upstart/values/argocd-seed.yaml
+++ b/spec/upstart/values/argocd-seed.yaml
@@ -1,0 +1,105 @@
+# ArgoCD seed values — used by `bootstrap.argocd.values-file` in upstart.yaml v3.
+# =============================================================================
+# Source of truth: this file. Until the Python renderer of upstart.yaml v3
+# ships (Phase B of ADR 0036), the CLI builds the same dict in
+# estabilis-platform-tools/src/estabilis/kubernetes.py (function
+# `_helm_install_argocd`, lines 2729-2812). Any change here MUST be mirrored
+# there until the renderer takes over.
+#
+# Static, cross-provider. Variables (${X}) intentionally absent — Phase A is
+# extracting the constant seed; client-specific tweaks belong in
+# upstart.local.yaml or in chart-level platform-root values, not here.
+#
+# Why each block exists:
+#   - redisSecretInit.enabled=false: the chart's built-in Job is disabled
+#     because we pre-create the Redis Secret (bootstrap.argocd.pre-create-secrets).
+#     The Job's foregroundDeletion finalizer caused a deadlock on ArgoCD
+#     self-manage sync — proposal 0002 §1.1 issue #2 root cause.
+#   - global.tolerations / global.affinity: ADR 0012 — ArgoCD runs BEFORE
+#     platform-root, so the scheduling helpers don't apply. Mirror the "auto"
+#     mode: tolerate spot (autoscaler can scale it up when no regular pool
+#     exists) + prefer regular (when both pools exist).
+#   - configs.params.server.insecure=true: ArgoCD listens HTTP; TLS is
+#     terminated upstream by Traefik. timeout.reconciliation=10s tightens the
+#     poll loop during bootstrap (chart default is 180s).
+#   - configs.cm.resource.customizations.ignoreDifferences.all: ignore the
+#     estabilis.io/managed-by label flap. The label is set by the
+#     `labels.platform_managed_selector` helper and re-applied by various
+#     controllers; without this rule ArgoCD reports phantom OutOfSync on
+#     every reconciliation.
+#   - configs.cm.resource.customizations.health.*: ESO ExternalSecret and
+#     CNPG Cluster need Lua health rules because the default ArgoCD health
+#     check declares them Progressing forever (ESO conditions vs Synced
+#     mismatch; CNPG status.phase enum vs ArgoCD health enum).
+# -----------------------------------------------------------------------------
+
+redisSecretInit:
+  enabled: false
+
+global:
+  tolerations:
+    - key: kubernetes.azure.com/scalesetpriority
+      operator: Equal
+      value: spot
+      effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          preference:
+            matchExpressions:
+              - key: estabilis.io/schedulable
+                operator: In
+                values:
+                  - regular
+
+configs:
+  params:
+    server.insecure: true
+    timeout.reconciliation: 10s
+
+  cm:
+    resource.customizations.ignoreDifferences.all: |
+      jqPathExpressions:
+        - .metadata.labels."estabilis.io/managed-by"
+
+    resource.customizations.health.external-secrets.io_ExternalSecret: |
+      hs = {}
+      if obj.status ~= nil then
+        if obj.status.conditions ~= nil then
+          for i, condition in ipairs(obj.status.conditions) do
+            if condition.type == "Ready" and condition.status == "True" then
+              hs.status = "Healthy"
+              hs.message = condition.message
+              return hs
+            end
+            if condition.type == "Ready" and condition.status == "False" then
+              hs.status = "Degraded"
+              hs.message = condition.message
+              return hs
+            end
+          end
+        end
+      end
+      hs.status = "Progressing"
+      hs.message = "Waiting for secret to sync"
+      return hs
+
+    resource.customizations.health.postgresql.cnpg.io_Cluster: |
+      hs = {}
+      if obj.status == nil or obj.status.phase == nil then
+        hs.status = "Progressing"
+        hs.message = "Waiting for cluster initialization"
+        return hs
+      end
+      if obj.status.phase == "Cluster in healthy state" then
+        hs.status = "Healthy"
+        hs.message = "Cluster is healthy"
+      elseif obj.status.phase == "Setting up primary" or obj.status.phase == "Creating primary" then
+        hs.status = "Progressing"
+        hs.message = obj.status.phase
+      else
+        hs.status = "Progressing"
+        hs.message = obj.status.phase or "Cluster not ready"
+      end
+      return hs


### PR DESCRIPTION
Phase A of [ADR 0036 — `upstart.yaml v3` as declarative bootstrap source of truth](https://github.com/Estabilis/estabilis-platform-tools/blob/main/docs/adr/0036-upstart-yaml-v3-declarative-bootstrap.md).

## Summary

- Adds `spec/upstart/` (JSON Schema 2020-12 + base + AWS/Azure overlays + ArgoCD seed values) and `spec/cleanup/` (schema + base + AWS/Azure overlays).
- All 6 YAML specs validate against their JSON Schemas (verified locally via `check-jsonschema`).
- Adds pre-commit hook (`check-jsonschema`) so the schemas are a CI gate on this and future PRs touching `spec/*`. ADR §4.11 Layer 2 (`additionalProperties: false` is hard, no silent acceptance of unknown fields).
- `spec/.argocdignore` as defense-in-depth — `spec/` is the source-of-truth for renderers, NEVER consumed by ArgoCD ApplicationSets.

## Out of scope (this PR)

- Python renderer refactor of `upstart.py` (Phase B per ADR §8.2) — separate work in `estabilis-platform-tools`. Includes the 4 wave-engine hard requirements (universal `syncOptions` in trigger; fail-loud on `operationState.phase=Failed`; fail-loud on timeout exhaustion; hardening re-sync for `verify-and-resync` waves) and the `apply-crds` yq filter.
- Client migration (Phase C) — preserves existing `templates/{aws,azure}/upstart.yaml` v1/v2 as archival until full migration cycle validates.
- Argo Workflows renderer (Phase D, optional) and `estabilis-autopilot` repo split (Phase E).

## Files

| Path | Purpose |
|---|---|
| `spec/upstart/schema/upstart.v3.schema.json` | JSON Schema 2020-12 — top-level `version` mandatory; 21 `$defs`; per-block `additionalProperties: false`; merged-spec required-set enforced post-merge by the renderer |
| `spec/upstart/upstart.yaml` | Base, provider-agnostic — 11 waves (TLS → Policies), 13 namespaces, universal `ServerSideApply=true` in `defaults`, `parameters: auto`, `condition: ${configRepoUrl:+true}` on overrides source |
| `spec/upstart/upstart.aws.yaml` | AWS overlay — Karpenter pre-bootstrap (3 steps via `helm-template-apply` chart-from-git), 3 extra namespaces, Wave 0 inserted before TLS, Platform Secrets extended with Vault + inline `vault-init` manual marker, Ingresses inserted before Policies |
| `spec/upstart/upstart.azure.yaml` | Azure overlay — empty `bootstrap.pre` explicit (AKS managed pools, no Karpenter) |
| `spec/upstart/values/argocd-seed.yaml` | ArgoCD helm seed values — byte-for-byte from `estabilis-platform-tools/src/estabilis/kubernetes.py:2729-2812`; preserves Lua health checks for ESO `ExternalSecret` and CNPG `Cluster` |
| `spec/cleanup/schema/cleanup.v1.schema.json` | Cleanup schema (7 action types: helm-uninstall, remove-finalizers-and-delete, remove-finalizers, aws-ec2-terminate, delete-namespaces, delete-all-resources, delete-webhooks) |
| `spec/cleanup/cleanup.yaml` | Base teardown — argocd uninstall FIRST (controller stops), then drain, finalize orphan CRs, delete namespaces, cleanup default, remove orphan webhooks |
| `spec/cleanup/cleanup.aws.yaml` | AWS overlay — 3 phases (Karpenter CRs finalize, helm uninstall karpenter, terminate orphan EC2 nodes) |
| `spec/cleanup/cleanup.azure.yaml` | Azure overlay — empty (`order: []`) — AKS pool lifecycle is terraform-owned |
| `spec/.argocdignore` | Defense-in-depth — `spec/` must never be consumed by ArgoCD |
| `.pre-commit-config.yaml` | Adds `check-jsonschema` hook block for both schemas |

## Test plan

- [ ] CI `pre-commit` workflow runs all hooks including the new `check-jsonschema` gate
- [ ] Schema rejects unknown fields (verified locally: a `unknown-field:` injected under `bootstrap.pre[0]` is rejected with `$.bootstrap.pre[0]: Additional properties are not allowed`)
- [ ] No drift between `spec/upstart/values/argocd-seed.yaml` and `kubernetes.py:2729-2812` (will be checked when Phase B renderer ships; until then both files are source-of-truth and any change MUST be mirrored)
- [ ] Phase B Python renderer (separate PR in `estabilis-platform-tools`) consumes these specs and produces identical bootstrap behavior to current `upstart.py` against cortex prd dry-run

## Related

- ADR 0036 (this PR's design doc): https://github.com/Estabilis/estabilis-platform-tools/blob/main/docs/adr/0036-upstart-yaml-v3-declarative-bootstrap.md
- ADR 0036 acceptance commit (`371a6ac`): https://github.com/Estabilis/estabilis-platform-tools/commit/371a6ac

Draft until CI green + reviewer approval.