### PR TITLE
feat(platform-root): parametrize external-secrets chartVersion + installCRDs

### DIFF
--- a/bootstrap/platform-root/templates/external-secrets.yaml
+++ b/bootstrap/platform-root/templates/external-secrets.yaml
@@ -10,7 +10,7 @@ spec:
   sources:
     - repoURL: https://charts.external-secrets.io
       chart: external-secrets
-      targetRevision: "2.1.0"
+      targetRevision: {{ .Values.componentConfig.externalSecrets.chartVersion | quote }}
       helm:
         valueFiles:
           - $values/values/platform/external-secrets.yaml
@@ -29,7 +29,7 @@ spec:
                 "provider" .Values.global.provider) | nindent 10 }}
         parameters:
           - name: installCRDs
-            value: "false"
+            value: {{ .Values.componentConfig.externalSecrets.installCRDs | toString | quote }}
           {{- /* Delegate webhook cert lifecycle to cert-manager + cainjector
                 instead of the chart's bundled cert-controller. The bundled
                 cert-controller does Update (full PUT) operations on the

--- a/bootstrap/platform-root/values.yaml
+++ b/bootstrap/platform-root/values.yaml
@@ -152,6 +152,33 @@ vault:
 #   loki        → loki-ingress
 #   traefik     → loki-ingress
 #   observability (group) → grafana, loki, mimir, alloy, tempo, dashboards, mimir-rules
+# ---------------------------------------------------------------------------
+# Component Configuration — per-component overridable settings (chart
+# versions, install flags, etc.). Separate from `components.<name>: bool`
+# above, which only toggles deployment.
+#
+# Downstream overrides via `overrides/platform-root/values.yaml` deep-merge
+# with the defaults below — set only the keys you need to override.
+# ---------------------------------------------------------------------------
+componentConfig:
+  externalSecrets:
+    # ESO Helm chart version (charts.external-secrets.io). Bump in lockstep
+    # with the CRD version applied by the upstart pipeline
+    # (`externalSecretsCrdVersion` in spec/upstart/upstart.yaml — they must
+    # match or be compatible to avoid schema/controller drift like the
+    # cortex-prd incident on 2026-05-20, where chart was at 2.1.0 but
+    # platform-secrets emitted `nullBytePolicy: Ignore` which the
+    # cluster's old CRD didn't declare → ArgoCD ComparisonError).
+    chartVersion: "2.1.0"
+    # When `true`, the ESO Helm chart installs/upgrades the CRDs alongside
+    # the controller. When `false` (default), CRDs are managed out-of-band
+    # by the upstart `Operator CRDs` wave so the lifecycle is decoupled
+    # from the controller upgrade. Flip to `true` only if downstream
+    # explicitly wants Helm to take ownership of the CRDs (be aware that
+    # CRDs pre-applied by the upstart pipeline will have a `kubectl
+    # kube-apiserver` field manager that Helm will need to override).
+    installCRDs: false
+
 components:
   # --- core (do not disable) ---
   cert-manager: true         # core: TLS for all services


### PR DESCRIPTION
## Summary

`bootstrap/platform-root/templates/external-secrets.yaml` hardcoded duas decisões que precisavam ser controláveis por downstream:

- `targetRevision: "2.1.0"` (versão do chart ESO de charts.external-secrets.io)
- `parameters[].name: installCRDs → value: "false"` (se o chart deve gerenciar os CRDs)

Sem mecanismo de override, downstream precisava forkar ou fazer live patch out-of-band para subir o ESO ou flipar `installCRDs`.

## Mudança

Ambos passam a ser lidos de `componentConfig.externalSecrets.*`:

```yaml
# bootstrap/platform-root/values.yaml (upstream default)
componentConfig:
  externalSecrets:
    chartVersion: "2.1.0"
    installCRDs: false
```

```yaml
# bootstrap/platform-root/templates/external-secrets.yaml
targetRevision: {{ .Values.componentConfig.externalSecrets.chartVersion | quote }}
...
- name: installCRDs
  value: {{ .Values.componentConfig.externalSecrets.installCRDs | toString | quote }}
```

Downstream sobrescreve em `overrides/platform-root/values.yaml`:

```yaml
componentConfig:
  externalSecrets:
    chartVersion: "2.5.0"
    installCRDs: true
```

## Backward compatibility

Defaults preservam o comportamento atual byte-a-byte. `helm template` com defaults rende exatamente os mesmos valores hardcoded de antes (`targetRevision: "2.1.0"`, `installCRDs: "false"`). Validado localmente.

## Motivação / incident link

`cortex-platform-aws-us-east-1-prd` em 2026-05-20: app `platform-secrets` com `ComparisonError` permanente. Causa raiz: `estabilis-platform` chart v0.54.1 (mesma release branch que esse PR) passou a emitir `nullBytePolicy: Ignore` nos ExternalSecrets do `platform-secrets`, mas o CRD `externalsecrets.external-secrets.io` no cluster era do ESO chart 2.1.0 — não declarava o campo. ArgoCD não conseguia calcular structured-merge diff.

Resolvido aplicando manualmente o CRD do ESO chart 2.5.0 no cluster. Para evitar drift entre upstart-applied CRD e Helm-managed controller no futuro, é importante que downstream consiga bumpar o chart do controller também — sem precisar forkar este repo. Este PR habilita isso.

Pareado com o já existente `${externalSecretsCrdVersion:-2.4.1}` em `spec/upstart/upstart.yaml:182` (override do CRD aplicado pela pipeline de bootstrap). Os dois mecanismos juntos dão controle completo do par CRD+controller a partir do downstream.

## Test plan

- [x] `helm template` com defaults rende `targetRevision: "2.1.0"` + `installCRDs: "false"` (idêntico ao comportamento atual).
- [x] `helm template --set componentConfig.externalSecrets.chartVersion=2.5.0 --set componentConfig.externalSecrets.installCRDs=true` rende `targetRevision: "2.5.0"` + `installCRDs: "true"`.
- [ ] Lint upstream (CI roda automático).
- [ ] Após merge + bump de tag, downstream `cortex-platform-aws-us-east-1-prd` pode setar `componentConfig.externalSecrets.chartVersion: "2.5.0"` em `overrides/platform-root/values.yaml` e o ESO sobe via ArgoCD sync.

## Follow-ups (não nesse PR)

- Avaliar adotar o mesmo padrão `componentConfig.<comp>.chartVersion` para os outros componentes core (cert-manager, kyverno, traefik, cnpg-operator, etc.) que hoje têm `targetRevision` hardcoded nos respectivos templates.