### PR TITLE
fix(spec): correct external-dns ordering + drop duplicate loki-ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.53.11] - 2026-05-17
+
+### Fixed
+
+- `spec/upstart/upstart.yaml`: two bootstrap-spec fixes surfaced by the cortex hml audit 2026-05-17.
+  - Wave 8 "Networking & Ingress": swap order so `external-dns-config` syncs **before** `external-dns`. The config app renders the `external-dns-cloudflare-config` Secret (hub path: direct from `cloudflareApiToken`; workload path: ExternalSecret from AWS SM) that the `external-dns` pod mounts as `CF_API_TOKEN` env var with `Optional: false`. In manual sequential bootstrap, syncing `external-dns` first leaves the pod in `CreateContainerConfigError` until `external-dns-config` catches up. Auto-sync clusters converge via retry (both Apps are sync-wave 7 in the chart) but manual runs hit the symptom every time.
+  - Wave 10 "Post-Deploy": remove `loki-ingress` (kept only in the AWS overlay `Ingresses` wave). Was duplicated across base + overlay, causing a no-op double-sync.
+
 ## [0.53.10] - 2026-05-17
 
 ### Fixed

--- a/spec/upstart/upstart.yaml
+++ b/spec/upstart/upstart.yaml
@@ -226,8 +226,22 @@ waves:
   - name: Networking & Ingress
     timeout: 300
     apps:
-      - { name: external-dns, optional: true }
+      # external-dns-config MUST sync before external-dns.
+      # external-dns-config renders the Secret `external-dns-cloudflare-config`
+      # (hub path: direct Secret with stringData.api-token from the
+      # cloudflareApiToken helm parameter; workload path: ExternalSecret
+      # pointing to AWS SM). The external-dns pod mounts that Secret as
+      # CF_API_TOKEN env var (Optional: false). Without the Secret present
+      # at pod start, kubelet returns CreateContainerConfigError and the
+      # pod restart-loops until external-dns-config catches up.
+      #
+      # Both Apps are sync-wave 7 in the chart upstream
+      # (bootstrap/platform-root/templates/external-dns.yaml renders both),
+      # so auto-sync runs them in parallel and converges via retry. In
+      # manual sequential bootstrap (this spec), the ordering becomes
+      # operational — keep config first.
       - { name: external-dns-config, optional: true }
+      - { name: external-dns, optional: true }
       - { name: traefik, optional: true }
       - { name: velero, optional: true }
 
@@ -252,7 +266,12 @@ waves:
       - { name: grafana-dashboards, optional: true }
       - { name: alloy-rbac, optional: true }
       - { name: mimir-rules, optional: true }
-      - { name: loki-ingress, optional: true }
+      # loki-ingress moved to the AWS overlay "Ingresses" wave
+      # (upstart.aws.yaml). It belonged here historically alongside
+      # other Post-Deploy items, but conceptually it's an ingress and
+      # the AWS overlay already lists it. Keeping it in both waves
+      # caused a no-op duplicate sync. Reference: cortex hml audit
+      # 2026-05-17.
 
   - name: Policies
     apps:


### PR DESCRIPTION
## Problem

Two bootstrap-spec issues surfaced by the cortex hml manual bootstrap on 2026-05-17.

### 1. Wave 8 "Networking & Ingress" — wrong ordering

Current order in `spec/upstart/upstart.yaml`:
```yaml
- { name: external-dns, optional: true }
- { name: external-dns-config, optional: true }
```

`external-dns-config` is the App that renders the Secret `external-dns-cloudflare-config`:
- **Hub path** (when `global.cloudflareApiToken` is populated): emits a plain `Secret` with `stringData.api-token` from the helm parameter.
- **Workload path**: emits an `ExternalSecret` pointing to AWS Secrets Manager.

The `external-dns` Deployment mounts that Secret as the `CF_API_TOKEN` env var with `Optional: false`. If the Secret doesn't exist at pod start, kubelet returns `CreateContainerConfigError` and the pod restart-loops until `external-dns-config` catches up.

Both Apps are sync-wave `7` in the chart upstream (`bootstrap/platform-root/templates/external-dns.yaml` renders both), so an **auto-sync** cluster ends up running them in parallel and converging via retry. The symptom is invisible there.

But a **manual sequential bootstrap** (i.e., this spec, executed by an operator following the runbook) syncs Apps in the listed order, and the operator hits the `CreateContainerConfigError` every time. Observed live on cortex hml.

Fix: swap the order so `external-dns-config` comes first.

### 2. Wave 10 "Post-Deploy" — `loki-ingress` duplicated

`loki-ingress` is listed in both:
- `spec/upstart/upstart.yaml` Wave 10 "Post-Deploy"
- `spec/upstart/upstart.aws.yaml` Wave "Ingresses" (insert-before "Policies")

The second sync is a no-op (idempotent), but it's noise. Conceptually `loki-ingress` belongs with the other ingresses (`argocd-ingress`, `grafana-ingress`, `vault-ingress`) in the AWS overlay wave — not in Post-Deploy alongside `grafana-dashboards`, `alloy-rbac`, `mimir-rules`.

Fix: remove from base Wave 10. Keep only in the AWS overlay.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` parses cleanly.
- Diff contained to `spec/upstart/upstart.yaml` + `CHANGELOG.md`.
- Inline comments document the rationale + reference the cortex hml incident.

## SemVer

PATCH (`v0.53.10 → v0.53.11`) — bug fix in declarative spec. No new functionality or API change. Memory `feedback_semver_default_tweak_is_patch` applies.

## Out of scope (intentional)

The hml audit also surfaced 5 Applications that exist in-cluster but aren't orchestrated by the spec/runbook: `argocd-image-updater`, `snapshot-controller`, `client-argocd-appsets`, `client-kyverno-exceptions`, `hub-client-apps`. All five have `syncPolicy.automated` set in their own spec, so they're fire-and-forget — they don't need a `sync_wave_app` step and don't need to appear in `upstart.yaml`. Not a spec gap.