### PR TITLE
feat(grafana-stack): Tempo S3 backend on AWS (MINOR)

### DIFF
--- a/bootstrap/platform-root/templates/grafana-stack.yaml
+++ b/bootstrap/platform-root/templates/grafana-stack.yaml
@@ -316,6 +316,17 @@ spec:
           {{- include "platform-root.schedulingValuesTopLevel" (dict
                 "mode" (default "auto" (index .Values.scheduling "tempo"))
              ) | nindent 10 }}
+        {{- if eq .Values.global.provider "aws" }}
+        parameters:
+          - name: tempo.storage.trace.s3.bucket
+            value: "{{ .Values.global.observabilityBucketName }}"
+          - name: tempo.storage.trace.s3.endpoint
+            value: "s3.{{ .Values.global.region }}.amazonaws.com"
+          - name: tempo.storage.trace.s3.region
+            value: "{{ .Values.global.region }}"
+          - name: serviceAccount.annotations.eks\.amazonaws\.com/role-arn
+            value: "{{ .Values.identity.tempo.roleArn }}"
+        {{- end }}
     - repoURL: {{ .Values.platformRepoUrl }}
       targetRevision: {{ .Values.platformVersion }}
       ref: values

--- a/core/components/grafana-stack/tempo-values-aws.yaml
+++ b/core/components/grafana-stack/tempo-values-aws.yaml
@@ -1,0 +1,40 @@
+# AWS-specific Tempo values
+# Loaded in addition to tempo-values.yaml when provider=aws.
+#
+# Wiring (injected via helm.parameters from platform-root grafana-stack.yaml
+# template's AWS branch):
+#   - tempo.storage.trace.s3.bucket    → global.observabilityBucketName
+#   - tempo.storage.trace.s3.endpoint  → s3.{region}.amazonaws.com
+#   - tempo.storage.trace.s3.region    → global.region
+#   - serviceAccount.annotations.eks.amazonaws.com/role-arn → identity.tempo.roleArn
+#
+# IAM: aws_iam_role.tempo has s3:{Get,Put,Delete,List}Object on the
+# observability bucket — matches the convention loki + mimir established
+# in v0.19.0 (bucket-wide access, shared bucket).
+#
+# Storage layout in the shared observability bucket:
+#   loki:  fake/, index/  (no global prefix support in chart 6.54)
+#   mimir: blocks/, ruler/, alertmanager/
+#   tempo: single-tenant/ (Tempo's hardcoded multi-tenancy root when
+#          multitenancy_enabled=false)
+#
+# WAL stays on the local PVC; only immutable blocks ship to S3. Tempo 2.x
+# always writes WAL locally regardless of backend choice. After this
+# change the PVC's growth bound is WAL turnover (observed: <10Mi),
+# not retention — so the 4Gi PVC from tempo-values.yaml is conservative.
+
+tempo:
+  storage:
+    trace:
+      backend: s3
+      s3:
+        bucket: ""        # injected
+        endpoint: ""      # injected — s3.{region}.amazonaws.com
+        region: ""        # injected
+        insecure: false
+
+serviceAccount:
+  create: true
+  name: grafana-tempo
+  annotations:
+    eks.amazonaws.com/role-arn: ""   # injected

--- a/providers/aws/iam.tf
+++ b/providers/aws/iam.tf
@@ -279,6 +279,78 @@ resource "aws_iam_role_policy" "mimir_s3" {
   policy = data.aws_iam_policy_document.mimir_s3.json
 }
 
+# ========================== tempo =========================================
+# Tempo's S3 backend uses the thanos-io/objstore client, which picks up
+# IRSA credentials via the AWS SDK default chain (AWS_ROLE_ARN +
+# AWS_WEB_IDENTITY_TOKEN_FILE injected by the EKS pod-identity webhook
+# when the SA carries the role-arn annotation). No static keys needed.
+
+data "aws_iam_policy_document" "tempo_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [module.eks.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:grafana:grafana-tempo"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "tempo_s3" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+    # See comment on loki_s3 — bucket-wide access, shared with loki + mimir.
+    # Each component lands at its own top-level prefix (loki: fake/, mimir:
+    # blocks/+ruler/+alertmanager/, tempo: single-tenant/).
+    resources = [
+      aws_s3_bucket.observability.arn,
+      "${aws_s3_bucket.observability.arn}/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+      "kms:DescribeKey",
+    ]
+    resources = [aws_kms_key.s3_data.arn]
+  }
+}
+
+resource "aws_iam_role" "tempo" {
+  name               = "${local.cluster_name}-tempo"
+  assume_role_policy = data.aws_iam_policy_document.tempo_trust.json
+}
+
+resource "aws_iam_role_policy" "tempo_s3" {
+  name   = "${local.cluster_name}-tempo-s3"
+  role   = aws_iam_role.tempo.id
+  policy = data.aws_iam_policy_document.tempo_s3.json
+}
+
 # ========================== cnpg (CloudNativePG) ==========================
 # Even though database infra is out of scope for Phase 1, CNPG runs inside
 # the cluster and backs up to S3. The IRSA role is provisioned so the

