### PR TITLE
feat(aws): Terraform-managed ALB Controller webhook TLS (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [0.54.0] - 2026-05-18
+
+### Added — Terraform-managed ALB Controller webhook TLS (opt-in)
+
+New tfvar `alb_controller_webhook_tls_managed_by` (default `"chart"`, opt-in `"terraform"`) controls how the aws-load-balancer-controller webhook TLS cert is provisioned.
+
+**Why.** The `eks-charts/aws-load-balancer-controller` chart auto-generates the webhook TLS cert via the Helm `genSignedCert` helper. The helper is non-deterministic — each render produces a new cert. Combined with the chart's Deployment template lacking a `checksum/secret` annotation, this creates a race: after a re-sync, the chart updates the Secret + the MutatingWebhookConfiguration CABundle, but the ALB Controller pods keep serving the previous cert from memory. The API server validates the webhook against the new CABundle while the pod responds with the old cert, producing `x509: certificate signed by unknown authority` errors that block every Service creation in the cluster.
+
+Observed in production during bootstrap of `eks-cortex-platform-hml-us-east-1` on 2026-05-15. Manual workaround: `kubectl rollout restart deployment/aws-load-balancer-controller -n aws-load-balancer-controller`.
+
+**Fix.** When `alb_controller_webhook_tls_managed_by = "terraform"`, the module generates a stable CA (10-year validity) and webhook cert (5-year validity) via the `tls` provider, then passes them to the chart through `webhookTLS.{caCert,cert,key}` helm values. The chart's `webhookCerts` helper takes the operator-provided values branch and skips `genSignedCert` entirely — no regen on re-renders, no race.
+
+**Backward compat.** Default remains `"chart"` (existing behavior). Existing deployments stay unchanged unless the operator explicitly opts in. Default render is byte-identical to v0.53.3 for any cluster that doesn't set the new tfvar.
+
+### Migration path for existing deployments
+
+> **Brief migration window — plan for ~30s of webhook errors.** Between step 4 (ArgoCD syncs the chart re-render that now carries the TF-provided cert) and step 5 (rollout restart loads the new cert into pod memory), the cluster has the new CABundle on the webhook config but the old cert in the running pods. Service creations in that window will fail with `x509: certificate signed by unknown authority` until the rollout completes. Run steps 4–5 back-to-back. After this one-time migration, the feature eliminates the race permanently.
+
+Per-deployment, when ready:
+
+1. Edit `terraform.tfvars`: add `alb_controller_webhook_tls_managed_by = "terraform"`.
+2. `terraform apply` — creates 4 new TLS resources and populates 3 new keys (`albControllerWebhookTLS.{caCert,cert,key}`) on Secret `platform-infrastructure-sensitive`.
+3. `estabilis promote` (or manual re-resolve+apply of platform-root) so ArgoCD picks up the new `helm.parameters`.
+4. Watch ArgoCD reconcile the ALB Controller Application — when the chart re-renders, the rendered Secret `aws-load-balancer-tls` and webhook `caBundle` carry the new TF-provided values. With `webhookTLS` set, the Application drops the `ignoreDifferences` entries that previously blocked these fields, so ArgoCD pushes them to the cluster.
+5. Immediately run `kubectl rollout restart deployment/aws-load-balancer-controller -n aws-load-balancer-controller` to load the new cert into the running pods.
+6. Verify with `kubectl get pod -n aws-load-balancer-controller` (all `1/1 Ready`) and a sanity `kubectl create service clusterip dummy --tcp=80:80` in a temp namespace — should succeed without webhook errors.
+
+For **fresh clusters** bootstrapped with `alb_controller_webhook_tls_managed_by = "terraform"` from the start, there is no migration window — the TF cert is in place before pods come up.
+
+### Files changed
+
+- `providers/aws/alb-controller-webhook-tls.tf` — NEW, conditional CA + webhook cert resources gated on the new tfvar.
+- `providers/aws/variables.tf` — declared `alb_controller_webhook_tls_managed_by` with detailed description + validation.
+- `providers/aws/platform-outputs.tf` — conditional injection of `albControllerWebhookTLS.*` keys into `platform-infrastructure-sensitive`.
+- `bootstrap/platform-root/templates/aws-load-balancer-controller.yaml` — conditional `webhookTLS` block in `valuesObject` when keys are present.
+- `providers/aws/terraform.tfvars.example` — documented opt-in syntax.
+
+### Out-of-scope (future work — separate ADR)
+
+Migration to `cert-manager.io/Certificate` with cert-manager CAInjector. That removes the manual rotation but requires wave reordering (cert-manager must run before ALB Controller; today it runs after).
+
 ## [0.53.12] - 2026-05-18
 
 ### Fixed

--- a/bootstrap/platform-root/templates/aws-load-balancer-controller.yaml
+++ b/bootstrap/platform-root/templates/aws-load-balancer-controller.yaml
@@ -55,6 +55,22 @@ spec:
                 "mode" (default "auto" (index .Values.scheduling "aws-load-balancer-controller"))
              "provider" .Values.global.provider
              ) | nindent 10 }}
