### PR TITLE
fix(platform-root): guard null emissions on node-exporter + trivy-operator

### DIFF
--- a/bootstrap/platform-root/templates/node-exporter.yaml
+++ b/bootstrap/platform-root/templates/node-exporter.yaml
@@ -20,9 +20,15 @@ spec:
           {{- include "platform-root.overrideValueFile" (dict "component" "node-exporter" "root" $) | nindent 10 }}
           {{- include "platform-root.gitopsValueFile" (dict "component" "node-exporter" "root" $) | nindent 10 }}
         ignoreMissingValueFiles: true
+        {{- /* Scheduling (ADR 0012 — issue #97). DaemonSet: tolerations only.
+              valuesObject is only emitted when the provider actually contributes
+              a toleration; otherwise the chart would render `valuesObject: null`
+              and produce permanent OutOfSync drift (see v0.53.2 fix). */}}
+        {{- $nodeExporterTolerations := include "platform-root.schedulingTolerationsOnly" (dict "provider" .Values.global.provider) }}
+        {{- if $nodeExporterTolerations | trim }}
         valuesObject:
-          {{- /* Scheduling (ADR 0012 — issue #97). DaemonSet: tolerations only. */}}
-          {{- include "platform-root.schedulingTolerationsOnly" (dict "provider" .Values.global.provider) | nindent 10 }}
+          {{- $nodeExporterTolerations | nindent 10 }}
+        {{- end }}
         {{- include "platform-root.provenanceParametersBlock" $ | nindent 8 }}
     - repoURL: {{ .Values.platformGitopsRepoUrl }}
       targetRevision: {{ .Values.platformGitopsVersion }}

--- a/bootstrap/platform-root/templates/trivy-operator.yaml
+++ b/bootstrap/platform-root/templates/trivy-operator.yaml
@@ -29,9 +29,12 @@ spec:
           {{- include "platform-root.schedulingValuesTopLevel" (dict
                 "mode" $mode
                 "provider" .Values.global.provider) | nindent 10 }}
+          {{- $trivyScanTolerations := include "platform-root.schedulingTolerations" (dict "provider" .Values.global.provider) }}
           trivy:
+            {{- if $trivyScanTolerations | trim }}
             scanJobTolerations:
-              {{- include "platform-root.schedulingTolerations" (dict "provider" .Values.global.provider) | nindent 14 }}
+              {{- $trivyScanTolerations | nindent 14 }}
+            {{- end }}
             scanJobAffinity:
               {{- include "platform-root.schedulingAffinity" (dict "mode" $mode) | nindent 14 }}
     - repoURL: {{ .Values.platformRepoUrl }}


### PR DESCRIPTION
## Summary

Follow-up to v0.53.2 (PR #167) — the audit on AWS render caught two outer-level null cases the previous fix missed:

- `node-exporter.yaml` emitted bare `valuesObject:` followed by the now-guarded `schedulingTolerationsOnly` include. On AWS the include returns empty → `valuesObject: null` → ArgoCD permanent OutOfSync.
- `trivy-operator.yaml` emitted bare `scanJobTolerations:` directly from `schedulingTolerations`, same pattern as the kyverno direct usages fixed in v0.53.2.

## Fix

- **node-exporter**: hoist toleration include into `$nodeExporterTolerations`, wrap the whole `valuesObject:` key in `{{- if $... | trim }}` guard. valuesObject is only emitted when the provider actually contributes a toleration.
- **trivy-operator**: same `{{- if $trivyScanTolerations | trim }}` guard around `scanJobTolerations:`. `scanJobAffinity:` stays unguarded because `schedulingAffinity` always returns content.

## Validation

| Render | After v0.53.2 | After this PR |
|---|---|---|
| AWS — all null-valued keys | 2 (valuesObject@node-exporter, scanJobTolerations@trivy-operator) | **0** |
| Azure — all null-valued keys | 0 | 0 |
| Azure — spot toleration count | 48 | 48 (including `scanJobTolerations` on trivy) |

- `helm lint` passes for both providers.
- Full audit via `yaml.safe_load_all` shows zero null-valued keys ANYWHERE in either provider's rendered manifest set.

## Test plan

- [x] AWS render: zero null-valued keys
- [x] Azure render: zero null-valued keys; spot toleration still emitted on `scanJobTolerations` + 47 other paths
- [x] `helm lint` passes both providers
- [ ] On merge: bump VERSION to v0.53.3 + CHANGELOG.md + direct-push `chore(release): v0.53.3` to main

Refs ADR 0012, v0.53.2 (#167).