### PR TITLE
fix(argocd): promote HML override values into upstream defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.53.9] - 2026-05-17
+
+### Fixed
+
+- `core/components/argocd/values.yaml`: promote HML override values into the upstream defaults. Two-part change: (1) **resources** bumped to sizes that match a `~40-Application platform-root` deployment (avoids the chart's stock floors that OOMKill the controller/repo-server under that workload — observed live multiple times); (2) **HA baseline**: `replicas: 2` + `pdb.minAvailable: 1` on every multi-replica component (`server`, `controller`, `repoServer`, `applicationSet`). Single-replica chart components (`redis`, `dex`, `notifications`) intentionally remain without PDB to preserve drainability — a Deployment of 1 replica with `minAvailable: 1` makes the pod voluntarily-undisruptable (drain, Karpenter consolidation, and node upgrades block forever waiting for a second replica that never exists). Requires `estabilis-platform-gitops >= v0.39.13` for the argocd ResourceQuota `limits.memory: 32Gi`; default `platformGitopsVersion` is already at `v0.39.13` from v0.53.8. Total peak memory request with the new defaults is ~19Gi, well within the 32Gi cap.
+
 ## [0.53.8] - 2026-05-17
 
 ### Fixed

--- a/core/components/argocd/values.yaml
+++ b/core/components/argocd/values.yaml
@@ -136,46 +136,88 @@ configs:
       hs.message = "Waiting for secret to sync"
       return hs
 
+# --------------------------------------------------------------------------
+# Resource sizing rationale (promoted from cortex HML override 2026-05-17)
+# --------------------------------------------------------------------------
+# Defaults sized for a ~40-Application platform-root deployment. The argo-cd
+# chart's stock floors (repo-server 512Mi, controller 256Mi) get OOMKilled
+# under that workload — observed live during v0.28.x rollout (4 OOMKills in
+# 5 minutes during bursty sync) and again 2026-05-07 (9 OOMs/day on
+# argocd-application-controller after the 2Gi → 3Gi bump; krr 14d
+# --use-oomkill-data put the peak at 3840Mi, so 5Gi gives ~30% headroom).
+#
+# `replicas: 2` + `pdb.minAvailable: 1` on every multi-replica component is
+# the HA baseline matching the legacy cortex-eks-prod fleet. PDB is the
+# reason replicas MUST stay at 2 — a Deployment of 1 replica with
+# `minAvailable: 1` makes the pod voluntarily-undisruptable: drain,
+# Karpenter consolidation, and node upgrades all block forever waiting for
+# a second replica that never exists. Components without a `pdb` block
+# (notifications, dex, redis) are chart-singleton-by-design and intentionally
+# skip the PDB to preserve drainability.
+#
+# Compatible with the argocd ResourceQuota in estabilis-platform-gitops
+# (>= v0.39.13, components/resource-quotas/values.yaml limits.memory: 32Gi);
+# total peak request budget with the values below is ~19Gi.
+# --------------------------------------------------------------------------
+
 server:
-  replicas: 1
-  resources:
-    requests:
-      cpu: 50m
-      memory: 128Mi
-    limits:
-      cpu: 200m
-      memory: 256Mi
-
-controller:
-  replicas: 1
-  # The argocd helm chart (9.5.x statefulset.yaml) only renders
-  # `controller.extraArgs`, NOT `controller.args` — the latter is a
-  # silent no-op. The platform set `args:` since 6c217ff (2026-04-25)
-  # but the intended 50/25 worker sizing has never reached any client
-  # cluster running this chart, so every bootstrap fell back to the
-  # binary defaults `--status-processors=20` and `--operation-processors=10`.
-  # Result: operation queue stalls during 30+ App reconcile waves
-  # (sync travando + UI argocd-server loading sem fim).
-  extraArgs:
-    - --status-processors=50
-    - --operation-processors=25
-  resources:
-    requests:
-      cpu: 500m
-      memory: 1Gi
-    limits:
-      cpu: 2
-      memory: 2Gi
-
-repoServer:
   replicas: 2
+  pdb:
+    enabled: true
+    minAvailable: 1
   resources:
     requests:
       cpu: 100m
       memory: 256Mi
     limits:
       cpu: 500m
+      memory: 1Gi
+
+controller:
+  replicas: 2
+  pdb:
+    enabled: true
+    minAvailable: 1
+  # The argocd helm chart (9.5.x statefulset.yaml) only renders
+  # `controller.extraArgs`, NOT `controller.args` — the latter is a
+  # silent no-op (chart 9.5.6 statefulset.yaml only renders extraArgs).
+  # The platform set `args:` since 6c217ff (2026-04-25) but the intended
+  # 50/25 worker sizing never reached any client cluster running this
+  # chart, so every bootstrap fell back to the binary defaults
+  # `--status-processors=20` and `--operation-processors=10`.
+  # Result: operation queue stalls during 30+ App reconcile waves
+  # (sync travando + UI argocd-server loading sem fim).
+  extraArgs:
+    - --status-processors=50
+    - --operation-processors=25
+  # Memory limit bumped 3Gi → 5Gi (2026-05-07). 9 additional OOMKills
+  # observed in a single day on argocd-application-controller-1 after the
+  # 2026-05-05 bump from 2Gi → 3Gi. krr (14d, --use-oomkill-data) puts
+  # the OOM-aware peak around 3840Mi; 5Gi gives ~30% headroom. Request
+  # stays at 1Gi (Burstable QoS) — working-set baseline is ~1.5Gi
+  # steady, so 1Gi is the right scheduling floor; surplus up to 5Gi is
+  # bursty bootstrap-storm headroom that does NOT need node reservation.
+  # Re-evaluate when peak working-set revisits 4Gi sustained.
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
+    limits:
+      cpu: 1500m
+      memory: 5Gi
+
+repoServer:
+  replicas: 2
+  pdb:
+    enabled: true
+    minAvailable: 1
+  resources:
+    requests:
+      cpu: 200m
       memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
   copyutil:
     resources:
       requests:
@@ -223,40 +265,52 @@ repoServer:
 redis:
   serviceAccount:
     create: true
+  # redis is single-replica in the argo-cd chart (HA redis is the separate
+  # `redis-ha` subchart, disabled here). NO PDB — `minAvailable=1` on a
+  # single-replica Deployment makes the pod voluntarily-undisruptable
+  # (drain blocks forever waiting for a second replica that never exists).
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+applicationSet:
+  replicas: 2
+  pdb:
+    enabled: true
+    minAvailable: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+dex:
+  # dex is singleton-by-design in the argo-cd chart (no `replicas` key
+  # exposed). NO PDB — same drainability reason as redis above.
   resources:
     requests:
       cpu: 50m
       memory: 64Mi
     limits:
-      cpu: 100m
-      memory: 128Mi
-
-applicationSet:
-  resources:
-    requests:
-      cpu: 20m
-      memory: 64Mi
-    limits:
-      cpu: 100m
-      memory: 256Mi
-
-dex:
-  resources:
-    requests:
-      cpu: 20m
-      memory: 64Mi
-    limits:
-      cpu: 100m
+      cpu: 200m
       memory: 256Mi
 
 notifications:
   enabled: true
+  # notifications is singleton-by-design in the argo-cd chart (no `replicas`
+  # key exposed). NO PDB — same drainability reason as redis above.
   resources:
     requests:
-      cpu: 20m
-      memory: 64Mi
+      cpu: 50m
+      memory: 128Mi
     limits:
-      cpu: 100m
+      cpu: 200m
       memory: 256Mi
 
 tolerations:


### PR DESCRIPTION
## Problem

The `cortex` downstream override (`overrides/argocd/values.yaml`) was carrying ArgoCD resource sizes and HA configuration for a `~40-Application platform-root` deployment that should have been the upstream default in the first place. Every fresh cluster bootstrap had to either copy the same override or run with the chart's stock floors, which OOMKill the controller and repo-server under any non-trivial workload (observed live multiple times — most recently 2026-05-07: 9 OOMKills/day on `argocd-application-controller` after the 2Gi → 3Gi bump; krr analysis with `--use-oomkill-data` put the working-set peak at 3840Mi).

## Fix

Two-part promotion to upstream:

### 1. Resources

| Component | Field | Before (upstream) | After (HML promoted) |
|---|---|---|---|
| server | requests.cpu/memory | 50m / 128Mi | 100m / 256Mi |
| server | limits.cpu/memory | 200m / 256Mi | 500m / 1Gi |
| controller | requests.cpu/memory | 500m / 1Gi | 250m / 1Gi |
| controller | limits.cpu/memory | 2 / 2Gi | 1500m / **5Gi** |
| repoServer | requests.cpu/memory | 100m / 256Mi | 200m / 512Mi |
| repoServer | limits.cpu/memory | 500m / 512Mi | 1000m / 2Gi |
| applicationSet | requests.cpu/memory | 20m / 64Mi | 100m / 128Mi |
| applicationSet | limits.cpu/memory | 100m / 256Mi | 500m / 512Mi |
| redis | requests.cpu/memory | 50m / 64Mi | 100m / 128Mi |
| redis | limits.cpu/memory | 100m / 128Mi | 500m / 512Mi |
| dex | requests.cpu/memory | 20m / 64Mi | 50m / 64Mi |
| dex | limits.cpu/memory | 100m / 256Mi | 200m / 256Mi |
| notifications | requests.cpu/memory | 20m / 64Mi | 50m / 128Mi |
| notifications | limits.cpu/memory | 100m / 256Mi | 200m / 256Mi |

### 2. HA baseline

| Component | Replicas | PDB | Reason |
|---|---|---|---|
| server | **2** | `minAvailable: 1` | Stateless HTTP gateway; survives single-replica eviction during drain |
| controller | **2** | `minAvailable: 1` | StatefulSet w/ sharding — replicas=2 enables 2-shard distribution |
| repoServer | 2 (was already) | `minAvailable: 1` | Stateless template renderer; 2 replicas absorb bursty load |
| applicationSet | **2** | `minAvailable: 1` | Stateless controller; 2 replicas required for leader election failover |
| redis | 1 (chart default) | **no PDB** | Singleton-by-design (HA redis = separate `redis-ha` subchart) |
| dex | 1 (chart default) | **no PDB** | Singleton-by-design (no `replicas` key in chart) |
| notifications | 1 (chart default) | **no PDB** | Singleton-by-design (no `replicas` key in chart) |

PDB is intentionally **only** on the multi-replica components. On a Deployment of 1 replica with `minAvailable: 1`, the pod becomes voluntarily-undisruptable: drain, Karpenter consolidation, and node upgrades all block forever waiting for a second replica that never exists. This is exactly the failure mode the `redis`/`dex`/`notifications` block in the HML override already warned about — promoting that pattern upstream as the canonical rule.

## Required prerequisite

The `argocd` namespace ResourceQuota in `estabilis-platform-gitops` must allow ≥ 19Gi `limits.memory` to fit the new defaults. That's already done in `v0.39.13` (Estabilis/estabilis-platform-gitops#44, bumped 16Gi → 32Gi). Default `platformGitopsVersion` for `estabilis-platform` is already at `v0.39.13` from `v0.53.8`, so any cluster running this `v0.53.9` release also has the matching quota.

## SemVer

PATCH (`v0.53.8 → v0.53.9`) — promoting downstream-validated values into upstream defaults. No new API, no rename. Memory `feedback_semver_default_tweak_is_patch` applies.

## Follow-up

Downstream `cortex-platform-aws-us-east-1-hml/overrides/argocd/values.yaml` becomes redundant — entire block can be deleted on next bump (the override now matches upstream byte-for-byte modulo the inline comments). Same for any other client that copied this baseline.