+          {{- /* Terraform-managed webhook TLS (opt-in via tfvar
+                `alb_controller_webhook_tls_managed_by = "terraform"`).
+                When all three values are present the chart's
+                webhookCerts helper (see chart _helpers.tpl) skips its
+                genSignedCert path and uses these PEMs instead — same CA
+                across every render, no race with running pods. When the
+                tfvar stays at the default "chart", these values are
+                unset and the chart auto-generates as before. */}}
+          {{- with .Values.albControllerWebhookTLS }}
+          {{- if and .caCert .cert .key }}
+          webhookTLS:
+            caCert: |-{{ .caCert | nindent 14 }}
+            cert: |-{{ .cert | nindent 14 }}
+            key: |-{{ .key | nindent 14 }}
+          {{- end }}
+          {{- end }}
     - repoURL: {{ .Values.platformGitopsRepoUrl }}
       targetRevision: {{ .Values.platformGitopsVersion }}
       ref: values
@@ -63,12 +79,25 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: aws-load-balancer-controller
-  {{- /* Ignore drift on fields the chart's webhook self-signing logic
-        populates at install time (caBundle / TLS Secret data) and on
-        the IngressClassParams body which the chart leaves empty for the
-        operator to fill in. Without this, the App reports OutOfSync on
-        every reconcile despite the controller working correctly. */}}
+  {{- /* IngressClassParams /spec is always ignored — the chart leaves
+        the body empty for the operator to fill in.
+
+        The caBundle / TLS Secret data ignore entries are gated on the
+        chart auto-gen path. When `webhookTLS` is set via valuesObject
+        (TF-managed mode), the chart's webhookCerts helper produces the
+        same deterministic content every render, so the ignore entries
+        would actively block migration on existing clusters (ArgoCD
+        wouldn't push the new TF-provided cert to the live Secret /
+        webhook config). Dropping them in TF mode lets ArgoCD reconcile
+        the cert into the cluster as expected. */}}
   ignoreDifferences:
+    {{- $tfManagedTLS := false }}
+    {{- with .Values.albControllerWebhookTLS }}
+    {{- if and .caCert .cert .key }}
+    {{- $tfManagedTLS = true }}
+    {{- end }}
+    {{- end }}
+    {{- if not $tfManagedTLS }}
     - group: admissionregistration.k8s.io
       kind: MutatingWebhookConfiguration
       name: aws-load-balancer-webhook
@@ -84,6 +113,7 @@ spec:
       name: aws-load-balancer-tls
       jsonPointers:
         - /data
+    {{- end }}
     - group: elbv2.k8s.aws
       kind: IngressClassParams
       name: alb

