### PR TITLE
feat(azure): kubernetes provider v3 + ConfigMap parity with AWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [0.59.0] - 2026-05-27
+
+### Changed — `azure`: bump kubernetes provider v2 → v3
+
+Upgrades `hashicorp/kubernetes` from `~> 2.37` to `~> 3.1`, renaming all resource types to the `_v1` suffix required by v3. Four `moved` blocks ensure zero-downtime migration (no destroy+recreate) for existing deployments:
+
+- `kubernetes_namespace.argocd` → `kubernetes_namespace_v1.argocd`
+- `kubernetes_config_map.platform_infrastructure` → `kubernetes_config_map_v1.platform_infrastructure`
+- `kubernetes_secret.platform_infrastructure` → `kubernetes_secret_v1.platform_infrastructure`
+- `kubernetes_secret.hub_cluster` → `kubernetes_secret_v1.hub_cluster`
+
+The `moved` blocks can be removed after all deployments have applied at least once with v0.59.0+.
+
+### Added — `azure`: ConfigMap parity with AWS (ADR 0020 revision tracking)
+
+Brings the Azure `platform-infrastructure` ConfigMap to parity with AWS by adding revision tracking keys and infrastructure signals consumed by downstream GitOps:
+
+**Revision tracking (ADR 0020):**
+- `platformRevision` — enables branch tracking; falls back to `platformVersion` → VERSION file
+- `configRepoRevision` — falls back to `configRepoVersion`
+- `clientGitopsRepoVersion` / `clientGitopsRepoRevision` — client GitOps repo pinning
+
+**Infrastructure signals:**
+- `global.region` — Azure region (`var.location`)
+- `global.oidcIssuerUrl` — AKS OIDC issuer URL for workload identity federation
+- `global.ingressController` — derived from `traefik_enabled` / `traefik_internal_enabled` toggles
+- `global.traefikInternal` — explicit flag for internal Traefik instance
+- `global.slackAlertingEnabled` — Mimir Alertmanager Slack pipeline gate
+
+**New variables (all with backwards-compatible defaults):**
+- `platform_revision` (string, default `""`)
+- `config_repo_revision` (string, default `""`)
+- `client_gitops_repo_version` (string, default `""`)
+- `client_gitops_repo_revision` (string, default `""`)
+- `slack_alerting_enabled` (bool, default `false`)
+
 ## [0.58.1] - 2026-05-26
 
 ### Fixed — `azure/aks`: UAMI missing Network Contributor on VNet

