### PR TITLE
feat(azure): support external Private DNS Zones for hub-spoke topologies

### DIFF
--- a/providers/azure/acr.tf
+++ b/providers/azure/acr.tf
@@ -174,14 +174,14 @@ resource "azurerm_container_registry_cache_rule" "dockerhub" {
 # ---------------------------------------------------------------------------
 
 resource "azurerm_private_dns_zone" "acr" {
-  count               = var.acr_enabled && local.acr_is_premium && var.acr_private_endpoint_enabled ? 1 : 0
+  count               = var.acr_enabled && local.acr_is_premium && var.acr_private_endpoint_enabled && local.create_local_acr_pdz ? 1 : 0
   name                = "privatelink.azurecr.io"
   resource_group_name = azurerm_resource_group.platform.name
   tags                = local.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "acr" {
-  count                 = var.acr_enabled && local.acr_is_premium && var.acr_private_endpoint_enabled ? 1 : 0
+  count                 = var.acr_enabled && local.acr_is_premium && var.acr_private_endpoint_enabled && local.create_local_acr_pdz ? 1 : 0
   name                  = "acr-dns-link"
   resource_group_name   = azurerm_resource_group.platform.name
   private_dns_zone_name = azurerm_private_dns_zone.acr[0].name
@@ -206,7 +206,7 @@ resource "azurerm_private_endpoint" "acr" {
 
   private_dns_zone_group {
     name                 = "acr-dns-group"
-    private_dns_zone_ids = [azurerm_private_dns_zone.acr[0].id]
+    private_dns_zone_ids = [local.acr_pdz_id]
   }
 }
 

--- a/providers/azure/cost-export.tf
+++ b/providers/azure/cost-export.tf
@@ -93,7 +93,7 @@ resource "azurerm_private_endpoint" "cost_exports_blob" {
 
   private_dns_zone_group {
     name                 = "default"
-    private_dns_zone_ids = [azurerm_private_dns_zone.blob.id]
+    private_dns_zone_ids = [local.blob_pdz_id]
   }
 }
 

--- a/providers/azure/keyvault.tf
+++ b/providers/azure/keyvault.tf
@@ -157,14 +157,14 @@ resource "azurerm_key_vault_secret" "openai_api_key" {
 # ---------------------------------------------------------------------------
 
 resource "azurerm_private_dns_zone" "vaultcore" {
-  count               = var.keyvault_private_endpoint_enabled ? 1 : 0
+  count               = var.keyvault_private_endpoint_enabled && local.create_local_vaultcore_pdz ? 1 : 0
   name                = "privatelink.vaultcore.azure.net"
   resource_group_name = azurerm_resource_group.platform.name
   tags                = local.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "vaultcore" {
-  count                 = var.keyvault_private_endpoint_enabled ? 1 : 0
+  count                 = var.keyvault_private_endpoint_enabled && local.create_local_vaultcore_pdz ? 1 : 0
   name                  = "vnetlink-${local.base_name}-vaultcore"
   resource_group_name   = azurerm_resource_group.platform.name
   private_dns_zone_name = azurerm_private_dns_zone.vaultcore[0].name
@@ -188,6 +188,6 @@ resource "azurerm_private_endpoint" "keyvault_platform" {
 
   private_dns_zone_group {
     name                 = "default"
-    private_dns_zone_ids = [azurerm_private_dns_zone.vaultcore[0].id]
+    private_dns_zone_ids = [local.vaultcore_pdz_id]
   }
 }

--- a/providers/azure/main.tf
+++ b/providers/azure/main.tf
@@ -158,6 +158,17 @@ locals {
   # Storage accounts require IPs without /32 (max /30 or bare IP)
   firewall_base_ips_bare = [for ip in local.firewall_base_ips : replace(ip, "/32", "")]
 
+  # ---------------------------------------------------------------------------
+  # Private DNS Zone resolution — external (hub) vs local (standalone)
+  # ---------------------------------------------------------------------------
+  create_local_blob_pdz      = var.external_pdz_blob_id == ""
+  create_local_acr_pdz       = var.external_pdz_acr_id == ""
+  create_local_vaultcore_pdz = var.external_pdz_vaultcore_id == ""
+
+  blob_pdz_id      = var.external_pdz_blob_id != "" ? var.external_pdz_blob_id : azurerm_private_dns_zone.blob[0].id
+  acr_pdz_id       = var.external_pdz_acr_id != "" ? var.external_pdz_acr_id : azurerm_private_dns_zone.acr[0].id
+  vaultcore_pdz_id = var.external_pdz_vaultcore_id != "" ? var.external_pdz_vaultcore_id : azurerm_private_dns_zone.vaultcore[0].id
+
   # Per-resource firewall IPs (base + extras)
   firewall_keyvault_ips = distinct(concat(local.firewall_base_ips, var.keyvault_extra_allowed_ips))
   firewall_acr_ips      = distinct(concat(local.firewall_base_ips, var.acr_extra_allowed_ips))

--- a/providers/azure/shared.tf
+++ b/providers/azure/shared.tf
@@ -123,6 +123,6 @@ resource "azurerm_private_endpoint" "keyvault_hub" {
 
   private_dns_zone_group {
     name                 = "default"
-    private_dns_zone_ids = [azurerm_private_dns_zone.vaultcore[0].id]
+    private_dns_zone_ids = [local.vaultcore_pdz_id]
   }
 }

--- a/providers/azure/storage.tf
+++ b/providers/azure/storage.tf
@@ -59,20 +59,22 @@ resource "azurerm_private_endpoint" "observability_blob" {
 
   private_dns_zone_group {
     name                 = "default"
-    private_dns_zone_ids = [azurerm_private_dns_zone.blob.id]
+    private_dns_zone_ids = [local.blob_pdz_id]
   }
 }
 
 resource "azurerm_private_dns_zone" "blob" {
+  count               = local.create_local_blob_pdz ? 1 : 0
   name                = "privatelink.blob.core.windows.net"
   resource_group_name = azurerm_resource_group.platform.name
   tags                = local.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "blob" {
+  count                 = local.create_local_blob_pdz ? 1 : 0
   name                  = "vnetlink-${local.base_name}-blob"
   resource_group_name   = azurerm_resource_group.platform.name
-  private_dns_zone_name = azurerm_private_dns_zone.blob.name
+  private_dns_zone_name = azurerm_private_dns_zone.blob[0].name
   virtual_network_id    = azurerm_virtual_network.platform.id
 }
 
@@ -161,7 +163,7 @@ resource "azurerm_private_endpoint" "cnpg_blob" {
 
   private_dns_zone_group {
     name                 = "default"
-    private_dns_zone_ids = [azurerm_private_dns_zone.blob.id]
+    private_dns_zone_ids = [local.blob_pdz_id]
   }
 }
 
@@ -228,6 +230,6 @@ resource "azurerm_private_endpoint" "velero_blob" {
 
   private_dns_zone_group {
     name                 = "default"
-    private_dns_zone_ids = [azurerm_private_dns_zone.blob.id]
+    private_dns_zone_ids = [local.blob_pdz_id]
   }
 }

--- a/providers/azure/tfstate.tf
+++ b/providers/azure/tfstate.tf
@@ -83,6 +83,6 @@ resource "azurerm_private_endpoint" "tfstate_blob" {
 
   private_dns_zone_group {
     name                 = "default"
-    private_dns_zone_ids = [azurerm_private_dns_zone.blob.id]
+    private_dns_zone_ids = [local.blob_pdz_id]
   }
 }

--- a/providers/azure/variables.tf
+++ b/providers/azure/variables.tf
@@ -941,6 +941,28 @@ variable "storage_private_endpoint_enabled" {
   default     = false
 }
 
+# ---------------------------------------------------------------------------
+# Private DNS Zones — external (hub-spoke) vs local (standalone)
+# ---------------------------------------------------------------------------
+
+variable "external_pdz_blob_id" {
+  description = "ARM resource ID of an external Private DNS Zone for privatelink.blob.core.windows.net (e.g., from a hub). When set, the module skips creating a local blob PDZ and uses this one for all blob PE dns_zone_groups. Leave empty to create a local PDZ (default, standalone mode)."
+  type        = string
+  default     = ""
+}
+
+variable "external_pdz_acr_id" {
+  description = "ARM resource ID of an external Private DNS Zone for privatelink.azurecr.io. When set, skips local ACR PDZ. Leave empty for local (default)."
+  type        = string
+  default     = ""
+}
+
+variable "external_pdz_vaultcore_id" {
+  description = "ARM resource ID of an external Private DNS Zone for privatelink.vaultcore.azure.net. When set, skips local vaultcore PDZ. Leave empty for local (default)."
+  type        = string
+  default     = ""
+}
+
 variable "storage_soft_delete_enabled" {
   description = "Enable blob and container soft delete on all storage accounts."
   type        = bool


### PR DESCRIPTION
## Summary

- Add `external_pdz_blob_id`, `external_pdz_acr_id`, `external_pdz_vaultcore_id` variables (string, default `""`)
- When set, module skips creating local PDZ + vnet_link and uses the external ARM ID in all PE `dns_zone_groups`
- When empty (default), module creates local PDZs — identical behavior to v0.56.0
- Resolves Azure "overlapping namespace" error in hub-spoke deployments where canonical PDZs live centralized in the hub

## Motivation

Hub-spoke architectures (CAF) centralize Private DNS Zones in a connectivity subscription/RG and link all spoke VNets to them. When the platform module also creates its own local PDZs for the same namespaces, Azure rejects the second vnet_link with:

> A virtual network cannot be linked to multiple zones with overlapping namespaces.

## Usage

```hcl
# Standalone (default — no change needed)
# Module creates local PDZs as before

# Hub-spoke (pass hub PDZ IDs)
external_pdz_blob_id      = "/subscriptions/.../privateDnsZones/privatelink.blob.core.windows.net"
external_pdz_acr_id       = "/subscriptions/.../privateDnsZones/privatelink.azurecr.io"
external_pdz_vaultcore_id = "/subscriptions/.../privateDnsZones/privatelink.vaultcore.azure.net"
```

## Files changed

| File | Change |
|---|---|
| `variables.tf` | 3 new variables |
| `main.tf` | Locals: `create_local_*_pdz`, `*_pdz_id` |
| `storage.tf` | Count on blob PDZ/link, refs → `local.blob_pdz_id` |
| `acr.tf` | Count on ACR PDZ/link, ref → `local.acr_pdz_id` |
| `keyvault.tf` | Count on vaultcore PDZ/link, ref → `local.vaultcore_pdz_id` |
| `shared.tf` | Ref → `local.vaultcore_pdz_id` |
| `cost-export.tf` | Ref → `local.blob_pdz_id` |
| `tfstate.tf` | Ref → `local.blob_pdz_id` |

## Test plan

- [ ] `terraform validate` passes (verified locally)
- [ ] `terraform plan` with all `external_pdz_*` empty shows zero diff on existing deployment
- [ ] `terraform plan` with `external_pdz_blob_id` set shows destroy of local blob PDZ + vnet_link, PE dns_zone_groups updated in-place
- [ ] `terraform plan` with all 3 external PDZ IDs set shows no local PDZs created
- [ ] Migration path: set external vars → apply → create hub vnet_links (brief DNS gap during transition)