### PR TITLE
fix(platform-root): advance default platformGitopsVersion v0.39.11 -> v0.39.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.53.7] - 2026-05-15
+
+### Fixed
+
+- `bootstrap/platform-root/values.yaml`: advance default `platformGitopsVersion` from `v0.39.11` to `v0.39.12`. Carries the second Karpenter NodePool refinement (Estabilis/estabilis-platform-gitops#43): adds `karpenter.k8s.aws/instance-memory Gt 4096` (MiB) requirement. Combined with the `instance-cpu Gt 1` from v0.39.11, the default NodePool now guarantees any provisioned node has `≥ 2 vCPU AND > 4 GiB raw memory` (i.e., `xlarge+` minimum). Eliminates the "node slowly tightens as DaemonSets accumulate post-provisioning" failure mode observed on cortex HML 2026-05-15. Clusters consuming this release see Karpenter mark all `*.large` nodes as `Drifted` and replace them with `xlarge+` over the next disruption budget cycles.
+
 ## [0.53.6] - 2026-05-15
 
 ### Fixed

--- a/bootstrap/platform-root/values.yaml
+++ b/bootstrap/platform-root/values.yaml
@@ -38,7 +38,7 @@ configRepoVersion: ""       # DEPRECATED: use configRepoRevision
 # See ADR 0001 (estabilis-platform-tools/docs/adr/0001-workload-bootstrap-strategy.md).
 # Default values below; downstream can override via overrides/platform-root/values.yaml.
 platformGitopsRepoUrl: "https://github.com/Estabilis/estabilis-platform-gitops.git"
-platformGitopsVersion: "v0.39.11"
+platformGitopsVersion: "v0.39.12"
 
 global:
   # Provenance — injected at runtime by the CLI (see block above).


### PR DESCRIPTION
## Problem

Follow-up to #172. v0.39.11 unblocked `*.medium` pod density. v0.39.12 (Estabilis/estabilis-platform-gitops#43) adds the second NodePool refinement: `karpenter.k8s.aws/instance-memory Gt 4096` (MiB), excluding `*.large` and below from the eligible instance set. Forces `xlarge+` as the minimum, eliminating the "node slowly tightens as DaemonSets accumulate post-provisioning" failure mode.

## Fix

Bump default `platformGitopsVersion` from `v0.39.11` to `v0.39.12`. Clusters that consume this release observe Karpenter mark all `*.large` nodes as `Drifted` and replace them with `xlarge+` across disruption budget cycles.

## Combined effect of v0.53.6 + v0.53.7

Any node a downstream cluster provisions via Karpenter has `>= 2 vCPU AND > 4 GiB raw memory`. The default became operationally sane.

## SemVer

PATCH — bump of a default value pin to a newer compatible release. No API change. Memory `feedback_semver_default_tweak_is_patch` applies.