### PR TITLE
feat(aws): iam_policy_name_use_cluster_prefix — multi-cluster-per-account IRSA safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,67 @@
 # Changelog
 
+## [Unreleased]
+
+### Added — `iam_policy_name_use_cluster_prefix` (multi-cluster-per-account safety)
+
+New tfvar that opts-in to cluster-prefixed IAM policy names for the six
+IRSA bundles wired by `providers/aws/`:
+
+| Module                  | Canonical (default)            | Prefixed (`true`)                                      |
+| ----------------------- | ------------------------------ | ------------------------------------------------------ |
+| `external_secrets_irsa` | `External_Secrets`             | `${cluster_name}-External_Secrets`                     |
+| `external_dns_irsa`     | `External_DNS`                 | `${cluster_name}-External_DNS`                         |
+| `cert_manager_irsa`     | `Cert_Manager`                 | `${cluster_name}-Cert_Manager`                         |
+| `velero_irsa`           | `Velero`                       | `${cluster_name}-Velero`                               |
+| `ebs_csi_irsa`          | `EBS_CSI`                      | `${cluster_name}-EBS_CSI`                              |
+| `alb_controller_irsa`   | `AWS_Load_Balancer_Controller` | `${cluster_name}-AWS_Load_Balancer_Controller`         |
+
+### Why
+
+The upstream `terraform-aws-modules/iam-role-for-service-accounts`
+submodule hardcodes the canonical policy names when `policy_name` is
+left unset. IAM policies are **account-scoped**, so the second EKS
+cluster in the same AWS account that enables the same IRSA bundle fails
+during apply with `EntityAlreadyExists`. Hit in production on 2026-05-13
+bringing up `cortex-platform-hml` next to `cortex-platform-prd` (both in
+account `093996075120`), where 4 of 6 policies collided.
+
+### Behavior
+
+- Default `false` — preserves existing canonical names. Zero-impact for
+  every cluster already running (same names continue to be produced and
+  managed by Terraform with no plan diff).
+- Set `true` on **new** clusters being brought up alongside an existing
+  cluster in the same AWS account.
+- **Do NOT flip on an existing cluster** without first detaching +
+  reattaching policies — Terraform plans delete-then-create on the
+  policy, briefly revoking pod permissions.
+
+### Convention for new IRSA modules
+
+`CONTRIBUTING.md` (new file at repo root) documents the rule every
+future IRSA module addition MUST follow:
+
+```hcl
+policy_name = var.iam_policy_name_use_cluster_prefix ? "${local.cluster_name}-<Canonical>" : null
+```
+
+This keeps the codebase free of the same trap surfacing every time a new
+upstream IRSA helper is wired in.
+
+### Files changed
+
+- `providers/aws/variables.tf` — new variable with heredoc description
+  + irreversibility warning.
+- `providers/aws/iam.tf` — `policy_name` added to `external_secrets_irsa`,
+  `external_dns_irsa`, `cert_manager_irsa`, `velero_irsa`.
+- `providers/aws/eks.tf` — `policy_name` added to `ebs_csi_irsa`.
+- `providers/aws/alb-controller.tf` — `policy_name` added to
+  `alb_controller_irsa`.
+- `providers/aws/terraform.tfvars.example` — documents the new tfvar.
+- `CONTRIBUTING.md` — new file with IRSA module convention + release
+  process notes.
+
 ## [0.51.0] - 2026-05-14
 
 ### Added — `spec/upstart/` and `spec/cleanup/` (Phase A of ADR 0036)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,108 @@
