### PR TITLE
feat(azure): add 8 missing keys to platform-infrastructure ConfigMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.59.2] - 2026-05-27
+
+### Added — `azure`: ConfigMap missing keys
+
+Adds 8 keys to the `platform-infrastructure` ConfigMap that Terraform already knows but were not published:
+
+- `global.internalDomain` — internal DNS domain for dual-FQDN Ingress (VNet-scoped access)
+- `global.privateFqdn` — AKS API server private FQDN (cross-cluster kubectl, ArgoCD cluster registration)
+- `global.nodeResourceGroup` — MC_ RG for Velero disk snapshots and node troubleshooting
+- `global.kubernetesVersion` — effective K8s version (may differ from requested during upgrade)
+- `global.containerRegistryName` — provider-agnostic registry name (complements existing `acrLoginServer`)
+- `global.tfstateStorageAccountName` — tfstate SA for downstream workload cluster data sources
+- `global.logAnalyticsWorkspaceId` — ARM ID for workload diagnostic settings
+- `global.logAnalyticsWorkspaceName` — LAW name for queries and troubleshooting
+
+All keys are additive with proper conditional guards (`acr_enabled`, `diagnostics_enabled`).
+
 ## [0.59.1] - 2026-05-27
 
 ### Added — `azure`: hub-cluster bridge annotations (ADR 0023 Etapa B parity)

--- a/providers/azure/platform-outputs.tf
+++ b/providers/azure/platform-outputs.tf
@@ -72,6 +72,10 @@ resource "kubernetes_config_map_v1" "platform_infrastructure" {
     "global.region"                    = var.location
     "global.oidcIssuerUrl"             = azurerm_kubernetes_cluster.platform.oidc_issuer_url
     "global.resourceGroup"             = azurerm_resource_group.platform.name
+    "global.privateFqdn"               = azurerm_kubernetes_cluster.platform.private_fqdn
+    "global.nodeResourceGroup"         = azurerm_kubernetes_cluster.platform.node_resource_group
+    "global.kubernetesVersion"         = azurerm_kubernetes_cluster.platform.kubernetes_version
+    "global.internalDomain"            = var.internal_domain
     "global.storageAccountName"        = azurerm_storage_account.observability.name
     "global.cnpgStorageAccountName"    = azurerm_storage_account.cnpg_backup.name
     "global.cnpgBackupContainerName"   = "cnpg-backup"
@@ -105,9 +109,17 @@ resource "kubernetes_config_map_v1" "platform_infrastructure" {
     # Gate for hubble-ui-ingress rendering (Hubble UI only exists in ACNS)
     "global.networkDataplane" = var.network_dataplane
 
-    # ACR
-    "global.acrLoginServer"       = var.acr_enabled ? azurerm_container_registry.platform[0].login_server : ""
-    "global.sharedAcrLoginServer" = var.shared_acr_login_server
+    # Container Registry
+    "global.containerRegistryName" = var.acr_enabled ? azurerm_container_registry.platform[0].name : ""
+    "global.acrLoginServer"        = var.acr_enabled ? azurerm_container_registry.platform[0].login_server : ""
+    "global.sharedAcrLoginServer"  = var.shared_acr_login_server
+
+    # Tfstate storage — downstream workload clusters consume via data source
+    "global.tfstateStorageAccountName" = azurerm_storage_account.tfstate.name
+
+    # Log Analytics Workspace
+    "global.logAnalyticsWorkspaceId"   = var.diagnostics_enabled ? azurerm_log_analytics_workspace.platform[0].id : ""
+    "global.logAnalyticsWorkspaceName" = var.diagnostics_enabled ? azurerm_log_analytics_workspace.platform[0].name : ""
 
     # Optional integrations — boolean flags only (never the secret value).
     # platform-secrets chart uses these to gate ExternalSecrets that


### PR DESCRIPTION
## Summary

Adds 8 keys to the `platform-infrastructure` ConfigMap that Terraform already computes but were not published for downstream consumption.

| Key | Value | Guard | Consumer |
|---|---|---|---|
| `global.internalDomain` | `var.internal_domain` | always (empty default) | ApplicationSet → dual-FQDN Ingress |
| `global.privateFqdn` | AKS private FQDN | always | cross-cluster kubectl, ArgoCD cluster registration |
| `global.nodeResourceGroup` | AKS MC_ RG | always | Velero disk snapshots, node troubleshooting |
| `global.kubernetesVersion` | effective K8s version | always | Charts gating features by version |
| `global.containerRegistryName` | ACR name (provider-agnostic) | `acr_enabled` | CI/CD pipelines, operator |
| `global.tfstateStorageAccountName` | tfstate SA name | always | Downstream workload cluster data sources |
| `global.logAnalyticsWorkspaceId` | LAW ARM ID | `diagnostics_enabled` | Workload diagnostic settings |
| `global.logAnalyticsWorkspaceName` | LAW name | `diagnostics_enabled` | Queries, dashboards |

All keys are additive — no existing keys changed or removed.

## Release

PATCH bump → `v0.59.2`. CHANGELOG entry included. After merge, direct-push `chore(release): v0.59.2` to trigger auto-tag.