### PR TITLE
fix(platform-root): wrap tolerations/parameters emission in conditional guards

### DIFF
--- a/bootstrap/platform-root/templates/_helpers.tpl
+++ b/bootstrap/platform-root/templates/_helpers.tpl
@@ -361,8 +361,10 @@ nodeAffinity:
 {{- $affinity := include "platform-root.schedulingAffinity" (dict "mode" $mode) -}}
 {{- range $comp := .paths }}
 {{ $comp }}:
+  {{- if $tolerations | trim }}
   tolerations:
     {{- $tolerations | nindent 4 }}
+  {{- end }}
   affinity:
     {{- $affinity | nindent 4 }}
 {{- end -}}
@@ -377,8 +379,11 @@ nodeAffinity:
 */ -}}
 {{- define "platform-root.schedulingValuesTopLevel" -}}
 {{- $mode := default "auto" .mode -}}
+{{- $tolerations := include "platform-root.schedulingTolerations" . -}}
+{{- if $tolerations | trim }}
 tolerations:
-  {{- include "platform-root.schedulingTolerations" . | nindent 2 }}
+  {{- $tolerations | nindent 2 }}
+{{- end }}
 affinity:
   {{- include "platform-root.schedulingAffinity" (dict "mode" $mode) | nindent 2 }}
 {{- end -}}
@@ -388,8 +393,11 @@ affinity:
   not applicable (DS always deploys to all nodes matching node selector).
 */ -}}
 {{- define "platform-root.schedulingTolerationsOnly" -}}
+{{- $tolerations := include "platform-root.schedulingTolerations" . -}}
+{{- if $tolerations | trim }}
 tolerations:
-  {{- include "platform-root.schedulingTolerations" . | nindent 2 }}
+  {{- $tolerations | nindent 2 }}
+{{- end }}
 {{- end -}}
 
 {{- /*

--- a/bootstrap/platform-root/templates/kyverno.yaml
+++ b/bootstrap/platform-root/templates/kyverno.yaml
@@ -26,15 +26,20 @@ spec:
                 "mode" $mode
                 "paths" (list "admissionController" "backgroundController" "cleanupController" "reportsController")
                 "provider" .Values.global.provider) | nindent 10 }}
+          {{- $kyvernoTolerations := include "platform-root.schedulingTolerations" (dict "provider" .Values.global.provider) }}
           crds:
             migration:
+              {{- if $kyvernoTolerations | trim }}
               tolerations:
-                {{- include "platform-root.schedulingTolerations" (dict "provider" .Values.global.provider) | nindent 16 }}
+                {{- $kyvernoTolerations | nindent 16 }}
+              {{- end }}
               affinity:
                 {{- include "platform-root.schedulingAffinity" (dict "mode" $mode) | nindent 16 }}
           webhooksCleanup:
+            {{- if $kyvernoTolerations | trim }}
             tolerations:
-              {{- include "platform-root.schedulingTolerations" (dict "provider" .Values.global.provider) | nindent 14 }}
+              {{- $kyvernoTolerations | nindent 14 }}
+            {{- end }}
             affinity:
               {{- include "platform-root.schedulingAffinity" (dict "mode" $mode) | nindent 14 }}
         {{- include "platform-root.provenanceParametersBlock" $ | nindent 8 }}

--- a/bootstrap/platform-root/templates/network-policies.yaml
+++ b/bootstrap/platform-root/templates/network-policies.yaml
@@ -34,8 +34,7 @@ spec:
               `platform-root.componentsForwarding` in _helpers.tpl. */}}
         valuesObject:
           {{- include "platform-root.componentsForwarding" . | nindent 10 }}
-        parameters:
-          {{- include "platform-root.provenanceParameters" $ | nindent 10 }}
+        {{- include "platform-root.provenanceParametersBlock" $ | nindent 8 }}
     - repoURL: {{ .Values.platformGitopsRepoUrl }}
       targetRevision: {{ .Values.platformGitopsVersion }}
       ref: values

--- a/bootstrap/platform-root/templates/opencost.yaml
+++ b/bootstrap/platform-root/templates/opencost.yaml
@@ -55,15 +55,15 @@ spec:
                 "paths" (list "opencost")
              "provider" .Values.global.provider
              ) | nindent 10 }}