--- a/providers/aws/alb-controller-webhook-tls.tf
+++ b/providers/aws/alb-controller-webhook-tls.tf
@@ -1,0 +1,106 @@
+# ============================================================================
+# ALB Controller webhook TLS — Terraform-managed (alternative to chart auto-gen)
+# ============================================================================
+#
+# When var.alb_controller_webhook_tls_managed_by = "terraform", these resources
+# generate a stable CA + webhook cert that the aws-load-balancer-controller
+# chart consumes via webhookTLS.{caCert,cert,key} values. This avoids the
+# race condition where the chart's `genSignedCert` helper produces a new cert
+# on every render, while ALB Controller pods keep serving the previous cert
+# from memory because the Deployment template lacks a `checksum/secret`
+# annotation. Symptom: `x509: certificate signed by unknown authority` blocks
+# every Service creation cluster-wide until pods are manually restarted.
+#
+# Gating:
+#   - var.ingress_controller = "alb"
+#   - var.alb_controller_webhook_tls_managed_by = "terraform"
+#   Both required — defaults keep the chart's auto-gen path in place.
+#
+# Lifecycle:
+#   - CA: 10 year validity. Rotation is operator-driven via
+#     `terraform taint tls_private_key.alb_controller_ca` + apply.
+#   - Webhook cert: 5 year validity. Same rotation path.
+#   Rotation is a manual maintenance window task — acceptable at this cadence.
+#
+# Out-of-scope (future work, separate ADR):
+#   - Migration to cert-manager.io/Certificate with cert-manager CAInjector.
+#     That eliminates the manual rotation but requires wave reordering
+#     (cert-manager must run before ALB Controller, currently it runs after).
+# ============================================================================
+
+locals {
+  alb_controller_webhook_tls_tf_managed = (
+    var.ingress_controller == "alb" &&
+    var.alb_controller_webhook_tls_managed_by == "terraform"
+  )
+}
+
+resource "tls_private_key" "alb_controller_ca" {
+  count = local.alb_controller_webhook_tls_tf_managed ? 1 : 0
+
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "tls_self_signed_cert" "alb_controller_ca" {
+  count = local.alb_controller_webhook_tls_tf_managed ? 1 : 0
+
+  private_key_pem = tls_private_key.alb_controller_ca[0].private_key_pem
+
+  subject {
+    common_name  = "estabilis-alb-controller-ca"
+    organization = "estabilis-platform"
+  }
+
+  validity_period_hours = 8760 * 10 # 10 years
+  is_ca_certificate     = true
+
+  allowed_uses = [
+    "digital_signature",
+    "cert_signing",
+    "crl_signing",
+  ]
+}
+
+resource "tls_private_key" "alb_controller_webhook" {
+  count = local.alb_controller_webhook_tls_tf_managed ? 1 : 0
+
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "tls_cert_request" "alb_controller_webhook" {
+  count = local.alb_controller_webhook_tls_tf_managed ? 1 : 0
+
+  private_key_pem = tls_private_key.alb_controller_webhook[0].private_key_pem
+
+  subject {
+    common_name = "aws-load-balancer-webhook-service.aws-load-balancer-controller.svc"
+  }
+
+  # SANs mirror the chart's webhookCerts helper (_helpers.tpl). Service short
+  # name + svc + svc.cluster.local form the canonical webhook URL set the
+  # API server tries when calling MutatingWebhookConfiguration.clientConfig.
+  dns_names = [
+    "aws-load-balancer-webhook-service",
+    "aws-load-balancer-webhook-service.aws-load-balancer-controller",
+    "aws-load-balancer-webhook-service.aws-load-balancer-controller.svc",
+    "aws-load-balancer-webhook-service.aws-load-balancer-controller.svc.cluster.local",
+  ]
+}
+
+resource "tls_locally_signed_cert" "alb_controller_webhook" {
+  count = local.alb_controller_webhook_tls_tf_managed ? 1 : 0
+
+  cert_request_pem   = tls_cert_request.alb_controller_webhook[0].cert_request_pem
+  ca_private_key_pem = tls_private_key.alb_controller_ca[0].private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.alb_controller_ca[0].cert_pem
+
+  validity_period_hours = 8760 * 5 # 5 years
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}

--- a/providers/aws/platform-outputs.tf
+++ b/providers/aws/platform-outputs.tf
@@ -177,40 +177,53 @@ resource "kubernetes_secret_v1" "platform_infrastructure" {
     }
   }
 
-  data = {
-    # Identity
-    "global.accountId" = data.aws_caller_identity.current.account_id
-    "global.region"    = var.region
+  data = merge(
+    {
+      # Identity
+      "global.accountId" = data.aws_caller_identity.current.account_id
+      "global.region"    = var.region
 
-    # Secrets Manager path prefix — ESO ClusterSecretStore scopes to this.
-    "global.secretsPathPrefix" = local.secrets_path_prefix
+      # Secrets Manager path prefix — ESO ClusterSecretStore scopes to this.
+      "global.secretsPathPrefix" = local.secrets_path_prefix
 
-    # IRSA role ARNs — consumed by ArgoCD Application parameters to annotate
-    # each ServiceAccount with eks.amazonaws.com/role-arn.
-    "identity.certManager.roleArn"      = var.dns_provider == "route53" ? module.cert_manager_irsa[0].arn : ""
-    "identity.externalDns.roleArn"      = var.dns_provider == "route53" ? module.external_dns_irsa[0].arn : ""
-    "identity.externalSecrets.roleArn"  = module.external_secrets_irsa.arn
-    "identity.loki.roleArn"             = aws_iam_role.loki.arn
-    "identity.mimir.roleArn"            = aws_iam_role.mimir.arn
-    "identity.tempo.roleArn"            = aws_iam_role.tempo.arn
-    "identity.cnpg.roleArn"             = aws_iam_role.cnpg.arn
-    "identity.velero.roleArn"           = module.velero_irsa.arn
-    "identity.albController.roleArn"    = var.ingress_controller == "alb" ? module.alb_controller_irsa[0].arn : ""
-    "identity.workloadOperator.roleArn" = var.shared_hub_secrets_enabled ? aws_iam_role.workload_operator[0].arn : ""
-    "identity.opencost.roleArn"         = var.cost_export_enabled ? aws_iam_role.opencost[0].arn : ""
+      # IRSA role ARNs — consumed by ArgoCD Application parameters to annotate
+      # each ServiceAccount with eks.amazonaws.com/role-arn.
+      "identity.certManager.roleArn"      = var.dns_provider == "route53" ? module.cert_manager_irsa[0].arn : ""
+      "identity.externalDns.roleArn"      = var.dns_provider == "route53" ? module.external_dns_irsa[0].arn : ""
+      "identity.externalSecrets.roleArn"  = module.external_secrets_irsa.arn
+      "identity.loki.roleArn"             = aws_iam_role.loki.arn
+      "identity.mimir.roleArn"            = aws_iam_role.mimir.arn
+      "identity.tempo.roleArn"            = aws_iam_role.tempo.arn
+      "identity.cnpg.roleArn"             = aws_iam_role.cnpg.arn
+      "identity.velero.roleArn"           = module.velero_irsa.arn
+      "identity.albController.roleArn"    = var.ingress_controller == "alb" ? module.alb_controller_irsa[0].arn : ""
+      "identity.workloadOperator.roleArn" = var.shared_hub_secrets_enabled ? aws_iam_role.workload_operator[0].arn : ""
+      "identity.opencost.roleArn"         = var.cost_export_enabled ? aws_iam_role.opencost[0].arn : ""
 
-    # Cloudflare API token — only populated when dns_provider = "cloudflare".
-    "global.cloudflareApiToken" = var.dns_provider == "cloudflare" ? var.cloudflare_api_token : ""
+      # Cloudflare API token — only populated when dns_provider = "cloudflare".
+      "global.cloudflareApiToken" = var.dns_provider == "cloudflare" ? var.cloudflare_api_token : ""
 
-    # Vault (v0.27.0+) — populated only when vault_enabled=true.
-    # vault.exposuresJson moved to ConfigMap as global.vaultExposures (ADR 0014
-    # convention; non-sensitive). The Secret keeps the identity + KMS key id
-    # which ARE sensitive.
-    "identity.vault.roleArn" = var.vault_enabled ? module.vault_irsa[0].arn : ""
-    "vault.kmsKeyId"         = var.vault_enabled ? aws_kms_key.vault[0].key_id : ""
-    "vault.kmsRegion"        = var.vault_enabled ? var.region : ""
-    "vault.backupBucketName" = var.vault_enabled ? aws_s3_bucket.vault_backup[0].id : ""
-  }
+      # Vault (v0.27.0+) — populated only when vault_enabled=true.
+      # vault.exposuresJson moved to ConfigMap as global.vaultExposures (ADR 0014
+      # convention; non-sensitive). The Secret keeps the identity + KMS key id
+      # which ARE sensitive.
+      "identity.vault.roleArn" = var.vault_enabled ? module.vault_irsa[0].arn : ""
+      "vault.kmsKeyId"         = var.vault_enabled ? aws_kms_key.vault[0].key_id : ""
+      "vault.kmsRegion"        = var.vault_enabled ? var.region : ""
+      "vault.backupBucketName" = var.vault_enabled ? aws_s3_bucket.vault_backup[0].id : ""
+    },
+    # ALB Controller webhook TLS — populated only when Terraform manages the
+    # cert (see alb-controller-webhook-tls.tf). Keys are intentionally absent
+    # when var.alb_controller_webhook_tls_managed_by = "chart" so the chart
+    # falls back to its built-in genSignedCert path. Dotted keys (literal `.`
+    # in the data field) become nested values at helm `--set` time:
+    # `.Values.albControllerWebhookTLS.{caCert,cert,key}` in platform-root.
+    local.alb_controller_webhook_tls_tf_managed ? {
+      "albControllerWebhookTLS.caCert" = tls_self_signed_cert.alb_controller_ca[0].cert_pem
+      "albControllerWebhookTLS.cert"   = tls_locally_signed_cert.alb_controller_webhook[0].cert_pem
+      "albControllerWebhookTLS.key"    = tls_private_key.alb_controller_webhook[0].private_key_pem
+    } : {},
+  )
 }
 
 # ---------------------------------------------------------------------------

