### PR TITLE
feat(azure): hub-cluster bridge annotations parity with AWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.59.1] - 2026-05-27
+
+### Added — `azure`: hub-cluster bridge annotations (ADR 0023 Etapa B parity)
+
+Adds 5 annotations to the `hub-cluster` Secret that the AWS provider already publishes, enabling client ApplicationSets to inject cluster-level metadata as helm parameters:
+
+- `bridge.region` — Azure region (`var.location`)
+- `bridge.cluster-name` — `{name_prefix}-{deployment_id}`, used to compose app FQDNs
+- `bridge.domain` — DNS zone root, used to compose app FQDNs
+- `bridge.tier` — normalized environment (`prd`/`prod` → `"production"`, others keep name)
+- `bridge.secret-path-template` — Vault path template for ExternalSecret resolution (empty when `vault_enabled = false`, fail-loud)
+- `bridge.hub-secrets-path-prefix` — shared hub secrets path in HashiCorp Vault for workload-operator (empty when `vault_enabled = false`)
+- `bridge.internal-domain` — internal DNS domain for dual-FQDN Ingress
+
+The `bridge_tier`, `bridge_secret_path_template`, and `shared_hub_secrets_prefix_effective` locals replicate the exact AWS logic — provider-agnostic, not Azure-specific.
+
+New variables:
+- `shared_hub_secrets_prefix` (string, default `""`) — customizable Vault path prefix, defaults to `estabilis/shared/{name_prefix}`
+- `internal_domain` (string, default `""`) — internal DNS domain for VNet-scoped access
+
+- `bridge.ingress-group-name` — empty string (ALB concept, no Azure equivalent; keeps interface symmetry with AWS)
+
 ## [0.59.0] - 2026-05-27
 
 ### Changed — `azure`: bump kubernetes provider v2 → v3

--- a/providers/azure/main.tf
+++ b/providers/azure/main.tf
@@ -210,6 +210,29 @@ locals {
 
   config_repo_revision_effective   = length(var.config_repo_revision) > 0 ? var.config_repo_revision : var.config_repo_version
   client_gitops_revision_effective = length(var.client_gitops_repo_revision) > 0 ? var.client_gitops_repo_revision : var.client_gitops_repo_version
+
+  # ---------------------------------------------------------------------------
+  # ExternalSecret path resolution — provider-agnostic (parity with AWS).
+  #
+  # Published as hub-cluster Secret annotations so client ApplicationSets
+  # can inject them as helm parameters into the common-app chart (>= v0.2.0).
+  #
+  # Provider mapping (only the template string changes):
+  #   Vault              "secret/data/org/{tier}/{app}"
+  #   Azure Key Vault    "{app}-{tier}"
+  #   AWS Secrets Manager "estabilis/{tier}/{app}"
+  #
+  # When vault_enabled = false, template is empty — chart's `required`
+  # check on `pathTemplate` raises a clear error (fail loud).
+  # ---------------------------------------------------------------------------
+  bridge_tier                 = contains(["prd", "prod"], var.environment) ? "production" : var.environment
+  bridge_secret_path_template = var.vault_enabled ? "secret/data/org/{tier}/{app}" : ""
+
+  # Hub shared secrets prefix — same pattern as AWS (Secrets Manager path).
+  # When vault_enabled, workload-operator uses this path inside HashiCorp
+  # Vault to publish/read hub-registrar-token and shared secrets between
+  # hub and workload clusters.
+  shared_hub_secrets_prefix_effective = length(var.shared_hub_secrets_prefix) > 0 ? var.shared_hub_secrets_prefix : "estabilis/shared/${var.name_prefix}"
 }
 
 # ---------------------------------------------------------------------------

