### PR TITLE
feat(exposures): auto-derive internal hosts from internal_domain

### DIFF
--- a/providers/aws/main.tf
+++ b/providers/aws/main.tf
@@ -145,35 +145,64 @@ locals {
     for app in ["grafana", "argocd", "loki", "mimir", "hubble", "vault"] : app =>
     "${app}.${local.cluster_name}.${var.domain}"
   }
+  _app_host_internal = {
+    for app in ["grafana", "argocd", "loki", "mimir", "hubble", "vault"] : app =>
+    "${app}.${local.cluster_name}.${var.internal_domain}"
+  }
+  _use_internal_domain = var.internal_domain != ""
 
   grafana_exposures_resolved = {
     for k, v in var.grafana_exposures : k => merge(v, {
-      host = length(v.host) > 0 ? v.host : local._app_host.grafana
+      host = length(v.host) > 0 ? v.host : (
+        local._use_internal_domain && k == "internal"
+        ? local._app_host_internal.grafana
+        : local._app_host.grafana
+      )
     })
   }
   loki_exposures_resolved = {
     for k, v in var.loki_exposures : k => merge(v, {
-      host = length(v.host) > 0 ? v.host : local._app_host.loki
+      host = length(v.host) > 0 ? v.host : (
+        local._use_internal_domain && k == "internal"
+        ? local._app_host_internal.loki
+        : local._app_host.loki
+      )
     })
   }
   mimir_exposures_resolved = {
     for k, v in var.mimir_exposures : k => merge(v, {
-      host = length(v.host) > 0 ? v.host : local._app_host.mimir
+      host = length(v.host) > 0 ? v.host : (
+        local._use_internal_domain && k == "internal"
+        ? local._app_host_internal.mimir
+        : local._app_host.mimir
+      )
     })
   }
   argocd_exposures_resolved = {
     for k, v in var.argocd_exposures : k => merge(v, {
-      host = length(v.host) > 0 ? v.host : local._app_host.argocd
+      host = length(v.host) > 0 ? v.host : (
+        local._use_internal_domain && k == "internal"
+        ? local._app_host_internal.argocd
+        : local._app_host.argocd
+      )
     })
   }
   hubble_ui_exposures_resolved = {
     for k, v in var.hubble_ui_exposures : k => merge(v, {
-      host = length(v.host) > 0 ? v.host : local._app_host.hubble
+      host = length(v.host) > 0 ? v.host : (
+        local._use_internal_domain && k == "internal"
+        ? local._app_host_internal.hubble
+        : local._app_host.hubble
+      )
     })
   }
   vault_exposures_resolved = {
     for k, v in var.vault_exposures : k => merge(v, {
-      host = length(v.host) > 0 ? v.host : local._app_host.vault
+      host = length(v.host) > 0 ? v.host : (
+        local._use_internal_domain && k == "internal"
+        ? local._app_host_internal.vault
+        : local._app_host.vault
+      )
     })
   }
 }

--- a/providers/aws/variables.tf
+++ b/providers/aws/variables.tf
@@ -19,6 +19,12 @@ variable "domain" {
   type        = string
 }
 
