### PR TITLE
feat(azure/aks): auto-create UAMI when private_dns_zone_id is external

### DIFF
--- a/providers/azure/aks.tf
+++ b/providers/azure/aks.tf
@@ -1,4 +1,24 @@
 # ---------------------------------------------------------------------------
+# UAMI for AKS — required when private_dns_zone_id is an external ARM ID
+# AKS with SystemAssigned cannot write A records to PDZs outside the MC_ RG.
+# ---------------------------------------------------------------------------
+
+resource "azurerm_user_assigned_identity" "aks" {
+  count               = local.use_uami ? 1 : 0
+  name                = "mi-${local.base_name}-aks"
+  location            = azurerm_resource_group.platform.location
+  resource_group_name = azurerm_resource_group.platform.name
+  tags                = local.tags
+}
+
+resource "azurerm_role_assignment" "aks_pdz_contributor" {
+  count                = local.use_uami ? 1 : 0
+  scope                = var.private_dns_zone_id
+  role_definition_name = "Private DNS Zone Contributor"
+  principal_id         = azurerm_user_assigned_identity.aks[0].principal_id
+}
+
+# ---------------------------------------------------------------------------
 # AKS Cluster
 # ---------------------------------------------------------------------------
 
@@ -16,7 +36,8 @@ resource "azurerm_kubernetes_cluster" "platform" {
 
   # --- Identity ----------------------------------------------------------
   identity {
-    type = "SystemAssigned"
+    type         = local.use_uami ? "UserAssigned" : "SystemAssigned"
+    identity_ids = local.use_uami ? [azurerm_user_assigned_identity.aks[0].id] : null
   }
 
   workload_identity_enabled = true

--- a/providers/azure/main.tf
+++ b/providers/azure/main.tf
@@ -159,6 +159,11 @@ locals {
   firewall_base_ips_bare = [for ip in local.firewall_base_ips : replace(ip, "/32", "")]
 
   # ---------------------------------------------------------------------------
+  # AKS identity — UAMI when private_dns_zone_id is an ARM resource ID
+  # ---------------------------------------------------------------------------
+  use_uami = var.enable_private_cluster && !contains(["System", "None", ""], var.private_dns_zone_id)
+
+  # ---------------------------------------------------------------------------
   # Private DNS Zone resolution — external (hub) vs local (standalone)
   # ---------------------------------------------------------------------------
   create_local_blob_pdz      = var.external_pdz_blob_id == ""

--- a/providers/azure/network.tf
+++ b/providers/azure/network.tf
@@ -30,7 +30,7 @@ resource "azurerm_subnet" "aks_nodes" {
 resource "azurerm_role_assignment" "aks_network_contributor" {
   scope                = azurerm_subnet.aks_nodes.id
   role_definition_name = "Network Contributor"
-  principal_id         = azurerm_kubernetes_cluster.platform.identity[0].principal_id
+  principal_id         = local.use_uami ? azurerm_user_assigned_identity.aks[0].principal_id : azurerm_kubernetes_cluster.platform.identity[0].principal_id
 }
 
 resource "azurerm_subnet" "aks_pods" {


### PR DESCRIPTION
## Summary

- Auto-create User Assigned Managed Identity (UAMI) when `private_dns_zone_id` is an ARM resource ID (not `"System"` or `"None"`)
- Assign `Private DNS Zone Contributor` on the target PDZ to the UAMI
- Switch AKS `identity` block from `SystemAssigned` to `UserAssigned` automatically
- Update `Network Contributor` role assignment to use UAMI principal when applicable
- No new variables — trigger is implicit from the existing `private_dns_zone_id` value

## Motivation

AKS with `SystemAssigned` identity cannot write A records to Private DNS Zones outside the `MC_*` shadow RG. Microsoft docs require a UAMI with `Private DNS Zone Contributor` for external PDZs. This blocks the hub-spoke pattern where the AKS API server PDZ (`privatelink.<region>.azmk8s.io`) lives in a centralized hub.

## Behavior matrix

| `enable_private_cluster` | `private_dns_zone_id` | Identity | Result |
|---|---|---|---|
| `false` | (ignored) | SystemAssigned | Public cluster (current) |
| `true` | `"System"` | SystemAssigned | Private, PDZ in MC_ RG (current) |
| `true` | `"<ARM ID>"` | **UserAssigned** | Private, external PDZ (**new**) |

## Resources created (only when `use_uami = true`)

- `azurerm_user_assigned_identity.aks` — `mi-{base_name}-aks`
- `azurerm_role_assignment.aks_pdz_contributor` — `Private DNS Zone Contributor` scoped to `var.private_dns_zone_id`

## Test plan

- [ ] `terraform validate` passes (verified locally)
- [ ] `terraform plan` with `enable_private_cluster = false` shows zero diff
- [ ] `terraform plan` with `enable_private_cluster = true` + `private_dns_zone_id = "System"` shows zero diff
- [ ] `terraform plan` with `private_dns_zone_id = "<ARM ID>"` shows UAMI + role assignment + AKS identity change
- [ ] Verify `Network Contributor` role assignment uses UAMI principal when UAMI is active