### PR TITLE
fix(ingress): gate accepts traefik-internal as valid ingress controller

### DIFF
--- a/bootstrap/platform-root/templates/argocd-ingress.yaml
+++ b/bootstrap/platform-root/templates/argocd-ingress.yaml
@@ -21,7 +21,7 @@
 {{- /* Require components.traefik only when at least one exposure
        actually targets a Traefik-style class. ALB-only exposures are
        allowed when components.traefik is false. */}}
-{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) (eq (index .Values.components "traefik-internal" | default false) true) }}
 {{- if and $traefikGate $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/bootstrap/platform-root/templates/grafana-ingress.yaml
+++ b/bootstrap/platform-root/templates/grafana-ingress.yaml
@@ -20,7 +20,7 @@
 {{- $hasEnabled := false -}}
 {{- $hasTraefikExposure := false -}}
 {{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
-{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) (eq (index .Values.components "traefik-internal" | default false) true) }}
 {{- if and $traefikGate $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/bootstrap/platform-root/templates/hubble-ui-ingress.yaml
+++ b/bootstrap/platform-root/templates/hubble-ui-ingress.yaml
@@ -18,7 +18,7 @@
 {{- $hasEnabled := false -}}
 {{- $hasTraefikExposure := false -}}
 {{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
-{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) (eq (index .Values.components "traefik-internal" | default false) true) }}
 {{- $dataplane := index .Values.global "networkDataplane" | default "" -}}
 {{- if and
       $traefikGate

--- a/bootstrap/platform-root/templates/loki-ingress.yaml
+++ b/bootstrap/platform-root/templates/loki-ingress.yaml
@@ -17,7 +17,7 @@
 {{- $hasEnabled := false -}}
 {{- $hasTraefikExposure := false -}}
 {{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
-{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) (eq (index .Values.components "traefik-internal" | default false) true) }}
 {{- if and $traefikGate $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/bootstrap/platform-root/templates/mimir-ingress.yaml
+++ b/bootstrap/platform-root/templates/mimir-ingress.yaml
@@ -17,7 +17,7 @@
 {{- $hasEnabled := false -}}
 {{- $hasTraefikExposure := false -}}
 {{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
-{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) (eq (index .Values.components "traefik-internal" | default false) true) }}
 {{- if and $traefikGate $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application


### PR DESCRIPTION
## Summary
The traefikGate in all 5 ingress templates only checked `components.traefik`, blocking rendering when `traefik-internal` was the sole ingress controller.

Adds `(eq (index .Values.components "traefik-internal" | default false) true)` as alternative gate condition.

## Affected templates
- argocd-ingress.yaml
- grafana-ingress.yaml
- loki-ingress.yaml
- mimir-ingress.yaml
- hubble-ui-ingress.yaml