### PR TITLE
fix(platform-root): read bridge params for component gates

### DIFF
--- a/bootstrap/platform-root/templates/hubble-ui.yaml
+++ b/bootstrap/platform-root/templates/hubble-ui.yaml
@@ -1,5 +1,6 @@
-{{- /* optional: downstream can enable via components.hubble-ui: true (ACNS only) */ -}}
-{{- if eq (index .Values.components "hubble-ui") true }}
+{{- /* optional: downstream can enable via components.hubble-ui: true (ACNS only).
+  Also auto-enabled when global.networkDataplane == "cilium-acns" (bridge). */ -}}
+{{- if or (eq (index .Values.components "hubble-ui") true) (eq (index .Values.global "networkDataplane" | default "") "cilium-acns") }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/bootstrap/platform-root/templates/traefik-internal.yaml
+++ b/bootstrap/platform-root/templates/traefik-internal.yaml
@@ -4,9 +4,9 @@
   Internal LoadBalancer. Use alongside the public 'traefik' Deployment
   when the cluster needs both public and internal endpoints.
 
-  Gated by components.traefik-internal (default false).
+  Gated by components.traefik-internal OR global.traefikInternal (bridge).
 */ -}}
-{{- if eq (index .Values.components "traefik-internal" | default false) true }}
+{{- if or (eq (index .Values.components "traefik-internal" | default false) true) (eq (index .Values.global "traefikInternal" | default "false") "true") }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/bootstrap/platform-root/templates/traefik.yaml
+++ b/bootstrap/platform-root/templates/traefik.yaml
@@ -1,5 +1,9 @@
-{{- /* optional: downstream can disable via components.traefik: false */ -}}
-{{- if ne (index .Values.components "traefik") false }}
+{{- /* optional: downstream can disable via components.traefik: false.
+  Also auto-disabled when global.ingressController is set to something
+  other than "traefik" (e.g. "traefik-internal" for ILB-only clusters). */ -}}
+{{- $icOverride := index .Values.global "ingressController" | default "" -}}
+{{- $trafikDisabledByIC := and (ne $icOverride "") (ne $icOverride "traefik") -}}
+{{- if and (ne (index .Values.components "traefik") false) (not $trafikDisabledByIC) }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:


### PR DESCRIPTION
## Summary

Three component gates relied on `overrides/platform-root/values.yaml` instead of consuming bridge parameters:

- **traefik-internal**: now reads `global.traefikInternal` (Terraform injects `true` when `traefik_internal_enabled = true`)
- **traefik**: now auto-disables when `global.ingressController != "traefik"` (e.g. `traefik-internal` for ILB-only clusters)
- **hubble-ui**: now auto-enables when `global.networkDataplane == "cilium-acns"` (Terraform already injects this)

Eliminates the need for manual `overrides/platform-root/values.yaml` to toggle these components.

## Test plan

- [ ] `helm template` with `global.traefikInternal=true` — traefik-internal app rendered
- [ ] `helm template` with `global.ingressController=traefik-internal` — traefik app NOT rendered
- [ ] `helm template` with `global.networkDataplane=cilium-acns` — hubble-ui app rendered
- [ ] `helm template` with defaults (no bridge params) — no behavior change