### PR TITLE
fix(azure/aks): add UAMI VNet role + outbound_type variable

### DIFF
--- a/providers/azure/aks.tf
+++ b/providers/azure/aks.tf
@@ -18,6 +18,13 @@ resource "azurerm_role_assignment" "aks_pdz_contributor" {
   principal_id         = azurerm_user_assigned_identity.aks[0].principal_id
 }
 
+resource "azurerm_role_assignment" "aks_uami_vnet_contributor" {
+  count                = local.use_uami ? 1 : 0
+  scope                = azurerm_virtual_network.platform.id
+  role_definition_name = "Network Contributor"
+  principal_id         = azurerm_user_assigned_identity.aks[0].principal_id
+}
+
 # ---------------------------------------------------------------------------
 # AKS Cluster
 # ---------------------------------------------------------------------------
@@ -100,7 +107,7 @@ resource "azurerm_kubernetes_cluster" "platform" {
     network_plugin_mode = "overlay"
     network_data_plane  = var.network_dataplane == "cilium" || var.network_dataplane == "cilium-acns" ? "cilium" : "azure"
     network_policy      = var.network_dataplane == "cilium" || var.network_dataplane == "cilium-acns" ? "cilium" : null
-    outbound_type       = var.nat_gateway_enabled ? "userAssignedNATGateway" : "loadBalancer"
+    outbound_type       = var.outbound_type != "" ? var.outbound_type : (var.nat_gateway_enabled ? "userAssignedNATGateway" : "loadBalancer")
     service_cidr        = var.service_cidr
     dns_service_ip      = var.dns_service_ip
     pod_cidr            = var.pod_cidr
@@ -160,6 +167,8 @@ resource "azurerm_kubernetes_cluster" "platform" {
   depends_on = [
     azurerm_subnet_nat_gateway_association.aks_nodes,
     azurerm_subnet_network_security_group_association.aks_nodes,
+    azurerm_role_assignment.aks_pdz_contributor,
+    azurerm_role_assignment.aks_uami_vnet_contributor,
   ]
 
   tags = local.tags

--- a/providers/azure/variables.tf
+++ b/providers/azure/variables.tf
@@ -441,6 +441,17 @@ variable "nat_gateway_idle_timeout" {
   default     = 4
 }
 
+variable "outbound_type" {
+  description = "AKS outbound type. 'loadBalancer' (Azure-managed PIP+LB), 'userAssignedNATGateway' (when nat_gateway_enabled=true), 'userDefinedRouting' (egress via NVA/FortiGate UDR). Empty string auto-detects from nat_gateway_enabled. When 'userDefinedRouting', a UDR with 0.0.0.0/0 pointing to the NVA must exist on the node subnet BEFORE cluster creation."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.outbound_type == "" || contains(["loadBalancer", "userAssignedNATGateway", "userDefinedRouting"], var.outbound_type)
+    error_message = "outbound_type must be one of: loadBalancer, userAssignedNATGateway, userDefinedRouting (or empty for auto-detection)."
+  }
+}
+
 variable "nsg_enabled" {
   description = "Enable Network Security Group on AKS node subnet for defense in depth."
   type        = bool


### PR DESCRIPTION
## Summary

- **Bug fix:** Add `Network Contributor` role assignment on VNet for UAMI (required for `virtualNetworks/join/action` when creating PDZ vnet_links)
- **Bug fix:** Add `depends_on` for UAMI role assignments on the AKS cluster to ensure propagation before creation
- **Feature:** Add `outbound_type` variable for explicit control over AKS egress (supports `userDefinedRouting` for NVA/FortiGate deployments)

## Bug: UAMI missing VNet role (v0.58.0 regression)

The UAMI created in v0.58.0 had `Private DNS Zone Contributor` on the PDZ but lacked `Network Contributor` on the VNet. AKS needs both to create the vnet_link from VNet → PDZ:
1. `privateDnsZones/virtualNetworkLinks/write` on PDZ — existed
2. `virtualNetworks/join/action` on VNet — **missing, now fixed**

## Feature: outbound_type

| `outbound_type` | `nat_gateway_enabled` | Result |
|---|---|---|
| `""` (default) | `true` | `userAssignedNATGateway` (current) |
| `""` (default) | `false` | `loadBalancer` (current) |
| `"userDefinedRouting"` | `false` | No PIP/LB in MC_ — egress via NVA UDR (**new**) |

Pre-requisite: UDR `0.0.0.0/0 → NVA` must exist on node subnet before cluster creation.

## Test plan

- [ ] `terraform validate` passes (verified locally)
- [ ] `terraform plan` with defaults shows zero diff
- [ ] `terraform plan` with `private_dns_zone_id = "<ARM ID>"` shows new VNet role assignment
- [ ] `terraform plan` with `outbound_type = "userDefinedRouting"` shows outbound_type change