--- a/providers/aws/terraform.tfvars.example
+++ b/providers/aws/terraform.tfvars.example
@@ -135,6 +135,16 @@ client_gitops_repo_revision = "main"
 # ingress_controller       = "none"          # traefik | alb | none
 # traefik_internal_enabled = false
 
+# --- ALB Controller webhook TLS (default: chart auto-generates) ---
+# Opt-in toggle: makes Terraform issue a stable CA + webhook cert and feed
+# them to the chart via webhookTLS.{caCert,cert,key}. Without this, the
+# eks-charts genSignedCert helper produces a new cert every render and
+# can race with running ALB Controller pods (cert mismatch blocks every
+# Service creation until kubectl rollout restart). See variables.tf for
+# the full tradeoff + migration steps for existing clusters.
+# alb_controller_webhook_tls_managed_by = "chart"      # default, backward-compatible
+# alb_controller_webhook_tls_managed_by = "terraform"  # opt-in, recommended for new clusters
+
 # acm_enabled            = false             # Wildcard cert for ALB termination
 # acm_extra_domain_names = []
 

--- a/providers/aws/variables.tf
+++ b/providers/aws/variables.tf
@@ -850,6 +850,41 @@ variable "traefik_internal_enabled" {
   default     = false
 }
 
+variable "alb_controller_webhook_tls_managed_by" {
+  description = <<-EOT
+    Controls how the aws-load-balancer-controller webhook TLS cert is managed.
+
+    - "chart" (default) — chart auto-generates self-signed cert via Helm template
+      helper `genSignedCert`. This is the upstream eks-charts default behavior
+      and is backward-compatible with all existing Estabilis deployments.
+      Known issue: chart regenerates cert on each render, and the Deployment
+      lacks a `checksum/secret` annotation, so pods don't restart when the
+      Secret rotates. Operator may need to run `kubectl rollout restart` on
+      the ALB Controller deployment after every chart re-sync to resolve
+      "x509: certificate signed by unknown authority" webhook failures.
+
+    - "terraform" — Terraform generates a stable CA (10 year validity) and
+      webhook cert (5 year validity), passes them to the chart via
+      webhookTLS.{caCert,cert,key} helm values. Chart skips genSignedCert.
+      Race condition resolved. Cert rotation is operator-driven via
+      `terraform taint tls_private_key.alb_controller_ca + apply` —
+      acknowledge this is a manual maintenance window task ~once per decade.
+
+    Migration: existing clusters on "chart" can flip to "terraform" via this
+    tfvar, then run `terraform apply` to provision the new cert + helm
+    parameters. After ArgoCD reconciles, run
+    `kubectl rollout restart deployment/aws-load-balancer-controller -n
+    aws-load-balancer-controller` to load the new cert into the running pods.
+  EOT
+  type        = string
+  default     = "chart"
+
+  validation {
+    condition     = contains(["chart", "terraform"], var.alb_controller_webhook_tls_managed_by)
+    error_message = "alb_controller_webhook_tls_managed_by must be one of: chart, terraform."
+  }
+}
+
 # ---------------------------------------------------------------------------
 # DNS provider
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds opt-in tfvar `alb_controller_webhook_tls_managed_by` (default `chart`, opt-in `terraform`) that switches the aws-load-balancer-controller webhook TLS cert from the chart's non-deterministic `genSignedCert` helper to a Terraform-managed CA (10y) + cert (5y) passed in via `webhookTLS.{caCert,cert,key}`.