+# Contributing to `estabilis-platform`
+
+This document captures conventions that aren't obvious from the code but
+matter for keeping downstream consumers (`estabilis-platform-downstream`
+templates and per-client downstream repos) safe and predictable.
+
+## IRSA module convention (AWS provider)
+
+The `providers/aws/` module composes the upstream
+[`terraform-aws-modules/iam-role-for-service-accounts`][upstream] submodule
+for each cluster-scoped workload that needs AWS API access via IRSA. Today
+six built-in IRSA bundles are wired:
+
+| Module                  | File                          | Canonical policy name           |
+| ----------------------- | ----------------------------- | ------------------------------- |
+| `external_secrets_irsa` | `providers/aws/iam.tf`        | `External_Secrets`              |
+| `external_dns_irsa`     | `providers/aws/iam.tf`        | `External_DNS`                  |
+| `cert_manager_irsa`     | `providers/aws/iam.tf`        | `Cert_Manager`                  |
+| `velero_irsa`           | `providers/aws/iam.tf`        | `Velero`                        |
+| `ebs_csi_irsa`          | `providers/aws/eks.tf`        | `EBS_CSI`                       |
+| `alb_controller_irsa`   | `providers/aws/alb-controller.tf` | `AWS_Load_Balancer_Controller` |
+
+### The pitfall
+
+When you set `attach_<name>_policy = true` and leave `policy_name` unset, the
+upstream submodule **hardcodes** the canonical name (see
+`policy_name = try(coalesce(...))` in the submodule source). IAM policies
+are **account-scoped**, not cluster-scoped. So a second EKS cluster brought
+up in the same AWS account that enables the same IRSA bundle fails at
+apply time with `EntityAlreadyExists`.
+
+This bit us in May 2026 when bootstrapping `cortex-platform-hml` alongside
+the existing `cortex-platform-prd` (both in account `093996075120`). Four
+of the six policies collided in a single `terraform apply`.
+
+### The rule
+
+**Every new IRSA module added to `providers/aws/` MUST set an explicit
+`policy_name` gated on `var.iam_policy_name_use_cluster_prefix`.** Default
+`false` preserves backward compatibility with clusters that already own the
+unprefixed name; set `true` on new clusters in shared accounts.
+
+The pattern, applied identically to all six modules above:
+
+```hcl
+module "<name>_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 6.5"
+
+  use_name_prefix          = false
+  name                     = "${local.cluster_name}-<name>"
+  attach_<name>_policy     = true
+
+  # See CONTRIBUTING.md "IRSA module convention".
+  policy_name = var.iam_policy_name_use_cluster_prefix ? "${local.cluster_name}-<Canonical>" : null
+
+  oidc_providers = { ... }
+}
+```
+
+`<Canonical>` is the exact string the submodule would have hardcoded
+(check the upstream submodule's `coalesce` cascade for the
+`attach_<name>_policy = true` branch). Setting `policy_name = null` in the
+`false` branch is critical — it preserves the submodule's existing
+canonical-name behavior, which is what existing clusters in the field
+already own.
+
+### Why not just always prefix?
+
+Backward compatibility. Existing production clusters already own the
+unprefixed policy names. Flipping the default to `true` would plan
+delete-then-create on the policy resources in every running cluster,
+briefly revoking pod permissions across the platform — an outage we won't
+inflict for an aesthetic improvement.
+
+### Migration path for existing single-cluster-per-account deployments
+
+If you must rename the policies on a running cluster (e.g. to onboard a
+second cluster in the same account), do it as a controlled migration:
+
+1. `terraform plan` — confirm the diff is only the IAM policy resources,
+   not the IAM roles.
+2. Pre-create the new prefixed policies out of band (`aws iam create-policy`)
+   and attach to the IRSA roles ahead of the apply.
+3. Run apply during a maintenance window — there will still be a brief
+   window during the in-place policy version replacement.
+4. After apply, delete the old unprefixed policies manually.
+
+Or, simpler: bring up the second cluster with `iam_policy_name_use_cluster_prefix = true`
+and leave the first cluster on the canonical names indefinitely. Both modes
+coexist permanently.
+
+[upstream]: https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/modules/iam-role-for-service-accounts
+
+## Release process
+
+1. Land all feature PRs to `main`.
+2. Bump `VERSION` and add a `CHANGELOG.md` entry under the new
+   `## [X.Y.Z]` header (no `[Unreleased]` accumulator — entries are
+   written directly under the version they ship in).
+3. Commit with subject `chore(release): vX.Y.Z` and **direct-push** to
+   `main`. Do NOT route through a PR — squash merge rewrites the subject
+   to `chore(release): vX.Y.Z (#NNN)`, which breaks the auto-tag
+   workflow's prefix regex.
+4. The `.github/workflows/auto-tag.yml` workflow tags the commit and
+   publishes the GitHub Release page automatically.
+5. Propagate to downstream template + clients per the version-propagation
+   checklist in the consumer repo's `CLAUDE.md`.

