### PR TITLE
fix(platform-secrets): emit nullBytePolicy on every remoteRef (v0.53.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.53.5] - 2026-05-15
+
+### Fixed
+
+- `platform-secrets`: emit `nullBytePolicy: Ignore` explicitly in all 10 `remoteRef` blocks across 6 ExternalSecret templates (`acr.yaml`, `argocd.yaml`, `argocd-redis.yaml`, `cnpg.yaml`, `grafana.yaml`, `opencost.yaml`). The `externalsecrets.external-secrets.io/v1` CRD has `default: Ignore` on this field, which the API server materializes into the live state. Chart omitting the field produced permanent drift (`OutOfSync`) in every consumer.
+
 ## [0.53.4] - 2026-05-15
 
 ### Fixed — opencost default flipped to `false` (was producing Degraded state without CUR)

--- a/core/components/platform-secrets/templates/acr.yaml
+++ b/core/components/platform-secrets/templates/acr.yaml
@@ -28,4 +28,5 @@ spec:
     - secretKey: token
       remoteRef:
         key: {{ .Values.kvSecrets.acrArgocdToken | quote }}
+        nullBytePolicy: Ignore
 {{- end }}

--- a/core/components/platform-secrets/templates/argocd-redis.yaml
+++ b/core/components/platform-secrets/templates/argocd-redis.yaml
@@ -22,3 +22,4 @@ spec:
     - secretKey: auth
       remoteRef:
         key: {{ .Values.kvSecrets.argocdRedisPassword | quote }}
+        nullBytePolicy: Ignore

--- a/core/components/platform-secrets/templates/argocd.yaml
+++ b/core/components/platform-secrets/templates/argocd.yaml
@@ -35,6 +35,7 @@ spec:
     - secretKey: token
       remoteRef:
         key: {{ .Values.kvSecrets.configRepoToken | quote }}
+        nullBytePolicy: Ignore
 {{- end }}
 ---
 {{- if and .Values.clientGitopsRepoUrl (not .Values.githubAppEnabled) }}
@@ -66,4 +67,5 @@ spec:
     - secretKey: token
       remoteRef:
         key: {{ .Values.kvSecrets.clientGitopsRepoToken | quote }}
+        nullBytePolicy: Ignore
 {{- end }}

--- a/core/components/platform-secrets/templates/cnpg.yaml
+++ b/core/components/platform-secrets/templates/cnpg.yaml
@@ -22,3 +22,4 @@ spec:
     - secretKey: password
       remoteRef:
         key: {{ .Values.kvSecrets.grafanaDbPassword | quote }}
+        nullBytePolicy: Ignore

--- a/core/components/platform-secrets/templates/grafana.yaml
+++ b/core/components/platform-secrets/templates/grafana.yaml
@@ -17,6 +17,7 @@ spec:
     - secretKey: GF_DATABASE_PASSWORD
       remoteRef:
         key: {{ .Values.kvSecrets.grafanaDbPassword | quote }}
+        nullBytePolicy: Ignore
 ---
 # grafana-admin-credentials — persistent admin password from Key Vault
 apiVersion: external-secrets.io/v1
@@ -41,6 +42,7 @@ spec:
     - secretKey: password
       remoteRef:
         key: {{ .Values.kvSecrets.grafanaAdminPassword | quote }}
+        nullBytePolicy: Ignore
 ---
 {{- /* grafana-llm-provisioning ConfigMap is rendered unconditionally.
       The Grafana pod's `extraConfigmapMounts` in
@@ -99,4 +101,5 @@ spec:
     - secretKey: OPENAI_API_KEY
       remoteRef:
         key: {{ .Values.kvSecrets.openaiApiKey | quote }}
+        nullBytePolicy: Ignore
 {{- end }}

--- a/core/components/platform-secrets/templates/opencost.yaml
+++ b/core/components/platform-secrets/templates/opencost.yaml
@@ -28,6 +28,7 @@ spec:
     - secretKey: cloudIntegration
       remoteRef:
         key: {{ .Values.kvSecrets.opencostCloudIntegration | quote }}
+        nullBytePolicy: Ignore
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -51,4 +52,5 @@ spec:
     - secretKey: serviceKey
       remoteRef:
         key: {{ .Values.kvSecrets.opencostServiceKey | quote }}
+        nullBytePolicy: Ignore
 {{- end }}


### PR DESCRIPTION
## Problem

The CRD `externalsecrets.external-secrets.io/v1` declares `spec.data[].remoteRef.nullBytePolicy` with `default: Ignore`. The Kubernetes API server materializes this default into the live object, but every `remoteRef:` block across the 6 ExternalSecret templates in `core/components/platform-secrets/templates/` omits the field.

Result: the `platform-secrets` Application is permanently `OutOfSync` on every consumer cluster, with every active ExternalSecret reporting `nullBytePolicy: Ignore` as drift.

Verified on a fresh homologation bootstrap: 4 active ExternalSecrets all `OutOfSync` solely due to this drift.

## Fix

Add `nullBytePolicy: Ignore` explicitly to every `remoteRef:` block (10 occurrences across 6 templates):

| Template | remoteRef blocks |
|---|---|
| `acr.yaml` | 1 |
| `argocd.yaml` | 2 |
| `argocd-redis.yaml` | 1 |
| `cnpg.yaml` | 1 |
| `grafana.yaml` | 3 |
| `opencost.yaml` | 2 |
| **Total** | **10** |

The value matches the CRD default so behavior is unchanged — drift fix only, zero functional change.

## Validation

`helm template` of the `platform-secrets` subchart (the chart ArgoCD renders at runtime) followed by `yq 'select(.kind=="ExternalSecret") | .spec.data[].remoteRef.nullBytePolicy' | sort | uniq -c`:

```
     10 Ignore
```

Per-file `remoteRef` vs `nullBytePolicy` line count parity check confirms 1:1 on every template. `helm lint` passes on the subchart.

## SemVer

PATCH (`v0.53.4` → `v0.53.5`): drift fix, no API or behavior change.