--- a/providers/azure/platform-outputs.tf
+++ b/providers/azure/platform-outputs.tf
@@ -230,11 +230,28 @@ resource "kubernetes_secret_v1" "hub_cluster" {
     }
     annotations = {
       # ADR 0010 v1 bridge registry
-      "estabilis.io/bridge.tenant-id"                   = var.tenant_id
-      "estabilis.io/bridge.subscription-id"             = var.subscription_id
+      "estabilis.io/bridge.tenant-id"       = var.tenant_id
+      "estabilis.io/bridge.subscription-id" = var.subscription_id
+      "estabilis.io/bridge.region"          = var.location
+
+      # ADR 0023 Etapa B — cluster-level metadata consumed by client
+      # gitops ApplicationSets via the `clusters` generator.
+      "estabilis.io/bridge.cluster-name"       = "${var.name_prefix}-${var.deployment_id}"
+      "estabilis.io/bridge.domain"             = var.domain
+      "estabilis.io/bridge.ingress-group-name" = ""
+
       "estabilis.io/bridge.hub-key-vault-name"          = var.shared_hub_kv_enabled ? azurerm_key_vault.hub[0].name : ""
       "estabilis.io/bridge.hub-resource-group"          = var.shared_hub_kv_enabled ? azurerm_resource_group.shared[0].name : ""
+      "estabilis.io/bridge.hub-secrets-path-prefix"     = var.vault_enabled ? local.shared_hub_secrets_prefix_effective : ""
       "estabilis.io/bridge.workload-operator-client-id" = var.shared_hub_kv_enabled ? azurerm_user_assigned_identity.workload_operator[0].client_id : ""
+
+      # ExternalSecret path resolution — consumed by client ApplicationSets
+      # to inject helm parameters into the common-app chart (>= v0.2.0).
+      "estabilis.io/bridge.tier"                 = local.bridge_tier
+      "estabilis.io/bridge.secret-path-template" = local.bridge_secret_path_template
+
+      # Dual-domain — internal FQDN for VNet-scoped access
+      "estabilis.io/bridge.internal-domain" = var.internal_domain
     }
   }
 

--- a/providers/azure/variables.tf
+++ b/providers/azure/variables.tf
@@ -512,6 +512,18 @@ variable "traefik_internal_enabled" {
   default     = false
 }
 
+variable "shared_hub_secrets_prefix" {
+  description = "Prefix for shared hub secrets in HashiCorp Vault. Defaults to 'estabilis/shared/{name_prefix}' when empty. Only relevant when vault_enabled = true."
+  type        = string
+  default     = ""
+}
+
+variable "internal_domain" {
+  description = "Internal DNS domain for in-VNet access (e.g. Azure Private DNS Zone). Published as bridge.internal-domain annotation so ApplicationSets can inject dual-FQDN Ingress hosts."
+  type        = string
+  default     = ""
+}
+
 # ---------------------------------------------------------------------------
 # App exposures — map(object) model (ADR 0014). Each entry is a separate
 # K8s Ingress + Traefik Middleware(s) + Certificate. Operator chooses


### PR DESCRIPTION
## Summary

- Add 8 `estabilis.io/bridge.*` annotations to the `hub-cluster` Secret, full parity with AWS (ADR 0023 Etapa B)
- New locals `bridge_tier`, `bridge_secret_path_template`, `shared_hub_secrets_prefix_effective` — exact same logic as `providers/aws/locals.tf`
- New variables `shared_hub_secrets_prefix`, `internal_domain`

## Annotations added

| Annotation | Value | Consumed by |
|---|---|---|
| `bridge.region` | `var.location` | Naming region-scoped |
| `bridge.cluster-name` | `{name_prefix}-{deployment_id}` | common-app chart → FQDN composition |
| `bridge.domain` | `var.domain` | common-app chart → FQDN composition |
| `bridge.ingress-group-name` | `""` (ALB concept, no Azure equivalent) | Interface symmetry with AWS |
| `bridge.tier` | `prd/prod` → `"production"`, else env name | ExternalSecret path resolution |
| `bridge.secret-path-template` | Vault path template (empty when vault disabled) | ExternalSecret path resolution |
| `bridge.hub-secrets-path-prefix` | Vault hub secrets path (empty when vault disabled) | workload-operator hub secret sharing |
| `bridge.internal-domain` | `var.internal_domain` | Dual-FQDN Ingress (VNet-scoped) |

## Release

PATCH bump → `v0.59.1`. CHANGELOG entry included. After merge, direct-push `chore(release): v0.59.1` to trigger auto-tag.