--- a/providers/aws/alb-controller.tf
+++ b/providers/aws/alb-controller.tf
@@ -20,6 +20,9 @@ module "alb_controller_irsa" {
   name                                   = "${local.cluster_name}-alb-controller"
   attach_load_balancer_controller_policy = true
 
+  # See CONTRIBUTING.md "IRSA module convention".
+  policy_name = var.iam_policy_name_use_cluster_prefix ? "${local.cluster_name}-AWS_Load_Balancer_Controller" : null
+
   oidc_providers = {
     main = {
       provider_arn               = module.eks.oidc_provider_arn

--- a/providers/aws/eks.tf
+++ b/providers/aws/eks.tf
@@ -209,6 +209,9 @@ module "ebs_csi_irsa" {
   name                  = "${local.cluster_name}-ebs-csi"
   attach_ebs_csi_policy = true
 
+  # See CONTRIBUTING.md "IRSA module convention".
+  policy_name = var.iam_policy_name_use_cluster_prefix ? "${local.cluster_name}-EBS_CSI" : null
+
   oidc_providers = {
     main = {
       provider_arn               = module.eks.oidc_provider_arn

--- a/providers/aws/iam.tf
+++ b/providers/aws/iam.tf
@@ -26,6 +26,11 @@ module "external_secrets_irsa" {
   external_secrets_secrets_manager_arns = ["arn:${data.aws_partition.current.partition}:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:estabilis/${var.deployment_id}/*"]
   external_secrets_kms_key_arns         = [aws_kms_key.platform_secrets.arn]
 
+  # IAM policy name. Submodule hardcodes `External_Secrets` when null →
+  # collides across clusters in the same AWS account. See CONTRIBUTING.md
+  # "IRSA module convention".
+  policy_name = var.iam_policy_name_use_cluster_prefix ? "${local.cluster_name}-External_Secrets" : null
+
   oidc_providers = {
     main = {
       provider_arn               = module.eks.oidc_provider_arn
@@ -46,6 +51,9 @@ module "external_dns_irsa" {
   name                          = "${local.cluster_name}-external-dns"
   attach_external_dns_policy    = true
   external_dns_hosted_zone_arns = local.route53_zone_arns_or_wildcard
+
+  # See CONTRIBUTING.md "IRSA module convention".
+  policy_name = var.iam_policy_name_use_cluster_prefix ? "${local.cluster_name}-External_DNS" : null
 
   oidc_providers = {
     main = {
@@ -71,6 +79,9 @@ module "cert_manager_irsa" {
   attach_cert_manager_policy    = true
   cert_manager_hosted_zone_arns = local.route53_zone_arns_or_wildcard
 
+  # See CONTRIBUTING.md "IRSA module convention".
+  policy_name = var.iam_policy_name_use_cluster_prefix ? "${local.cluster_name}-Cert_Manager" : null
+
   oidc_providers = {
     main = {
       provider_arn               = module.eks.oidc_provider_arn
@@ -89,6 +100,9 @@ module "velero_irsa" {
   name                  = "${local.cluster_name}-velero"
   attach_velero_policy  = true
   velero_s3_bucket_arns = [aws_s3_bucket.velero.arn]
+
+  # See CONTRIBUTING.md "IRSA module convention".
+  policy_name = var.iam_policy_name_use_cluster_prefix ? "${local.cluster_name}-Velero" : null
 
   oidc_providers = {
     main = {

--- a/providers/aws/terraform.tfvars.example
+++ b/providers/aws/terraform.tfvars.example
@@ -273,3 +273,20 @@ client_gitops_repo_revision = "main"
 # network_observability_remote_resources = [
 #   { type = "AWS::EC2::Region", identifier = "us-west-2" },
 # ]
+
+# --- IRSA policy naming — multi-cluster-per-account safety -------------------
+# The upstream `terraform-aws-modules/iam-role-for-service-accounts` submodule
+# names its bundled IAM policies with hardcoded canonical names
+# (`External_Secrets`, `External_DNS`, `Cert_Manager`, `Velero`, `EBS_CSI`,
+# `AWS_Load_Balancer_Controller`). IAM policies are account-scoped, so a
+# second cluster in the same AWS account that enables the same IRSA bundles
+# fails on `EntityAlreadyExists` during apply.
+#
+# Set to `true` on NEW clusters being brought up alongside an existing cluster
+# in the same AWS account. Default `false` preserves backward compatibility
+# with clusters already owning the unprefixed names.
+#
+# WARNING: do NOT flip on an existing cluster without first detaching +
+# reattaching policies — Terraform plans delete-then-create, briefly revoking
+# pod permissions.
+# iam_policy_name_use_cluster_prefix = false

--- a/providers/aws/variables.tf
+++ b/providers/aws/variables.tf
@@ -294,6 +294,38 @@ variable "enable_cluster_creator_admin_permissions" {
   default     = true
 }
 
+variable "iam_policy_name_use_cluster_prefix" {
+  description = <<-EOT
+    Prefix IRSA-bundled IAM policy names with the cluster name to make them
+    cluster-scoped instead of account-scoped.
+
+    Background: the upstream `terraform-aws-modules/iam-role-for-service-accounts`
+    submodule hardcodes canonical IAM policy names when `policy_name` is not
+    overridden — `External_Secrets`, `External_DNS`, `Cert_Manager`, `Velero`,
+    `EBS_CSI`, `AWS_Load_Balancer_Controller`. IAM policies are account-scoped,
+    so a second cluster in the same AWS account that enables the same IRSA
+    bundles fails on `EntityAlreadyExists` at apply time (a real failure mode
+    observed when bringing up HML alongside PRD).
+
+    When this flag is `true`, each IRSA policy this module creates is named
+    `$${cluster_name}-<Canonical>` (e.g. `eks-cortex-platform-hml-us-east-1-External_Secrets`).
+    Names stay under IAM's 128-char policy-name cap with the longest CAF
+    cluster name.
+
+    DEFAULT IS `false` to preserve backward compatibility with existing
+    clusters that already own the unprefixed policy names. Set to `true` on
+    NEW clusters being brought up alongside an existing cluster in the same
+    AWS account. Do NOT flip on an existing cluster without first detaching
+    + reattaching policies — Terraform would delete-then-create, briefly
+    revoking pod permissions.
+
+    See CONTRIBUTING.md "IRSA module convention" for the rule applied to all
+    six built-in IRSA bundles in this module.
+  EOT
+  type        = bool
+  default     = false
+}
+
 variable "eks_access_entries" {
   description = "List of EKS Access Entry definitions (AWS best practice, replaces aws-auth ConfigMap). Each entry binds an IAM principal to an EKS access policy."
   type = list(object({


### PR DESCRIPTION
## Summary

Adds `var.iam_policy_name_use_cluster_prefix` (default `false`) that opts-in to cluster-prefixed IAM policy names across all 6 IRSA bundles. Solves `EntityAlreadyExists` failures when a second EKS cluster lands in the same AWS account that already runs the canonical IRSA policy names.

| Module | Canonical (default) | Prefixed (`true`) |
|--------|---------------------|-------------------|
| `external_secrets_irsa` | `External_Secrets` | `${cluster_name}-External_Secrets` |
| `external_dns_irsa`     | `External_DNS`     | `${cluster_name}-External_DNS` |
| `cert_manager_irsa`     | `Cert_Manager`     | `${cluster_name}-Cert_Manager` |
| `velero_irsa`           | `Velero`           | `${cluster_name}-Velero` |
| `ebs_csi_irsa`          | `EBS_CSI`          | `${cluster_name}-EBS_CSI` |
| `alb_controller_irsa`   | `AWS_Load_Balancer_Controller` | `${cluster_name}-AWS_Load_Balancer_Controller` |

## Why

Upstream `terraform-aws-modules/iam-role-for-service-accounts` hardcodes the canonical IAM policy name when `policy_name` is left unset (see the `try(coalesce(...))` cascade in the submodule). IAM policies are account-scoped, so a second cluster bringing up the same IRSA bundles fails at apply with `EntityAlreadyExists`.

Hit this on 2026-05-13 bringing up `cortex-platform-aws-us-east-1-hml` next to live PRD in shared account `093996075120` — 4 of 6 policies collided.

## Behavior

- **Default `false`** — zero-impact for existing clusters. No plan diff. Policies keep their current canonical names.
- **Set `true` on new clusters** in shared accounts. Each policy gets the `${cluster_name}-` prefix.
- **Do NOT flip on a running cluster** — Terraform plans delete-then-create on the policy resource, briefly revoking pod permissions.

## Convention going forward

New file `CONTRIBUTING.md` at repo root with an "IRSA module convention" section: every new IRSA module added to `providers/aws/` MUST set
```hcl
policy_name = var.iam_policy_name_use_cluster_prefix ? "${local.cluster_name}-<Canonical>" : null
```
so the same trap doesn't surface every time we wire a new upstream IRSA helper.

## Files changed

- `providers/aws/variables.tf` — new variable, heredoc with usage + irreversibility warning
- `providers/aws/iam.tf` — `policy_name` line in 4 IRSA modules
- `providers/aws/eks.tf` — `policy_name` line in `ebs_csi_irsa`
- `providers/aws/alb-controller.tf` — `policy_name` line in `alb_controller_irsa`
- `providers/aws/terraform.tfvars.example` — documents the new tfvar
- `CONTRIBUTING.md` — new file, IRSA convention + release process notes
- `CHANGELOG.md` — `[Unreleased]` entry

## Test plan

- [x] `terraform fmt -recursive` clean
- [x] `terraform validate` passes
- [x] All pre-commit hooks pass (fmt, validate, tflint, detect-secrets, etc.)
- [x] `policy_name = null` in the `false` branch verified to fall through to the submodule's existing `coalesce` cascade → identical behavior to today for running clusters
- [ ] Post-merge: release `v0.52.0` via direct-pushed `chore(release): v0.52.0` commit
- [ ] Downstream: bump `cortex-platform-hml` `main.tf` ref to `v0.52.0` + set `iam_policy_name_use_cluster_prefix = true` in tfvars → `terraform plan` → apply