### PR TITLE
fix(platform-root): advance default platformGitopsVersion v0.39.12 -> v0.39.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.53.8] - 2026-05-17
+
+### Fixed
+
+- `bootstrap/platform-root/values.yaml`: advance default `platformGitopsVersion` from `v0.39.12` to `v0.39.13`. Carries the argocd namespace ResourceQuota bump (Estabilis/estabilis-platform-gitops#44): `limits.memory: 16Gi → 32Gi`. The 16Gi cap was sized for a single-replica control plane; operators following the HA baseline (`controller.replicas: 2`) saw `application-controller-1` blocked indefinitely on `exceeded quota`, with sharding silently breaking reconcile (cluster assigned to a shard whose pod doesn't exist). Observed on cortex HML: 18h of `platform-root` `OutOfSync` with no actionable error anywhere. The 32Gi default now accommodates HA with headroom.
+
 ## [0.53.7] - 2026-05-15
 
 ### Fixed

--- a/bootstrap/platform-root/values.yaml
+++ b/bootstrap/platform-root/values.yaml
@@ -38,7 +38,7 @@ configRepoVersion: ""       # DEPRECATED: use configRepoRevision
 # See ADR 0001 (estabilis-platform-tools/docs/adr/0001-workload-bootstrap-strategy.md).
 # Default values below; downstream can override via overrides/platform-root/values.yaml.
 platformGitopsRepoUrl: "https://github.com/Estabilis/estabilis-platform-gitops.git"
-platformGitopsVersion: "v0.39.12"
+platformGitopsVersion: "v0.39.13"
 
 global:
   # Provenance — injected at runtime by the CLI (see block above).


### PR DESCRIPTION
## Problem

Follow-up to #173. v0.39.13 (Estabilis/estabilis-platform-gitops#44) bumps the `argocd` namespace ResourceQuota `limits.memory: 16Gi → 32Gi`. The 16Gi cap was sized for a single-replica control plane; operators following the HA baseline (`controller.replicas: 2`) saw `application-controller-1` blocked indefinitely on `exceeded quota`, with sharding silently breaking reconcile.

Observed on cortex HML 2026-05-17: 18h of `platform-root` `OutOfSync` with no actionable error anywhere (only `kubectl describe sts argocd-application-controller` surfaced `FailedCreate` retries, 103 deep).

## Fix

Bump default `platformGitopsVersion` from `v0.39.12` to `v0.39.13`. Clusters consuming this release see the updated ResourceQuota when `resource-quotas` Application syncs, removing the cap that was silently breaking reconcile under the HA configuration.

## SemVer

PATCH — bump of a default value pin to a newer compatible release. No API change.