### PR TITLE
fix(mimir): promote prd ingester resources + topology spread into upstream defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.53.10] - 2026-05-17
+
+### Fixed
+
+- `core/components/grafana-stack/mimir-values.yaml`: promote cortex prd ingester override into upstream defaults. The chart's stock `512Mi` memory limit was insufficient for the WAL replay on restart — with hundreds of segments accumulated, the ingester OOMKills mid-replay before `/ready` returns 200 and the Mimir Application stays at `Synced/Progressing` indefinitely. cortex prd documented this on 2026-05-01 (corrupted WAL → split-brain → forced node drain); cortex hml reproduced the same failure 2026-05-17. Promoted defaults: `replicas: 2`, `requests.memory: 384Mi`, `limits.cpu: 500m`, `limits.memory: 2Gi`, `topologySpreadConstraints` with `whenUnsatisfiable: DoNotSchedule` (prevents bin-pack of both replicas onto the same node, preserving HA). The grafana namespace ResourceQuota in `estabilis-platform-gitops` already accommodates this (`limits.memory: 32Gi`, 18.9Gi free on a typical cluster). Total ingester budget rises from 512Mi to 4Gi (2 replicas × 2Gi).
+
 ## [0.53.9] - 2026-05-17
 
 ### Fixed

--- a/core/components/grafana-stack/mimir-values.yaml
+++ b/core/components/grafana-stack/mimir-values.yaml
@@ -166,7 +166,24 @@ distributor:
       effect: "NoSchedule"
 
 ingester:
-  replicas: 1
+  # HA write path: 2 replicas + hard topology spread.
+  #
+  # Promoted from cortex prd override 2026-05-17 after cortex hml hit the
+  # same failure prd had on 2026-05-01: the chart's stock 512Mi memory
+  # limit isn't enough to load the WAL on restart. With ~395 segments
+  # accumulated, the ingester OOMKills mid-replay before /ready returns
+  # 200, restart loops forever, and the Mimir Application sits at
+  # Synced+Progressing indefinitely.
+  #
+  # 2Gi limit covers WAL replay storms with ~3× headroom over the
+  # observed peak (krr 14d --use-oomkill-data put peak ~1Gi on a fleet
+  # carrying 500k active series under replay churn). Request stays at
+  # 384Mi so Karpenter reserves the steady-state working set accurately
+  # without over-allocating.
+  #
+  # CPU limit bumped 200m → 500m so WAL segments load in 2-3s each
+  # instead of 5-9s — shrinks the readiness-probe failure window.
+  replicas: 2
   zoneAwareReplication:
     enabled: false
   persistentVolume:
@@ -174,10 +191,20 @@ ingester:
   resources:
     requests:
       cpu: 50m
-      memory: 128Mi
+      memory: 384Mi
     limits:
-      cpu: 200m
-      memory: 512Mi
+      cpu: 500m
+      memory: 2Gi
+  # `DoNotSchedule` (hard) — the chart default is `ScheduleAnyway` (soft),
+  # which lets the scheduler bin-pack both ingester pods onto the same
+  # node under capacity pressure. With replication_factor: 2, co-location
+  # defeats the entire HA story: one node failure takes both ingesters
+  # down. cortex prd 2026-05-01 cascaded exactly this: bin-pack →
+  # OOMKill → corrupted WAL → split-brain → forced node drain.
+  topologySpreadConstraints:
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
   tolerations:
     - key: "estabilis.io/workload-type"
       operator: "Equal"


### PR DESCRIPTION
## Problem

The default `grafana-mimir-ingester` config in `core/components/grafana-stack/mimir-values.yaml` ships with `replicas: 1` + `limits.memory: 512Mi`. Both are inadequate:

- **512Mi is too low for WAL replay**. On restart, Mimir loads every segment of the WAL into the TSDB head before `/ready` returns 200. With a few hundred segments accumulated (normal after any outage or slow start), the replay peaks above 512Mi → OOMKilled → restart → replay-from-zero with one extra segment → repeat. Infinite crash loop, never reaches Ready.

- **replicas: 1 with no topology spread** breaks HA the moment downstream bumps to 2: the chart's stock `topologySpreadConstraints` is `ScheduleAnyway` (soft), so both ingester pods bin-pack onto the same node under capacity pressure. One node failure = both ingesters down.

Two cortex clusters hit this:

- **cortex prd 2026-05-01**: documented incident — OOM cycle after raising tenant series cap, corrupted WAL segment, split-brain between ingesters, forced node drain to recover.
- **cortex hml 2026-05-17**: reproduced same OOM cycle with 22 restarts in 108min on a fresh cluster; observed 395 WAL segments piling up across crash iterations.

Both required a downstream `overrides/mimir/values.yaml` with the same fix. The override was promoted from prd into upstream here.

## Fix

```yaml
ingester:
  replicas: 2                                    # was 1
  resources:
    requests:
      memory: 384Mi                              # was 128Mi (Karpenter reservation accuracy)
    limits:
      cpu: 500m                                  # was 200m (faster WAL segments)
      memory: 2Gi                                # was 512Mi (~3× peak headroom)
  topologySpreadConstraints:                     # new — hard anti-bin-pack
    maxSkew: 1
    topologyKey: kubernetes.io/hostname
    whenUnsatisfiable: DoNotSchedule
```

Inline comments document the failure mode, the chosen numbers, and the cortex prd 2026-05-01 incident for future-readers.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` parses cleanly
- Total ingester memory budget rises from 512Mi → 4Gi (2 × 2Gi)
- Grafana namespace ResourceQuota already accommodates this (`limits.memory: 32Gi`, ~18.9Gi free on a typical cluster)

## SemVer

PATCH (`v0.53.9 → v0.53.10`) — value tweak to existing default keys. Memory `feedback_semver_default_tweak_is_patch` applies.