### PR TITLE
fix(aws): expose tempo_role_arn output (PATCH)

### DIFF
--- a/providers/aws/outputs.tf
+++ b/providers/aws/outputs.tf
@@ -172,6 +172,11 @@ output "mimir_role_arn" {
   value       = aws_iam_role.mimir.arn
 }
 
+output "tempo_role_arn" {
+  description = "IAM role ARN for Tempo ServiceAccount."
+  value       = aws_iam_role.tempo.arn
+}
+
 output "velero_role_arn" {
   description = "IAM role ARN for Velero ServiceAccount."
   value       = module.velero_irsa.arn


### PR DESCRIPTION
## Summary

- One-block addition to `providers/aws/outputs.tf`: `output "tempo_role_arn"` mirroring `loki_role_arn` / `mimir_role_arn`.
- **Fixes a regression introduced in v0.53.0** that breaks `helm template` on the platform-root chart for clusters re-rendering platform-root from terraform outputs (cortex's `scripts/platform-root-apply.sh` flow).

## What broke

v0.53.0 added `aws_iam_role.tempo` and wired `identity.tempo.roleArn` into the platform-infrastructure Secret (so in-cluster consumers see the role ARN), AND added a `{{ .Values.identity.tempo.roleArn }}` reference to the platform-root grafana-stack template. But it **forgot to expose the IAM role ARN as a terraform output**, so downstream consumers reading `terraform output tempo_role_arn` get an empty string.

The cortex deploy script (`platform-root-apply.sh`) feeds `--set identity.tempo.roleArn=$TEMPO_ROLE_ARN` from `tfout tempo_role_arn`. With the output missing, the `--set` is dropped, and `helm template` blows up:

\`\`\`
template: platform-root/templates/grafana-stack.yaml:328:30:
executing "..." at <.Values.identity.tempo.roleArn>:
nil pointer evaluating interface {}.roleArn
\`\`\`

Result on cortex-eks-prd 2026-05-15: platform-root Application stuck in `ComparisonError`, blocking all ArgoCD reconciliation cluster-wide.

## What this PR does

\`\`\`hcl
output "tempo_role_arn" {
  description = "IAM role ARN for Tempo ServiceAccount."
  value       = aws_iam_role.tempo.arn
}
\`\`\`

That's it. **+5 / -0.**

## Why this wasn't caught in #165

The PR added the resource, the Secret entry, and the template reference, but treated outputs.tf as out-of-scope (assumed in-cluster Secret was the only consumer). Clusters using the `estabilis promote` CLI (or other helm-render-from-cluster-state paths) hit this same gap; cortex hit it first because it uses a script-based promote pattern.

Worth adding to CONTRIBUTING.md: **when adding a new IRSA role, the canonical 4 places to wire are**:
1. `iam.tf` — `aws_iam_role.<name>` + inline policy
2. `platform-outputs.tf` — `identity.<name>.roleArn` in the platform-infrastructure Secret
3. **`outputs.tf` — terraform `output "<name>_role_arn"`** ← this PR
4. The component's `*-values-aws.yaml` + `grafana-stack.yaml` (or equivalent) — SA annotation reference

Will follow up with a CONTRIBUTING.md note once this regression is buried.

## Test plan

- [ ] `terraform output tempo_role_arn` returns the role ARN on cortex-eks-prd (or any v0.53.x consumer) after picking up v0.53.1.
- [ ] `helm template` of platform-root with `--set identity.tempo.roleArn=<arn>` renders cleanly.
- [ ] Cortex `scripts/platform-root-apply.sh` (after corresponding downstream fix wires `TEMPO_ROLE_ARN`) renders the grafana-tempo Application with the correct annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)