### PR TITLE
fix(platform-root): advance default platformGitopsVersion v0.39.3 -> v0.39.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.53.6] - 2026-05-15
+
+### Fixed
+
+- `bootstrap/platform-root/values.yaml`: advance default `platformGitopsVersion` from `v0.39.3` to `v0.39.11`. The default had been pinned to a stale gitops release for 8 patch versions while every cluster operator wrote a downstream `overrides/platform-root/values.yaml` override to consume newer releases — duplicating the decision across clients and producing fragmentation. Most consequential improvement carried in: `components/karpenter-resources` NodePool defaults (Estabilis/estabilis-platform-gitops#42), which replaces the broken `instance-size: [medium, large, xlarge]` constraint with `instance-cpu Gt 1` (excludes mediums that have 8 max-pods under AWS VPC CNI without Prefix Delegation), sets `consolidationPolicy: WhenEmpty` and `consolidateAfter: 5m` (mitigates v1.3+ SpotToSpotConsolidation thrashing). Clients consuming this release of `estabilis-platform` can drop their redundant `platformGitopsVersion` override in `overrides/platform-root/values.yaml`.
+
 ## [0.53.5] - 2026-05-15
 
 ### Fixed

--- a/bootstrap/platform-root/values.yaml
+++ b/bootstrap/platform-root/values.yaml
@@ -38,7 +38,7 @@ configRepoVersion: ""       # DEPRECATED: use configRepoRevision
 # See ADR 0001 (estabilis-platform-tools/docs/adr/0001-workload-bootstrap-strategy.md).
 # Default values below; downstream can override via overrides/platform-root/values.yaml.
 platformGitopsRepoUrl: "https://github.com/Estabilis/estabilis-platform-gitops.git"
-platformGitopsVersion: "v0.39.3"
+platformGitopsVersion: "v0.39.11"
 
 global:
   # Provenance — injected at runtime by the CLI (see block above).


### PR DESCRIPTION
## Problem

`bootstrap/platform-root/values.yaml` declares `platformGitopsVersion: "v0.39.3"` as the default. The actual `estabilis-platform-gitops` repo has shipped through `v0.39.11` since then — **8 patches behind**.

Every cluster operator was writing a downstream override in `overrides/platform-root/values.yaml` to consume newer gitops releases:

```yaml
# pattern across multiple clients
platformGitopsVersion: "v0.39.10"  # or higher
```

This is fragmentation by accident: the decision "which gitops version is canonical" belongs in one place, not in N client wrappers. New clients have to copy the override.

## Fix

Advance the default to `v0.39.11`. The most consequential improvement carried in is from `Estabilis/estabilis-platform-gitops#42`:

- `components/karpenter-resources` NodePool defaults — replaces the broken `instance-size: [medium, large, xlarge]` constraint with `instance-cpu Gt 1`. AWS VPC CNI without Prefix Delegation caps `*.medium` at 8 max-pods, which can't fit system DaemonSets + workload. The `instance-cpu Gt 1` constraint excludes mediums functionally while keeping the upper end (2xlarge, 4xlarge, …) open.
- `consolidationPolicy: WhenEmpty` (was `WhenEmptyOrUnderutilized`) + `consolidateAfter: 5m` (was `1m`) — mitigates the Karpenter v1.3+ SpotToSpotConsolidation thrashing observed live on production fleets (208 nodes launched in 24h, 95% disrupted by `Underutilized`).

Clients consuming this release of `estabilis-platform` can drop their redundant `platformGitopsVersion` override in `overrides/platform-root/values.yaml` — they inherit the default automatically.

## Validation

- 1 line change in `values.yaml` (the version pin itself)
- CHANGELOG entry describes the chain of consequences
- 14+ templates in `bootstrap/platform-root/templates/` already reference `.Values.platformGitopsVersion`; they pick up the new value without any other change

## SemVer

PATCH (`v0.53.5 → v0.53.6`) — bump of a default value pin to a newer compatible release. Memory `feedback_semver_default_tweak_is_patch` applies: changing the numeric value of an existing default key without renaming/adding functionality is PATCH.

## Follow-up

After merge + release `v0.53.6`:
1. Each client bumps `providers/aws/main.tf` `ref=v0.53.5` → `ref=v0.53.6`
2. Updates `terraform.tfvars` `platform_version = "v0.53.6"`
3. `terraform apply`
4. Removes the redundant `platformGitopsVersion` override
5. `estabilis promote` (or manual platform-root sync on AWS)