### PR TITLE
fix(ingress): toString + bridge gates in all ingress templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.61.3] - 2026-05-28
+
+### Fixed — ingress templates: toString + bridge gates
+
+Same `toString` fix as v0.61.2 applied to all 5 ingress templates
+(argocd, grafana, loki, mimir, hubble-ui). Also adds the
+`networkDataplane == cilium-acns` bridge to `hubble-ui-ingress`
+gate (was only in `hubble-ui`).
+
 ## [0.61.2] - 2026-05-28
 
 ### Fixed — `platform-root`: toString in component gate comparisons

--- a/bootstrap/platform-root/templates/argocd-ingress.yaml
+++ b/bootstrap/platform-root/templates/argocd-ingress.yaml
@@ -21,7 +21,7 @@
 {{- /* Require components.traefik only when at least one exposure
        actually targets a Traefik-style class. ALB-only exposures are
        allowed when components.traefik is false. */}}
-{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) (eq (index .Values.components "traefik-internal" | default false) true) }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik" | toString) "false") (eq (index .Values.components "traefik-internal" | default false | toString) "true") }}
 {{- if and $traefikGate $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/bootstrap/platform-root/templates/grafana-ingress.yaml
+++ b/bootstrap/platform-root/templates/grafana-ingress.yaml
@@ -20,7 +20,7 @@
 {{- $hasEnabled := false -}}
 {{- $hasTraefikExposure := false -}}
 {{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
-{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) (eq (index .Values.components "traefik-internal" | default false) true) }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik" | toString) "false") (eq (index .Values.components "traefik-internal" | default false | toString) "true") }}
 {{- if and $traefikGate $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/bootstrap/platform-root/templates/hubble-ui-ingress.yaml
+++ b/bootstrap/platform-root/templates/hubble-ui-ingress.yaml
@@ -18,11 +18,11 @@
 {{- $hasEnabled := false -}}
 {{- $hasTraefikExposure := false -}}
 {{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
-{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) (eq (index .Values.components "traefik-internal" | default false) true) }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik" | toString) "false") (eq (index .Values.components "traefik-internal" | default false | toString) "true") }}
 {{- $dataplane := index .Values.global "networkDataplane" | default "" -}}
 {{- if and
       $traefikGate
-      (eq (index .Values.components "hubble-ui" | default false) true)
+      (or (eq (index .Values.components "hubble-ui" | default false | toString) "true") (eq $dataplane "cilium-acns"))
       (eq $dataplane "cilium-acns")
       $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1

--- a/bootstrap/platform-root/templates/loki-ingress.yaml
+++ b/bootstrap/platform-root/templates/loki-ingress.yaml
@@ -17,7 +17,7 @@
 {{- $hasEnabled := false -}}
 {{- $hasTraefikExposure := false -}}
 {{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
-{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) (eq (index .Values.components "traefik-internal" | default false) true) }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik" | toString) "false") (eq (index .Values.components "traefik-internal" | default false | toString) "true") }}
 {{- if and $traefikGate $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/bootstrap/platform-root/templates/mimir-ingress.yaml
+++ b/bootstrap/platform-root/templates/mimir-ingress.yaml
@@ -17,7 +17,7 @@
 {{- $hasEnabled := false -}}
 {{- $hasTraefikExposure := false -}}
 {{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
-{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) (eq (index .Values.components "traefik-internal" | default false) true) }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik" | toString) "false") (eq (index .Values.components "traefik-internal" | default false | toString) "true") }}
 {{- if and $traefikGate $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application


### PR DESCRIPTION
## Summary

Completes the toString fix from v0.61.2 — missed in 5 ingress templates. Also adds networkDataplane bridge to hubble-ui-ingress.

## Test plan

- [ ] `helm template` with bridge params — all 5 ingress apps rendered
- [ ] `helm template` without bridge params — no behavior change