+variable "internal_domain" {
+  description = "Internal DNS domain for in-VPC access (e.g. Route53 Private Hosted Zone). When set, exposure profiles keyed 'internal' auto-derive hosts as {app}.{cluster_name}.{internal_domain}."
+  type        = string
+  default     = ""
+}
+
 variable "environment" {
   description = "Deployment environment identifier."
   type        = string

--- a/providers/azure/main.tf
+++ b/providers/azure/main.tf
@@ -53,38 +53,68 @@ locals {
     for app in ["grafana", "argocd", "loki", "mimir", "hubble", "vault"] : app =>
     "${app}.${azurerm_kubernetes_cluster.platform.name}.${var.domain}"
   }
+  _app_host_internal = {
+    for app in ["grafana", "argocd", "loki", "mimir", "hubble", "vault"] : app =>
+    "${app}.${azurerm_kubernetes_cluster.platform.name}.${var.internal_domain}"
+  }
+  _use_internal_domain = var.internal_domain != ""
 
   # Resolved exposures — applies the auto-derived host when the user left
-  # it empty in tfvars. Explicit values always win. Downstream outputs
-  # (platform-outputs.tf, outputs.tf) consume these, not var.*_exposures.
+  # it empty in tfvars. Profile key "internal" uses internal_domain;
+  # all other keys use domain. Explicit host always wins.
+  # Downstream outputs consume these, not var.*_exposures.
   grafana_exposures_resolved = {
     for k, v in var.grafana_exposures : k => merge(v, {
-      host = length(v.host) > 0 ? v.host : local._app_host.grafana
+      host = length(v.host) > 0 ? v.host : (
+        local._use_internal_domain && k == "internal"
+        ? local._app_host_internal.grafana
+        : local._app_host.grafana
+      )
     })
   }
   loki_exposures_resolved = {
     for k, v in var.loki_exposures : k => merge(v, {
-      host = length(v.host) > 0 ? v.host : local._app_host.loki
+      host = length(v.host) > 0 ? v.host : (
+        local._use_internal_domain && k == "internal"
+        ? local._app_host_internal.loki
+        : local._app_host.loki
+      )
     })
   }
   mimir_exposures_resolved = {
     for k, v in var.mimir_exposures : k => merge(v, {
-      host = length(v.host) > 0 ? v.host : local._app_host.mimir
+      host = length(v.host) > 0 ? v.host : (
+        local._use_internal_domain && k == "internal"
+        ? local._app_host_internal.mimir
+        : local._app_host.mimir
+      )
     })
   }
   argocd_exposures_resolved = {
     for k, v in var.argocd_exposures : k => merge(v, {
-      host = length(v.host) > 0 ? v.host : local._app_host.argocd
+      host = length(v.host) > 0 ? v.host : (
+        local._use_internal_domain && k == "internal"
+        ? local._app_host_internal.argocd
+        : local._app_host.argocd
+      )
     })
   }
   hubble_ui_exposures_resolved = {
     for k, v in var.hubble_ui_exposures : k => merge(v, {
-      host = length(v.host) > 0 ? v.host : local._app_host.hubble
+      host = length(v.host) > 0 ? v.host : (
+        local._use_internal_domain && k == "internal"
+        ? local._app_host_internal.hubble
+        : local._app_host.hubble
+      )
     })
   }
   vault_exposures_resolved = {
     for k, v in var.vault_exposures : k => merge(v, {
-      host = length(v.host) > 0 ? v.host : local._app_host.vault
+      host = length(v.host) > 0 ? v.host : (
+        local._use_internal_domain && k == "internal"
+        ? local._app_host_internal.vault
+        : local._app_host.vault
+      )
     })
   }
 


### PR DESCRIPTION
## Summary

- Exposure profiles keyed `internal` now auto-derive host as `{app}.{cluster_name}.{internal_domain}` when `var.internal_domain` is set
- All other profile keys (e.g. `external`, `push`) continue using `var.domain`
- Explicit `host` values always win over auto-derivation
- Applied to both Azure and AWS providers; AWS gains the `internal_domain` variable (Azure already had it)

## Usage

```hcl
# terraform.tfvars
domain          = "estabilis-example.dev"
internal_domain = "azure.estabilis-example.dev"

grafana_exposures = {
  external = { enabled = true, ingress_class = "traefik-internal" }
  internal = { enabled = true, ingress_class = "traefik-internal" }
}
# external → grafana.{cluster}.estabilis-example.dev
# internal → grafana.{cluster}.azure.estabilis-example.dev

hubble_ui_exposures = {
  internal = { enabled = true, ingress_class = "traefik-internal" }
}
# internal-only → hubble.{cluster}.azure.estabilis-example.dev
```

## Test plan

- [ ] `terraform plan` on Azure provider with `internal_domain` set — verify derived hosts
- [ ] `terraform plan` on Azure provider without `internal_domain` — verify no behavior change
- [ ] `terraform plan` on AWS provider — verify variable exists and defaults to `""`