--- a/providers/aws/platform-outputs.tf
+++ b/providers/aws/platform-outputs.tf
@@ -192,6 +192,7 @@ resource "kubernetes_secret_v1" "platform_infrastructure" {
     "identity.externalSecrets.roleArn"  = module.external_secrets_irsa.arn
     "identity.loki.roleArn"             = aws_iam_role.loki.arn
     "identity.mimir.roleArn"            = aws_iam_role.mimir.arn
+    "identity.tempo.roleArn"            = aws_iam_role.tempo.arn
     "identity.cnpg.roleArn"             = aws_iam_role.cnpg.arn
     "identity.velero.roleArn"           = module.velero_irsa.arn
     "identity.albController.roleArn"    = var.ingress_controller == "alb" ? module.alb_controller_irsa[0].arn : ""


### PR DESCRIPTION
## Summary

- Closes the last gap in the grafana-stack object-storage migration started in v0.19.0 (loki + mimir): **Tempo now uses S3** on AWS, via IRSA against the shared observability bucket.
- New \`core/components/grafana-stack/tempo-values-aws.yaml\` mirroring \`mimir-values-aws.yaml\` / \`loki-values-aws.yaml\`. Bucket / endpoint / region / role-arn injected via \`helm.parameters\` from \`grafana-stack.yaml\`.
- New raw \`aws_iam_role.tempo\` + inline \`tempo_s3\` policy in \`providers/aws/iam.tf\`, modeled exactly after \`aws_iam_role.mimir\`. Bucket-wide access matches the loki/mimir convention.

## Motivation

The Tempo chart 1.24.4 defaults to \`storage.trace.backend: local\`. On Cortex prd this produced a 4Gi PVC that hit 88.86% capacity at 720h retention (\`PvcAlmostFull\` alert on \`storage-grafana-tempo-0\`, 2026-05-14). Mimir and Loki already write to the shared observability bucket; Tempo was the only grafana-stack component still on local storage.

After this change, the PVC only carries the WAL (<10Mi steady-state observed); immutable blocks ship to S3. 30d retention becomes essentially free.

## What changes

| Path | Change |
|------|--------|
| \`core/components/grafana-stack/tempo-values-aws.yaml\` | **new** — s3 backend with placeholders, IRSA-annotated SA |
| \`bootstrap/platform-root/templates/grafana-stack.yaml\` | +11 lines — \`parameters:\` block under tempo App AWS branch |
| \`providers/aws/iam.tf\` | +72 lines — \`tempo_trust\` + \`tempo_s3\` data + role + role_policy |
| \`providers/aws/platform-outputs.tf\` | +1 line — exposes \`identity.tempo.roleArn\` |

Total: **+124 / -0**. No existing behavior changed; no rename; provider conditional gates everything to \`global.provider == \"aws\"\`.

## Notes

- **IRSA convention**: Tempo follows the same raw-resource pattern as mimir/loki (not the upstream submodule path that \`CONTRIBUTING.md\` governs). The inline \`aws_iam_role_policy\` is role-scoped, so the policy-name collision pitfall does not apply.
- **Credentials**: Tempo 2.9's S3 backend uses the thanos-io/objstore client → AWS SDK default chain picks up \`AWS_ROLE_ARN\` + \`AWS_WEB_IDENTITY_TOKEN_FILE\` injected by the EKS pod-identity webhook. No static keys.
- **Bucket lifecycle**: \`var.s3_observability_lifecycle_days\` should be \`>= tempo.retention\` (default 720h = 30d) to avoid S3 expiring blocks before Tempo's compactor does. Already true for clusters running the default (lifecycle disabled).
- **PVC sizing**: Kept at 4Gi for now (conservative — was sized for traces, now only carries WAL). Shrinking to e.g. 512Mi is a clean follow-up that doesn't belong in this PR.
- **Stranded blocks**: After the backend flip, existing \`/var/tempo/traces/*\` blocks on each cluster's PVC are no longer referenced. They'll persist until the PVC is recreated or the path manually cleared — not load-bearing, just wasted disk until then.
- **Azure**: Unaffected — \`{{- if eq .Values.global.provider \"aws\" }}\` only. Equivalent Azure wiring is a separate PR.

## Validation

- \`helm template\` of \`bootstrap/platform-root\` renders the tempo Argo Application with the expected \`parameters:\` block (bucket / endpoint / region / role-arn).
- \`helm template\` of \`grafana/tempo:1.24.4\` with the two values files + simulated \`parameters\` produces a ConfigMap whose \`storage.trace\` carries:
  \`\`\`yaml
  backend: s3
  s3:
    bucket: <bucket>
    endpoint: s3.<region>.amazonaws.com
    insecure: false
    region: <region>
  wal:
    path: /var/tempo/wal
  \`\`\`
  and a ServiceAccount annotated with \`eks.amazonaws.com/role-arn\`.
- \`terraform fmt -check -recursive\` on touched files: clean.

## Test plan

- [ ] Bump downstream cortex-platform-aws-us-east-1-prd to this MINOR
- [ ] \`terraform apply\` creates \`<cluster>-tempo\` IAM role + inline policy
- [ ] ArgoCD syncs grafana-tempo with new parameters
- [ ] Tempo pod restarts, ConfigMap shows \`backend: s3\`
- [ ] Verify object writes under \`single-tenant/\` prefix in the observability bucket
- [ ] \`PvcAlmostFull\` alert clears as PVC usage drops to WAL-only (<100Mi)
- [ ] Grafana → Explore → Traces still returns historical traces (last hour, last day) — confirms read path works
- [ ] \`tempo_distributor_bytes_received_total\` continues advancing — confirms ingest path unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)