## Why

The eks-charts/aws-load-balancer-controller chart auto-generates the webhook cert on every render. The chart's Deployment lacks a `checksum/secret` annotation, so pods do not restart when the Secret rotates. After a re-sync, the cluster ends up with a new CABundle on the webhook config while pods continue serving the previous cert from memory — `x509: certificate signed by unknown authority` blocks every Service creation cluster-wide until `kubectl rollout restart`. Observed in production during HML bootstrap on 2026-05-15.

When TF manages the cert, every render produces the same PEM. No regen, no race.

## What changed

| File | Change |
|---|---|
| `providers/aws/alb-controller-webhook-tls.tf` (NEW, 106 LOC) | 4 conditional TLS resources gated on `local.alb_controller_webhook_tls_tf_managed` |
| `providers/aws/variables.tf` | declared `alb_controller_webhook_tls_managed_by` with description + `validation` |
| `providers/aws/platform-outputs.tf` | conditional `merge()` injects `albControllerWebhookTLS.{caCert,cert,key}` into Secret `platform-infrastructure-sensitive` |
| `bootstrap/platform-root/templates/aws-load-balancer-controller.yaml` | conditional `webhookTLS` block in `valuesObject`; conditional drop of the 3 cert-related `ignoreDifferences` entries so ArgoCD actually pushes the TF-provided cert (Issue raised in brutal-code-critic review — without this, migration would silently no-op on existing clusters) |
| `providers/aws/terraform.tfvars.example` | documented opt-in syntax |
| `CHANGELOG.md` | v0.54.0 section with migration window note (~30s mismatch between ArgoCD sync and rollout restart) |

