### PR TITLE
fix(platform-root): toString in component gate comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.61.2] - 2026-05-28
+
+### Fixed — `platform-root`: toString in component gate comparisons
+
+Helm `--set` injects booleans but template `eq` fails with
+"incompatible types for comparison" when comparing bool to string.
+All three component gates now use `| toString` before comparison.
+
 ## [0.61.1] - 2026-05-28
 
 ### Fixed — `platform-root`: read bridge params for component gates

--- a/bootstrap/platform-root/templates/hubble-ui.yaml
+++ b/bootstrap/platform-root/templates/hubble-ui.yaml
@@ -1,6 +1,6 @@
 {{- /* optional: downstream can enable via components.hubble-ui: true (ACNS only).
   Also auto-enabled when global.networkDataplane == "cilium-acns" (bridge). */ -}}
-{{- if or (eq (index .Values.components "hubble-ui") true) (eq (index .Values.global "networkDataplane" | default "") "cilium-acns") }}
+{{- if or (eq (index .Values.components "hubble-ui" | default false | toString) "true") (eq (index .Values.global "networkDataplane" | default "") "cilium-acns") }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/bootstrap/platform-root/templates/traefik-internal.yaml
+++ b/bootstrap/platform-root/templates/traefik-internal.yaml
@@ -6,7 +6,7 @@
 
   Gated by components.traefik-internal OR global.traefikInternal (bridge).
 */ -}}
-{{- if or (eq (index .Values.components "traefik-internal" | default false) true) (eq (index .Values.global "traefikInternal" | default "false") "true") }}
+{{- if or (eq (index .Values.components "traefik-internal" | default false | toString) "true") (eq (index .Values.global "traefikInternal" | default false | toString) "true") }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/bootstrap/platform-root/templates/traefik.yaml
+++ b/bootstrap/platform-root/templates/traefik.yaml
@@ -3,7 +3,7 @@
   other than "traefik" (e.g. "traefik-internal" for ILB-only clusters). */ -}}
 {{- $icOverride := index .Values.global "ingressController" | default "" -}}
 {{- $trafikDisabledByIC := and (ne $icOverride "") (ne $icOverride "traefik") -}}
-{{- if and (ne (index .Values.components "traefik") false) (not $trafikDisabledByIC) }}
+{{- if and (ne (index .Values.components "traefik" | toString) "false") (not $trafikDisabledByIC) }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:


### PR DESCRIPTION
## Summary

Hotfix for v0.61.1 — `helm --set global.traefikInternal=true` injects a Go boolean, but the template `eq` fails with "incompatible types for comparison" when comparing bool to string `"true"`.

All three component gates now pipe through `| toString` before comparison, matching the pattern already used elsewhere in the chart.

## Test plan

- [ ] `helm template` with `--set global.traefikInternal=true` — no error, traefik-internal rendered
- [ ] `helm template` with `--set global.traefikInternal=false` — traefik-internal NOT rendered