--- a/providers/azure/main.tf
+++ b/providers/azure/main.tf
@@ -197,9 +197,19 @@ locals {
   # from the repo root; the VERSION file lives at the root.
   # ---------------------------------------------------------------------------
   module_version = trimspace(file("${path.module}/../../VERSION"))
-  platform_version_effective = (
-    length(var.platform_version) > 0 ? var.platform_version : local.module_version
+
+  # ADR 0020 — revision-aware derivation (parity with AWS).
+  # Both `platformVersion` and `platformRevision` ConfigMap keys get the
+  # same effective value — preserves backward compat where child
+  # Applications read `.Values.platformVersion` directly.
+  platform_revision_effective = (
+    length(var.platform_revision) > 0 ? var.platform_revision :
+    length(var.platform_version) > 0 ? var.platform_version :
+    local.module_version
   )
+
+  config_repo_revision_effective   = length(var.config_repo_revision) > 0 ? var.config_repo_revision : var.config_repo_version
+  client_gitops_revision_effective = length(var.client_gitops_repo_revision) > 0 ? var.client_gitops_repo_revision : var.client_gitops_repo_version
 }
 
 # ---------------------------------------------------------------------------

--- a/providers/azure/platform-outputs.tf
+++ b/providers/azure/platform-outputs.tf
@@ -11,7 +11,7 @@
 # Issue: https://github.com/Estabilis/estabilis-platform/issues/57
 # ---------------------------------------------------------------------------
 
-resource "kubernetes_namespace" "argocd" {
+resource "kubernetes_namespace_v1" "argocd" {
   count = var.platform_outputs_enabled ? 1 : 0
 
   metadata {
@@ -23,16 +23,21 @@ resource "kubernetes_namespace" "argocd" {
   }
 }
 
+moved {
+  from = kubernetes_namespace.argocd
+  to   = kubernetes_namespace_v1.argocd
+}
+
 # ---------------------------------------------------------------------------
 # ConfigMap — non-sensitive platform infrastructure values
 # ---------------------------------------------------------------------------
 
-resource "kubernetes_config_map" "platform_infrastructure" {
+resource "kubernetes_config_map_v1" "platform_infrastructure" {
   count = var.platform_outputs_enabled ? 1 : 0
 
   metadata {
     name      = "platform-infrastructure"
-    namespace = kubernetes_namespace.argocd[0].metadata[0].name
+    namespace = kubernetes_namespace_v1.argocd[0].metadata[0].name
     labels = {
       "app.kubernetes.io/managed-by" = "terraform"
       "app.kubernetes.io/part-of"    = "estabilis-platform"
@@ -40,15 +45,17 @@ resource "kubernetes_config_map" "platform_infrastructure" {
   }
 
   data = {
-    # Platform versions
-    "platformRepoUrl"   = var.platform_repo_url
-    "platformVersion"   = local.platform_version_effective
-    "configRepoUrl"     = var.config_repo_url
-    "configRepoVersion" = var.config_repo_version
-
-    # Client GitOps (structural — version lives in overrides YAML)
-    "clientGitopsRepoUrl" = var.client_gitops_repo_url
-    "deploymentId"        = var.deployment_id
+    # Platform versions + revisions (ADR 0020)
+    "platformRepoUrl"          = var.platform_repo_url
+    "platformVersion"          = local.platform_revision_effective
+    "platformRevision"         = local.platform_revision_effective
+    "configRepoUrl"            = var.config_repo_url
+    "configRepoVersion"        = var.config_repo_version
+    "configRepoRevision"       = local.config_repo_revision_effective
+    "clientGitopsRepoUrl"      = var.client_gitops_repo_url
+    "clientGitopsRepoVersion"  = var.client_gitops_repo_version
+    "clientGitopsRepoRevision" = local.client_gitops_revision_effective
+    "deploymentId"             = var.deployment_id
 
     # Global
     "global.provider"         = "azure"
@@ -62,6 +69,8 @@ resource "kubernetes_config_map" "platform_infrastructure" {
 
     # Azure resources
     "global.clusterName"               = azurerm_kubernetes_cluster.platform.name
+    "global.region"                    = var.location
+    "global.oidcIssuerUrl"             = azurerm_kubernetes_cluster.platform.oidc_issuer_url
     "global.resourceGroup"             = azurerm_resource_group.platform.name
     "global.storageAccountName"        = azurerm_storage_account.observability.name
     "global.cnpgStorageAccountName"    = azurerm_storage_account.cnpg_backup.name
@@ -108,6 +117,14 @@ resource "kubernetes_config_map" "platform_infrastructure" {
     # continuous "Secret does not exist" reconcile errors.
     "global.openaiApiKeyEnabled" = tostring(var.openai_api_key != "")
 
+    # Mimir Alertmanager Slack pipeline
+    "global.slackAlertingEnabled" = tostring(var.slack_alerting_enabled)
+
+    # Ingress controller — derived from toggle state (Azure has no
+    # freeform ingress_controller var; AWS does).
+    "global.ingressController" = var.traefik_enabled ? "traefik" : (var.traefik_internal_enabled ? "traefik-internal" : "none")
+    "global.traefikInternal"   = tostring(var.traefik_internal_enabled)
+
     # Cost
     "global.azureOfferId" = local.azure_offer_id
 
@@ -117,16 +134,21 @@ resource "kubernetes_config_map" "platform_infrastructure" {
   }
 }
 
+moved {
+  from = kubernetes_config_map.platform_infrastructure
+  to   = kubernetes_config_map_v1.platform_infrastructure
+}
+
 # ---------------------------------------------------------------------------
 # Secret — sensitive platform infrastructure values
 # ---------------------------------------------------------------------------
 
-resource "kubernetes_secret" "platform_infrastructure" {
+resource "kubernetes_secret_v1" "platform_infrastructure" {
   count = var.platform_outputs_enabled ? 1 : 0
 
   metadata {
     name      = "platform-infrastructure-sensitive"
-    namespace = kubernetes_namespace.argocd[0].metadata[0].name
+    namespace = kubernetes_namespace_v1.argocd[0].metadata[0].name
     labels = {
       "app.kubernetes.io/managed-by" = "terraform"
       "app.kubernetes.io/part-of"    = "estabilis-platform"
@@ -172,6 +194,11 @@ resource "kubernetes_secret" "platform_infrastructure" {
   }
 }
 
+moved {
+  from = kubernetes_secret.platform_infrastructure
+  to   = kubernetes_secret_v1.platform_infrastructure
+}
+
 # ---------------------------------------------------------------------------
 # ArgoCD Cluster Secret — hub cluster (GitOps Bridge, ADR 0010)
 # ---------------------------------------------------------------------------
@@ -187,12 +214,12 @@ resource "kubernetes_secret" "platform_infrastructure" {
 # treats both as distinct clusters pointing at the same server (selector
 # disambiguates).
 
-resource "kubernetes_secret" "hub_cluster" {
+resource "kubernetes_secret_v1" "hub_cluster" {
   count = var.platform_outputs_enabled ? 1 : 0
 
   metadata {
     name      = "hub-cluster"
-    namespace = kubernetes_namespace.argocd[0].metadata[0].name
+    namespace = kubernetes_namespace_v1.argocd[0].metadata[0].name
     labels = {
       "argocd.argoproj.io/secret-type" = "cluster"
       # ADR 0003 S4 vocabulary
@@ -218,4 +245,9 @@ resource "kubernetes_secret" "hub_cluster" {
       tlsClientConfig = { insecure = false }
     })
   }
+}
+
+moved {
+  from = kubernetes_secret.hub_cluster
+  to   = kubernetes_secret_v1.hub_cluster
 }

--- a/providers/azure/variables.tf
+++ b/providers/azure/variables.tf
@@ -102,6 +102,22 @@ variable "config_repo_version" {
   }
 }
 
+variable "platform_revision" {
+  description = <<-EOT
+    [OVERRIDE] Git revision (tag OR branch) for the platform source.
+    Leave empty (default) — falls back to platform_version, then VERSION file.
+    ADR 0020: enables branch tracking for continuous reconciliation.
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "config_repo_revision" {
+  description = "Git revision (tag OR branch) for the config repo. Defaults to config_repo_version when empty. ADR 0020."
+  type        = string
+  default     = ""
+}
+
 variable "config_repo_token" {
   description = "Git access token for the config repository. Pass via secrets.auto.tfvars or TF_VAR_config_repo_token. Required if config_repo_url is a private repo."
   type        = string
@@ -127,6 +143,18 @@ variable "deployment_id" {
     condition     = length(var.deployment_id) > 0
     error_message = "deployment_id is required (e.g., platform-azure-eastus2-hml)."
   }
+}
+
+variable "client_gitops_repo_version" {
+  description = "Git tag for the client GitOps repo. ADR 0020: prefer client_gitops_repo_revision for branch tracking."
+  type        = string
+  default     = ""
+}
+
+variable "client_gitops_repo_revision" {
+  description = "Git revision (tag OR branch) for the client GitOps repo. Defaults to client_gitops_repo_version when empty. ADR 0020."
+  type        = string
+  default     = ""
 }
 
 variable "client_gitops_repo_token" {
@@ -1066,6 +1094,12 @@ variable "openai_api_key" {
   type        = string
   default     = ""
   sensitive   = true
+}
+
+variable "slack_alerting_enabled" {
+  description = "Enable Mimir Alertmanager Slack pipeline. When true, mimir-alertmanager-config chart renders ExternalSecret + ConfigMap + upload Job."
+  type        = bool
+  default     = false
 }
 
 # ---------------------------------------------------------------------------

--- a/providers/azure/versions.tf
+++ b/providers/azure/versions.tf
@@ -24,7 +24,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.37"
+      version = "~> 3.1"
     }
     azuredevops = {
       source  = "microsoft/azuredevops"


### PR DESCRIPTION
## Summary

- Bump `hashicorp/kubernetes` from `~> 2.37` to `~> 3.1` with 4 `moved` blocks for zero-downtime migration (no destroy+recreate)
- Add ADR 0020 revision tracking keys to the `platform-infrastructure` ConfigMap: `platformRevision`, `configRepoRevision`, `clientGitopsRepoVersion`, `clientGitopsRepoRevision`
- Add infrastructure signals for downstream GitOps: `global.region`, `global.oidcIssuerUrl`, `global.ingressController`, `global.traefikInternal`, `global.slackAlertingEnabled`
- 5 new variables with backwards-compatible defaults: `platform_revision`, `config_repo_revision`, `client_gitops_repo_version`, `client_gitops_repo_revision`, `slack_alerting_enabled`

## Motivation

Azure provider had two gaps vs AWS:
1. Kubernetes provider v2 (deprecated) — AWS already on v3
2. Missing ConfigMap keys that downstream GitOps and the CLI consume for revision tracking (ADR 0020), ingress controller detection, and observability alerting

## Migration

- **`moved` blocks** handle the resource rename transparently — `terraform plan` shows "move" not "destroy+recreate"
- **All new variables default to empty/false** — existing deployments need zero tfvars changes
- **New ConfigMap keys are additive** — GitOps charts that don't read them are unaffected

After all deployments have applied at least once with this version, the `moved` blocks can be removed in a follow-up.

## Release

This is a **MINOR** bump → `v0.59.0`. CHANGELOG entry included. After merge, direct-push `chore(release): v0.59.0` to trigger auto-tag.