PR size: ~274 lines added. Slightly above the 200-line spec target — the extra came from the conditional `ignoreDifferences` block needed to make migration actually take effect on existing clusters.

## Backward compatibility

Default mode (`chart`) render is **byte-identical** to v0.53.3. Verified via `diff` against a worktree checked out at the tag. Existing clusters that do not flip the tfvar see zero behavioral change.

## Validations passing

- `terraform validate` clean
- Default-mode `helm template` render byte-identical to v0.53.3
- Opt-in mode emits the `webhookTLS:` block with multi-line PEM correctly indented under `valuesObject`
- Opt-in mode drops the 3 cert-related `ignoreDifferences` entries (verified: 1 entry remaining vs 4 in default mode — only `IngressClassParams /spec` stays)
- Azure render unchanged (separate `helm template --set global.provider=azure` diff against v0.53.3)
- `helm lint` passes in both modes
- 0 null-valued keys in `yaml.safe_load_all` audit on both renders
- `terraform console` confirms the gating local evaluates `false` for `chart` and `true` for `terraform` (4 TLS resources only materialize in opt-in mode)
- Helm `--set` empirically handles multi-line PEM with base64 `==` padding (tested locally before relying on this in the design)

## Test plan

- [x] `terraform validate` in `providers/aws/`
- [x] `helm lint bootstrap/platform-root` with AWS provider — both modes
- [x] Default-mode render compared byte-wise to v0.53.3
- [x] Opt-in render structurally checked (3 `webhookTLS` keys present, 3 ignore entries removed)
- [x] Azure render unaffected
- [ ] First consumer apply on HML cluster (post-release follow-up; expect a possible v0.54.1 if a provider-runtime gotcha shows up — brutal-critic + first-apply complementary per repo memory)

## Out of scope

- Migration to cert-manager.io/Certificate with cert-manager CAInjector (eliminates manual rotation but requires wave reordering; tracked separately, future ADR)
- Upstream PR on eks-charts adding `checksum/secret` annotation (no timeline)
- Auto-rotation logic (manual `terraform taint` accepted for 10y CA + 5y cert)