+        {{- if eq .Values.global.provider "azure" }}
         parameters:
-          {{- if eq .Values.global.provider "azure" }}
           - name: opencost.exporter.extraEnv.AZURE_SUBSCRIPTION_ID
             value: "{{ .Values.global.subscriptionId }}"
           - name: opencost.exporter.extraEnv.AZURE_TENANT_ID
             value: "{{ .Values.global.tenantId }}"
           - name: opencost.exporter.extraEnv.AZURE_OFFER_ID
             value: "{{ .Values.global.azureOfferId }}"
-          {{- end }}
+        {{- end }}
     - repoURL: {{ .Values.platformRepoUrl }}
       targetRevision: {{ .Values.platformVersion }}
       ref: values

--- a/bootstrap/platform-root/templates/resource-quotas.yaml
+++ b/bootstrap/platform-root/templates/resource-quotas.yaml
@@ -34,8 +34,7 @@ spec:
               `platform-root.componentsForwarding` in _helpers.tpl. */}}
         valuesObject:
           {{- include "platform-root.componentsForwarding" . | nindent 10 }}
-        parameters:
-          {{- include "platform-root.provenanceParameters" $ | nindent 10 }}
+        {{- include "platform-root.provenanceParametersBlock" $ | nindent 8 }}
     - repoURL: {{ .Values.platformGitopsRepoUrl }}
       targetRevision: {{ .Values.platformGitopsVersion }}
       ref: values


### PR DESCRIPTION
## Summary

- Three helpers in `_helpers.tpl` (`schedulingValuesFor`, `schedulingValuesTopLevel`, `schedulingTolerationsOnly`) and two direct usages in `kyverno.yaml` emitted `tolerations:` unconditionally. When the include returns empty (AWS provider — Azure spot toleration N/A), the rendered YAML became `tolerations:` with no value, parsed as `tolerations: null`.
- K8s API server normalizes `tolerations: null` → field absent. ArgoCD re-renders, sees `null`, compares to cluster (absent), reports **OutOfSync forever**. Functionally harmless (no tolerations = scheduling everywhere) but blocks auto-sync (infinite drift loop) and pollutes audit dashboards.
- Same pattern fixed for `parameters:` emission in `network-policies.yaml`, `resource-quotas.yaml`, and `opencost.yaml`.

## Fix

- Helpers + kyverno direct usages: wrap each emission in `{{- if $value | trim }}` guard.
- `network-policies.yaml` / `resource-quotas.yaml`: replace unguarded `parameters: + provenanceParameters include` with the already-guarded `provenanceParametersBlock` helper.
- `opencost.yaml`: hoist the existing `if eq provider azure` guard up one level so it also wraps the `parameters:` key.

## Validation

Rendered with `helm template` against minimum-required values for both providers:

| Provider | Before                                    | After                                  |
|---       |---                                        |---                                     |
| AWS      | 53 `tolerations: null` + 3 `parameters: null` | 0 / 0                              |
| Azure    | (Azure spot toleration emitted as expected) | 0 / 0 + 48 `kubernetes.azure.com/scalesetpriority` still emitted |

- `helm lint` passes for both providers.
- YAML parses cleanly (48 docs / 41 Applications on AWS; 42 docs / 35 Applications on Azure).
- `diff` of before/after AWS render shows ONLY removed `tolerations:` / `parameters:` bare lines and adjacent whitespace.

## Test plan

- [x] AWS render: 0 `tolerations: null`, 0 `parameters: null`
- [x] Azure render: spot toleration still emitted on all 48 expected paths; 0 nulls
- [x] `helm lint` passes for both providers
- [x] YAML parses (`yaml.safe_load_all`) for both providers
- [x] Diff vs main contains only the targeted removals (no functional change)
- [ ] On merge: bump VERSION to v0.53.2 + CHANGELOG.md + direct-push `chore(release): v0.53.2` to main (auto-tag workflow picks it up)
- [ ] Downstream client repos can bump `ref=v0.53.2` after the Release page is published

Refs ADR 0012 (scheduling modes and pool selection).