### PR TITLE
feat(azure): add Private Endpoint toggles + expand diagnostic settings

### DIFF
--- a/providers/azure/cost-export.tf
+++ b/providers/azure/cost-export.tf
@@ -17,13 +17,18 @@ resource "azurerm_storage_account" "cost_exports" {
   min_tls_version                 = "TLS1_2"
   shared_access_key_enabled       = true # required by OpenCost cloud-integration
   allow_nested_items_to_be_public = false
+  public_network_access_enabled   = var.storage_private_endpoint_enabled ? false : true
 
   # Start open so Cost Management can access during export creation.
   # azurerm_storage_account_network_rules locks down after export exists.
   # ignore_changes prevents Terraform from reverting Deny back to Allow.
-  network_rules {
-    default_action = "Allow"
-    bypass         = ["AzureServices"]
+  # Skipped when PE-only — Cost Management uses trusted services bypass.
+  dynamic "network_rules" {
+    for_each = var.storage_private_endpoint_enabled ? [] : [1]
+    content {
+      default_action = "Allow"
+      bypass         = ["AzureServices"]
+    }
   }
 
   dynamic "blob_properties" {
@@ -50,8 +55,9 @@ resource "azurerm_storage_account" "cost_exports" {
 # identity with StorageBlobDataContributor during export creation. This
 # identity then works behind the firewall via trusted Azure services bypass.
 # See: https://learn.microsoft.com/azure/cost-management-billing/costs/tutorial-improved-exports
+# Skipped when PE-only — public_network_access_enabled=false handles isolation.
 resource "azurerm_storage_account_network_rules" "cost_exports" {
-  count              = var.cost_export_enabled ? 1 : 0
+  count              = var.cost_export_enabled && !var.storage_private_endpoint_enabled ? 1 : 0
   storage_account_id = azurerm_storage_account.cost_exports[0].id
   default_action     = "Deny"
   bypass             = ["AzureServices"]
@@ -71,7 +77,7 @@ resource "azurerm_storage_container" "cost_exports" {
 # ---------------------------------------------------------------------------
 
 resource "azurerm_private_endpoint" "cost_exports_blob" {
-  count               = var.cost_export_enabled ? 1 : 0
+  count               = var.cost_export_enabled && var.storage_private_endpoint_enabled ? 1 : 0
   name                = "pe-${local.base_name}-costs-blob"
   location            = azurerm_resource_group.platform.location
   resource_group_name = azurerm_resource_group.platform.name

--- a/providers/azure/diagnostics.tf
+++ b/providers/azure/diagnostics.tf
@@ -1,7 +1,12 @@
 # ---------------------------------------------------------------------------
-# Log Analytics Workspace + AKS Diagnostic Settings
+# Log Analytics Workspace + Diagnostic Settings
 # Toggle via: diagnostics_enabled = false
+# External LAW: set external_log_analytics_workspace_id to send logs to both
 # ---------------------------------------------------------------------------
+
+locals {
+  external_law_enabled = var.external_log_analytics_workspace_id != ""
+}
 
 resource "azurerm_log_analytics_workspace" "platform" {
   count               = var.diagnostics_enabled ? 1 : 0
@@ -13,30 +18,248 @@ resource "azurerm_log_analytics_workspace" "platform" {
   tags                = local.tags
 }
 
+# ---------------------------------------------------------------------------
+# AKS
+# ---------------------------------------------------------------------------
+
 resource "azurerm_monitor_diagnostic_setting" "aks" {
   count                      = var.diagnostics_enabled ? 1 : 0
   name                       = "diag-${local.base_name}-aks"
   target_resource_id         = azurerm_kubernetes_cluster.platform.id
   log_analytics_workspace_id = azurerm_log_analytics_workspace.platform[0].id
 
-  enabled_log {
-    category = "kube-audit-admin"
-  }
+  enabled_log { category = "kube-audit-admin" }
+  enabled_log { category = "kube-controller-manager" }
+  enabled_log { category = "kube-scheduler" }
+  enabled_log { category = "cluster-autoscaler" }
+  enabled_log { category = "guard" }
+}
 
-  enabled_log {
-    category = "kube-controller-manager"
-  }
+resource "azurerm_monitor_diagnostic_setting" "aks_external" {
+  count                      = local.external_law_enabled ? 1 : 0
+  name                       = "diag-${local.base_name}-aks-external"
+  target_resource_id         = azurerm_kubernetes_cluster.platform.id
+  log_analytics_workspace_id = var.external_log_analytics_workspace_id
 
-  enabled_log {
-    category = "kube-scheduler"
-  }
+  enabled_log { category = "kube-audit-admin" }
+  enabled_log { category = "kube-controller-manager" }
+  enabled_log { category = "kube-scheduler" }
+  enabled_log { category = "cluster-autoscaler" }
+  enabled_log { category = "guard" }
+}
 
-  enabled_log {
-    category = "cluster-autoscaler"
-  }
+# ---------------------------------------------------------------------------
+# Key Vault — Platform
+# ---------------------------------------------------------------------------
 
-  enabled_log {
-    category = "guard"
-  }
+resource "azurerm_monitor_diagnostic_setting" "keyvault" {
+  count                      = var.diagnostics_enabled ? 1 : 0
+  name                       = "diag-${local.base_name}-kv"
+  target_resource_id         = azurerm_key_vault.platform.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.platform[0].id
 
+  enabled_log { category = "AuditEvent" }
+  enabled_log { category = "AzurePolicyEvaluationDetails" }
+  enabled_metric { category = "AllMetrics" }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "keyvault_external" {
+  count                      = local.external_law_enabled ? 1 : 0
+  name                       = "diag-${local.base_name}-kv-external"
+  target_resource_id         = azurerm_key_vault.platform.id
+  log_analytics_workspace_id = var.external_log_analytics_workspace_id
+
+  enabled_log { category = "AuditEvent" }
+  enabled_log { category = "AzurePolicyEvaluationDetails" }
+  enabled_metric { category = "AllMetrics" }
+}
+
+# ---------------------------------------------------------------------------
+# Key Vault — Hub/Shared
+# ---------------------------------------------------------------------------
+
+resource "azurerm_monitor_diagnostic_setting" "keyvault_hub" {
+  count                      = var.diagnostics_enabled && var.shared_hub_kv_enabled ? 1 : 0
+  name                       = "diag-${local.base_name}-hub-kv"
+  target_resource_id         = azurerm_key_vault.hub[0].id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.platform[0].id
+
+  enabled_log { category = "AuditEvent" }
+  enabled_log { category = "AzurePolicyEvaluationDetails" }
+  enabled_metric { category = "AllMetrics" }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "keyvault_hub_external" {
+  count                      = local.external_law_enabled && var.shared_hub_kv_enabled ? 1 : 0
+  name                       = "diag-${local.base_name}-hub-kv-external"
+  target_resource_id         = azurerm_key_vault.hub[0].id
+  log_analytics_workspace_id = var.external_log_analytics_workspace_id
+
+  enabled_log { category = "AuditEvent" }
+  enabled_log { category = "AzurePolicyEvaluationDetails" }
+  enabled_metric { category = "AllMetrics" }
+}
+
+# ---------------------------------------------------------------------------
+# Storage Account — TFState (blob service)
+# ---------------------------------------------------------------------------
+
+resource "azurerm_monitor_diagnostic_setting" "sa_tfstate" {
+  count                      = var.diagnostics_enabled ? 1 : 0
+  name                       = "diag-${local.base_name}-tfstate-blob"
+  target_resource_id         = "${azurerm_storage_account.tfstate.id}/blobServices/default"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.platform[0].id
+
+  enabled_log { category = "StorageRead" }
+  enabled_log { category = "StorageWrite" }
+  enabled_log { category = "StorageDelete" }
+  enabled_metric { category = "Transaction" }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "sa_tfstate_external" {
+  count                      = local.external_law_enabled ? 1 : 0
+  name                       = "diag-${local.base_name}-tfstate-blob-external"
+  target_resource_id         = "${azurerm_storage_account.tfstate.id}/blobServices/default"
+  log_analytics_workspace_id = var.external_log_analytics_workspace_id
+
+  enabled_log { category = "StorageRead" }
+  enabled_log { category = "StorageWrite" }
+  enabled_log { category = "StorageDelete" }
+  enabled_metric { category = "Transaction" }
+}
+
+# ---------------------------------------------------------------------------
+# Storage Account — Observability (blob service)
+# ---------------------------------------------------------------------------
+
+resource "azurerm_monitor_diagnostic_setting" "sa_observability" {
+  count                      = var.diagnostics_enabled ? 1 : 0
+  name                       = "diag-${local.base_name}-obs-blob"
+  target_resource_id         = "${azurerm_storage_account.observability.id}/blobServices/default"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.platform[0].id
+
+  enabled_log { category = "StorageRead" }
+  enabled_log { category = "StorageWrite" }
+  enabled_log { category = "StorageDelete" }
+  enabled_metric { category = "Transaction" }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "sa_observability_external" {
+  count                      = local.external_law_enabled ? 1 : 0
+  name                       = "diag-${local.base_name}-obs-blob-external"
+  target_resource_id         = "${azurerm_storage_account.observability.id}/blobServices/default"
+  log_analytics_workspace_id = var.external_log_analytics_workspace_id
+
+  enabled_log { category = "StorageRead" }
+  enabled_log { category = "StorageWrite" }
+  enabled_log { category = "StorageDelete" }
+  enabled_metric { category = "Transaction" }
+}
+
+# ---------------------------------------------------------------------------
+# Storage Account — CNPG Backup (blob service)
+# ---------------------------------------------------------------------------
+
+resource "azurerm_monitor_diagnostic_setting" "sa_cnpg" {
+  count                      = var.diagnostics_enabled ? 1 : 0
+  name                       = "diag-${local.base_name}-cnpg-blob"
+  target_resource_id         = "${azurerm_storage_account.cnpg_backup.id}/blobServices/default"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.platform[0].id
+
+  enabled_log { category = "StorageRead" }
+  enabled_log { category = "StorageWrite" }
+  enabled_log { category = "StorageDelete" }
+  enabled_metric { category = "Transaction" }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "sa_cnpg_external" {
+  count                      = local.external_law_enabled ? 1 : 0
+  name                       = "diag-${local.base_name}-cnpg-blob-external"
+  target_resource_id         = "${azurerm_storage_account.cnpg_backup.id}/blobServices/default"
+  log_analytics_workspace_id = var.external_log_analytics_workspace_id
+
+  enabled_log { category = "StorageRead" }
+  enabled_log { category = "StorageWrite" }
+  enabled_log { category = "StorageDelete" }
+  enabled_metric { category = "Transaction" }
+}
+
+# ---------------------------------------------------------------------------
+# Storage Account — Velero Backup (blob service)
+# ---------------------------------------------------------------------------
+
+resource "azurerm_monitor_diagnostic_setting" "sa_velero" {
+  count                      = var.diagnostics_enabled ? 1 : 0
+  name                       = "diag-${local.base_name}-velero-blob"
+  target_resource_id         = "${azurerm_storage_account.velero_backup.id}/blobServices/default"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.platform[0].id
+
+  enabled_log { category = "StorageRead" }
+  enabled_log { category = "StorageWrite" }
+  enabled_log { category = "StorageDelete" }
+  enabled_metric { category = "Transaction" }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "sa_velero_external" {
+  count                      = local.external_law_enabled ? 1 : 0
+  name                       = "diag-${local.base_name}-velero-blob-external"
+  target_resource_id         = "${azurerm_storage_account.velero_backup.id}/blobServices/default"
+  log_analytics_workspace_id = var.external_log_analytics_workspace_id
+
+  enabled_log { category = "StorageRead" }
+  enabled_log { category = "StorageWrite" }
+  enabled_log { category = "StorageDelete" }
+  enabled_metric { category = "Transaction" }
+}
+
+# ---------------------------------------------------------------------------
+# Storage Account — Cost Exports (blob service)
+# ---------------------------------------------------------------------------
+
+resource "azurerm_monitor_diagnostic_setting" "sa_cost_exports" {
+  count                      = var.diagnostics_enabled && var.cost_export_enabled ? 1 : 0
+  name                       = "diag-${local.base_name}-costs-blob"
+  target_resource_id         = "${azurerm_storage_account.cost_exports[0].id}/blobServices/default"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.platform[0].id
+
+  enabled_log { category = "StorageRead" }
+  enabled_log { category = "StorageWrite" }
+  enabled_log { category = "StorageDelete" }
+  enabled_metric { category = "Transaction" }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "sa_cost_exports_external" {
+  count                      = local.external_law_enabled && var.cost_export_enabled ? 1 : 0
+  name                       = "diag-${local.base_name}-costs-blob-external"
+  target_resource_id         = "${azurerm_storage_account.cost_exports[0].id}/blobServices/default"
+  log_analytics_workspace_id = var.external_log_analytics_workspace_id
+
+  enabled_log { category = "StorageRead" }
+  enabled_log { category = "StorageWrite" }
+  enabled_log { category = "StorageDelete" }
+  enabled_metric { category = "Transaction" }
+}
+
+# ---------------------------------------------------------------------------
+# ACR (Azure Container Registry)
+# ---------------------------------------------------------------------------
+
+resource "azurerm_monitor_diagnostic_setting" "acr" {
+  count                      = var.diagnostics_enabled && var.acr_enabled ? 1 : 0
+  name                       = "diag-${local.base_name}-acr"
+  target_resource_id         = azurerm_container_registry.platform[0].id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.platform[0].id
+
+  enabled_log { category = "ContainerRegistryRepositoryEvents" }
+  enabled_log { category = "ContainerRegistryLoginEvents" }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "acr_external" {
+  count                      = local.external_law_enabled && var.acr_enabled ? 1 : 0
+  name                       = "diag-${local.base_name}-acr-external"
+  target_resource_id         = azurerm_container_registry.platform[0].id
+  log_analytics_workspace_id = var.external_log_analytics_workspace_id
+
+  enabled_log { category = "ContainerRegistryRepositoryEvents" }
+  enabled_log { category = "ContainerRegistryLoginEvents" }
 }

--- a/providers/azure/keyvault.tf
+++ b/providers/azure/keyvault.tf
@@ -3,17 +3,18 @@
 # ---------------------------------------------------------------------------
 
 resource "azurerm_key_vault" "platform" {
-  name                       = "kv-${var.name_prefix}-${local.env_code}-${random_string.storage_suffix.result}"
-  location                   = azurerm_resource_group.platform.location
-  resource_group_name        = azurerm_resource_group.platform.name
-  tenant_id                  = var.tenant_id
-  sku_name                   = "standard"
-  rbac_authorization_enabled = true
-  soft_delete_retention_days = var.keyvault_soft_delete_days
-  purge_protection_enabled   = var.keyvault_purge_protection
+  name                          = "kv-${var.name_prefix}-${local.env_code}-${random_string.storage_suffix.result}"
+  location                      = azurerm_resource_group.platform.location
+  resource_group_name           = azurerm_resource_group.platform.name
+  tenant_id                     = var.tenant_id
+  sku_name                      = "standard"
+  rbac_authorization_enabled    = true
+  soft_delete_retention_days    = var.keyvault_soft_delete_days
+  purge_protection_enabled      = var.keyvault_purge_protection
+  public_network_access_enabled = var.keyvault_private_endpoint_enabled ? false : true
 
   dynamic "network_acls" {
-    for_each = var.firewall_enabled ? [1] : []
+    for_each = !var.keyvault_private_endpoint_enabled && var.firewall_enabled ? [1] : []
     content {
       default_action             = "Deny"
       bypass                     = "AzureServices"
@@ -148,4 +149,45 @@ resource "azurerm_key_vault_secret" "openai_api_key" {
   key_vault_id = azurerm_key_vault.platform.id
 
   depends_on = [azurerm_role_assignment.terraform_kv_officer]
+}
+
+# ---------------------------------------------------------------------------
+# Private Endpoint — Key Vault (platform) via VNet
+# PDZ vaultcore is shared with the hub KV in shared.tf
+# ---------------------------------------------------------------------------
+
+resource "azurerm_private_dns_zone" "vaultcore" {
+  count               = var.keyvault_private_endpoint_enabled ? 1 : 0
+  name                = "privatelink.vaultcore.azure.net"
+  resource_group_name = azurerm_resource_group.platform.name
+  tags                = local.tags
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "vaultcore" {
+  count                 = var.keyvault_private_endpoint_enabled ? 1 : 0
+  name                  = "vnetlink-${local.base_name}-vaultcore"
+  resource_group_name   = azurerm_resource_group.platform.name
+  private_dns_zone_name = azurerm_private_dns_zone.vaultcore[0].name
+  virtual_network_id    = azurerm_virtual_network.platform.id
+}
+
+resource "azurerm_private_endpoint" "keyvault_platform" {
+  count               = var.keyvault_private_endpoint_enabled ? 1 : 0
+  name                = "pe-${local.base_name}-kv-vault"
+  location            = azurerm_resource_group.platform.location
+  resource_group_name = azurerm_resource_group.platform.name
+  subnet_id           = azurerm_subnet.aks_nodes.id
+  tags                = local.tags
+
+  private_service_connection {
+    name                           = "psc-${local.base_name}-kv-vault"
+    private_connection_resource_id = azurerm_key_vault.platform.id
+    subresource_names              = ["vault"]
+    is_manual_connection           = false
+  }
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [azurerm_private_dns_zone.vaultcore[0].id]
+  }
 }

--- a/providers/azure/outputs.tf
+++ b/providers/azure/outputs.tf
@@ -130,6 +130,18 @@ output "acr_ci_client_id" {
   value       = var.acr_enabled && var.acr_ci_identity_enabled ? azurerm_user_assigned_identity.acr_ci[0].client_id : ""
 }
 
+# --- Diagnostics ---
+
+output "log_analytics_workspace_id" {
+  description = "Resource ID of the local Log Analytics Workspace (null if diagnostics_enabled=false)."
+  value       = var.diagnostics_enabled ? azurerm_log_analytics_workspace.platform[0].id : null
+}
+
+output "log_analytics_workspace_name" {
+  description = "Name of the local Log Analytics Workspace (null if diagnostics_enabled=false)."
+  value       = var.diagnostics_enabled ? azurerm_log_analytics_workspace.platform[0].name : null
+}
+
 # --- Network ---
 
 output "nat_gateway_public_ip" {

--- a/providers/azure/shared.tf
+++ b/providers/azure/shared.tf
@@ -27,17 +27,18 @@ resource "azurerm_key_vault" "hub" {
   # 24-char Key Vault name limit. The dashed form "kv-{prefix}-hub-{env}-{suffix}"
   # exceeds 24 chars for most prefixes. Matches the storage account naming
   # convention used elsewhere in the codebase (st{prefix}{env}obs{suffix}).
-  name                       = "kv${var.name_prefix}hub${local.env_code}${random_string.storage_suffix.result}"
-  resource_group_name        = azurerm_resource_group.shared[0].name
-  location                   = azurerm_resource_group.shared[0].location
-  sku_name                   = "standard"
-  tenant_id                  = var.tenant_id
-  rbac_authorization_enabled = true
-  purge_protection_enabled   = var.keyvault_purge_protection
-  soft_delete_retention_days = var.keyvault_soft_delete_days
+  name                          = "kv${var.name_prefix}hub${local.env_code}${random_string.storage_suffix.result}"
+  resource_group_name           = azurerm_resource_group.shared[0].name
+  location                      = azurerm_resource_group.shared[0].location
+  sku_name                      = "standard"
+  tenant_id                     = var.tenant_id
+  rbac_authorization_enabled    = true
+  purge_protection_enabled      = var.keyvault_purge_protection
+  soft_delete_retention_days    = var.keyvault_soft_delete_days
+  public_network_access_enabled = var.keyvault_private_endpoint_enabled ? false : true
 
   dynamic "network_acls" {
-    for_each = var.firewall_enabled ? [1] : []
+    for_each = !var.keyvault_private_endpoint_enabled && var.firewall_enabled ? [1] : []
     content {
       default_action             = "Deny"
       bypass                     = "AzureServices"
@@ -99,3 +100,29 @@ resource "azurerm_key_vault_secret" "hub_egress_ip" {
 # estabilis CLI during `estabilis upstart`, after the workload-operator
 # chart is synced and the ServiceAccount token exists in Kubernetes.
 # See: estabilis-platform-tools issue #69.
+
+# ---------------------------------------------------------------------------
+# Private Endpoint — Key Vault (hub) via VNet
+# Shares the PDZ vaultcore declared in keyvault.tf
+# ---------------------------------------------------------------------------
+
+resource "azurerm_private_endpoint" "keyvault_hub" {
+  count               = var.shared_hub_kv_enabled && var.keyvault_private_endpoint_enabled ? 1 : 0
+  name                = "pe-${local.base_name}-hub-vault"
+  location            = azurerm_resource_group.shared[0].location
+  resource_group_name = azurerm_resource_group.shared[0].name
+  subnet_id           = azurerm_subnet.aks_nodes.id
+  tags                = local.tags
+
+  private_service_connection {
+    name                           = "psc-${local.base_name}-hub-vault"
+    private_connection_resource_id = azurerm_key_vault.hub[0].id
+    subresource_names              = ["vault"]
+    is_manual_connection           = false
+  }
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [azurerm_private_dns_zone.vaultcore[0].id]
+  }
+}

--- a/providers/azure/storage.tf
+++ b/providers/azure/storage.tf
@@ -11,8 +11,7 @@ resource "azurerm_storage_account" "observability" {
   min_tls_version                 = "TLS1_2"
   shared_access_key_enabled       = false
   allow_nested_items_to_be_public = false
-
-  public_network_access_enabled = false
+  public_network_access_enabled   = var.storage_private_endpoint_enabled ? false : true
 
   dynamic "blob_properties" {
     for_each = var.storage_soft_delete_enabled ? [1] : []
@@ -25,14 +24,26 @@ resource "azurerm_storage_account" "observability" {
       }
     }
   }
+
+  dynamic "network_rules" {
+    for_each = !var.storage_private_endpoint_enabled && var.firewall_enabled ? [1] : []
+    content {
+      default_action             = "Deny"
+      bypass                     = ["AzureServices"]
+      ip_rules                   = local.firewall_base_ips_bare
+      virtual_network_subnet_ids = local.firewall_base_subnet_ids
+    }
+  }
+
   tags = local.tags
 }
 
 # ---------------------------------------------------------------------------
-# Private Endpoint — blob access only via VNet
+# Private Endpoint — observability blob access via VNet
 # ---------------------------------------------------------------------------
 
 resource "azurerm_private_endpoint" "observability_blob" {
+  count               = var.storage_private_endpoint_enabled ? 1 : 0
   name                = "pe-${local.base_name}-obs-blob"
   location            = azurerm_resource_group.platform.location
   resource_group_name = azurerm_resource_group.platform.name
@@ -100,6 +111,7 @@ resource "azurerm_storage_account" "cnpg_backup" {
   min_tls_version                 = "TLS1_2"
   shared_access_key_enabled       = false
   allow_nested_items_to_be_public = false
+  public_network_access_enabled   = var.storage_private_endpoint_enabled ? false : true
 
   dynamic "blob_properties" {
     for_each = var.storage_soft_delete_enabled ? [1] : []
@@ -114,7 +126,7 @@ resource "azurerm_storage_account" "cnpg_backup" {
   }
 
   dynamic "network_rules" {
-    for_each = var.firewall_enabled ? [1] : []
+    for_each = !var.storage_private_endpoint_enabled && var.firewall_enabled ? [1] : []
     content {
       default_action             = "Deny"
       bypass                     = ["AzureServices"]
@@ -132,6 +144,27 @@ resource "azurerm_storage_container" "cnpg_backup" {
   container_access_type = "private"
 }
 
+resource "azurerm_private_endpoint" "cnpg_blob" {
+  count               = var.storage_private_endpoint_enabled ? 1 : 0
+  name                = "pe-${local.base_name}-cnpg-blob"
+  location            = azurerm_resource_group.platform.location
+  resource_group_name = azurerm_resource_group.platform.name
+  subnet_id           = azurerm_subnet.aks_nodes.id
+  tags                = local.tags
+
+  private_service_connection {
+    name                           = "psc-${local.base_name}-cnpg-blob"
+    private_connection_resource_id = azurerm_storage_account.cnpg_backup.id
+    subresource_names              = ["blob"]
+    is_manual_connection           = false
+  }
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [azurerm_private_dns_zone.blob.id]
+  }
+}
+
 # ---------------------------------------------------------------------------
 # Storage Account – Velero Backup (Kubernetes disaster recovery)
 # ---------------------------------------------------------------------------
@@ -145,6 +178,7 @@ resource "azurerm_storage_account" "velero_backup" {
   min_tls_version                 = "TLS1_2"
   shared_access_key_enabled       = false
   allow_nested_items_to_be_public = false
+  public_network_access_enabled   = var.storage_private_endpoint_enabled ? false : true
 
   dynamic "blob_properties" {
     for_each = var.storage_soft_delete_enabled ? [1] : []
@@ -159,7 +193,7 @@ resource "azurerm_storage_account" "velero_backup" {
   }
 
   dynamic "network_rules" {
-    for_each = var.firewall_enabled ? [1] : []
+    for_each = !var.storage_private_endpoint_enabled && var.firewall_enabled ? [1] : []
     content {
       default_action             = "Deny"
       bypass                     = ["AzureServices"]
@@ -175,4 +209,25 @@ resource "azurerm_storage_container" "velero_backup" {
   name                  = "velero-backup"
   storage_account_id    = azurerm_storage_account.velero_backup.id
   container_access_type = "private"
+}
+
+resource "azurerm_private_endpoint" "velero_blob" {
+  count               = var.storage_private_endpoint_enabled ? 1 : 0
+  name                = "pe-${local.base_name}-velero-blob"
+  location            = azurerm_resource_group.platform.location
+  resource_group_name = azurerm_resource_group.platform.name
+  subnet_id           = azurerm_subnet.aks_nodes.id
+  tags                = local.tags
+
+  private_service_connection {
+    name                           = "psc-${local.base_name}-velero-blob"
+    private_connection_resource_id = azurerm_storage_account.velero_backup.id
+    subresource_names              = ["blob"]
+    is_manual_connection           = false
+  }
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [azurerm_private_dns_zone.blob.id]
+  }
 }

--- a/providers/azure/tfstate.tf
+++ b/providers/azure/tfstate.tf
@@ -18,6 +18,7 @@ resource "azurerm_storage_account" "tfstate" {
   min_tls_version                 = "TLS1_2"
   shared_access_key_enabled       = false
   allow_nested_items_to_be_public = false
+  public_network_access_enabled   = var.storage_private_endpoint_enabled ? false : true
 
   dynamic "blob_properties" {
     for_each = var.storage_soft_delete_enabled ? [1] : []
@@ -32,7 +33,7 @@ resource "azurerm_storage_account" "tfstate" {
   }
 
   dynamic "network_rules" {
-    for_each = var.firewall_enabled ? [1] : []
+    for_each = !var.storage_private_endpoint_enabled && var.firewall_enabled ? [1] : []
     content {
       default_action             = "Deny"
       bypass                     = ["AzureServices"]
@@ -58,4 +59,30 @@ resource "azurerm_role_assignment" "tfstate_deployer" {
   scope                = azurerm_storage_container.tfstate.id
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = data.azurerm_client_config.current.object_id
+}
+
+# ---------------------------------------------------------------------------
+# Private Endpoint — tfstate blob access via VNet
+# Shares the PDZ blob declared in storage.tf
+# ---------------------------------------------------------------------------
+
+resource "azurerm_private_endpoint" "tfstate_blob" {
+  count               = var.storage_private_endpoint_enabled ? 1 : 0
+  name                = "pe-${local.base_name}-tfstate-blob"
+  location            = azurerm_resource_group.tfstate.location
+  resource_group_name = azurerm_resource_group.tfstate.name
+  subnet_id           = azurerm_subnet.aks_nodes.id
+  tags                = local.tags
+
+  private_service_connection {
+    name                           = "psc-${local.base_name}-tfstate-blob"
+    private_connection_resource_id = azurerm_storage_account.tfstate.id
+    subresource_names              = ["blob"]
+    is_manual_connection           = false
+  }
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [azurerm_private_dns_zone.blob.id]
+  }
 }

--- a/providers/azure/variables.tf
+++ b/providers/azure/variables.tf
@@ -925,6 +925,22 @@ variable "storage_velero_extra_allowed_ips" {
   default     = []
 }
 
+# ---------------------------------------------------------------------------
+# Private Endpoints (opt-in — zero public access + VNet-only connectivity)
+# ---------------------------------------------------------------------------
+
+variable "keyvault_private_endpoint_enabled" {
+  description = "Enable Private Endpoint for Key Vaults (platform + hub). When true, public access is disabled and firewall rules are removed."
+  type        = bool
+  default     = false
+}
+
+variable "storage_private_endpoint_enabled" {
+  description = "Enable Private Endpoint for Storage Accounts (tfstate, cnpg, velero, observability, cost-exports). When true, public access is disabled and firewall rules are removed."
+  type        = bool
+  default     = false
+}
+
 variable "storage_soft_delete_enabled" {
   description = "Enable blob and container soft delete on all storage accounts."
   type        = bool
@@ -957,6 +973,12 @@ variable "log_analytics_retention_days" {
   description = "Retention days for Log Analytics Workspace (AKS audit logs)."
   type        = number
   default     = 30
+}
+
+variable "external_log_analytics_workspace_id" {
+  description = "Optional ARM resource ID of an external Log Analytics Workspace. When set, all diagnostic settings send logs to BOTH the local LAW and this external LAW. Useful for centralized logging (hub LAW, SIEM, compliance). The local LAW continues to exist for OMS agent and local queries."
+  type        = string
+  default     = ""
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `keyvault_private_endpoint_enabled` and `storage_private_endpoint_enabled` toggles (default `false`) that, when enabled, create PE + PDZ + vnet_link and set `public_network_access_enabled = false`, removing firewall rules (mutually exclusive)
- Expand diagnostic settings to KV platform, KV hub, 5 Storage Accounts (blob service), and ACR — all gated by `diagnostics_enabled`
- Add `external_log_analytics_workspace_id` variable for optional parallel external LAW (independent of `diagnostics_enabled`)
- Add `log_analytics_workspace_id` and `log_analytics_workspace_name` outputs

## Private Endpoint toggles

| Toggle | Resources | PDZ |
|---|---|---|
| `keyvault_private_endpoint_enabled` | KV platform + KV hub | `privatelink.vaultcore.azure.net` (shared, 1 PDZ + 2 PEs) |
| `storage_private_endpoint_enabled` | SA tfstate, cnpg, velero, observability, cost-exports | `privatelink.blob.core.windows.net` (existing, shared) |

When `false` (default): no behavior change — firewall rules apply as before.

**SA observability** was previously hardcoded PE-only; now gated by toggle (gets `network_rules` when PE=false).

**SA cost-exports** was previously PE+firewall hybrid; now PE-only when toggle=true (Cost Management uses trusted services bypass).

## Diagnostic settings matrix

| `diagnostics_enabled` | `external_law_id` | Result |
|---|---|---|
| `false` | `""` | Nothing (current behavior) |
| `true` | `""` | Local LAW + local diag settings (current + expanded) |
| `true` | `"<ARM ID>"` | Local LAW + local diags + external diags |
| `false` | `"<ARM ID>"` | External diags only (no local LAW, no OMS) |

## Test plan

- [ ] `terraform validate` passes (verified locally)
- [ ] `terraform plan` with both toggles `false` shows no diff on existing deployment
- [ ] `terraform plan` with `keyvault_private_endpoint_enabled = true` creates PE + PDZ vaultcore + vnet_link for both KVs
- [ ] `terraform plan` with `storage_private_endpoint_enabled = true` creates PEs for all 5 SAs, removes firewall rules
- [ ] `terraform plan` with `diagnostics_enabled = true` (default) shows new diag settings for KV/SA/ACR
- [ ] `terraform plan` with `external_log_analytics_workspace_id` set shows parallel external diag settings
- [ ] Verify `diagnostics_enabled = false` still suppresses all local diag settings + LAW