### PR TITLE
fix(platform-root): complete toString in remaining templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.61.4] - 2026-05-28
+
+### Fixed — complete toString in remaining templates
+
+Applies `| toString` to ALL remaining component gates: opencost,
+vault, vault-ingress, karpenter, platform-secrets, grafana-dashboards.
+Completes the sweep started in v0.61.2/v0.61.3.
+
 ## [0.61.3] - 2026-05-28
 
 ### Fixed — ingress templates: toString + bridge gates

--- a/bootstrap/platform-root/templates/grafana-dashboards.yaml
+++ b/bootstrap/platform-root/templates/grafana-dashboards.yaml
@@ -31,7 +31,7 @@ spec:
               Without CUR, opencost doesn't render — so its dashboards would
               show empty panels that mislead the operator. */}}
         - name: opencostEnabled
-          value: "{{ and (ne (index .Values.components "opencost") false) (not (empty .Values.global.curBucketName)) }}"
+          value: "{{ and (ne (index .Values.components "opencost" | toString) "false") (not (empty .Values.global.curBucketName)) }}"
   destination:
     server: https://kubernetes.default.svc
     namespace: grafana

--- a/bootstrap/platform-root/templates/karpenter.yaml
+++ b/bootstrap/platform-root/templates/karpenter.yaml
@@ -27,7 +27,7 @@
   skipped — Terraform leaves the IAM/SQS resources unprovisioned
   in those modes.
 */ -}}
-{{- if and (eq .Values.global.provider "aws") (ne (index .Values.components "karpenter") false) (or (eq .Values.global.autoscaler "karpenter") (eq .Values.global.autoscaler "hybrid")) }}
+{{- if and (eq .Values.global.provider "aws") (ne (index .Values.components "karpenter" | toString) "false") (or (eq .Values.global.autoscaler "karpenter") (eq .Values.global.autoscaler "hybrid")) }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/bootstrap/platform-root/templates/opencost.yaml
+++ b/bootstrap/platform-root/templates/opencost.yaml
@@ -10,7 +10,7 @@
 
        Azure deployments don't write global.curBucketName (CUR is an AWS concept),
        so opencost is naturally skipped on Azure even when explicitly enabled. */ -}}
-{{- if and (ne (index .Values.components "opencost") false) (not (empty .Values.global.curBucketName)) }}
+{{- if and (ne (index .Values.components "opencost" | toString) "false") (not (empty .Values.global.curBucketName)) }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/bootstrap/platform-root/templates/platform-secrets.yaml
+++ b/bootstrap/platform-root/templates/platform-secrets.yaml
@@ -48,7 +48,7 @@ spec:
               exist, so skipping the ExternalSecrets here avoids permanent
               SecretSyncedError state. */}}
         - name: opencostEnabled
-          value: "{{ and (ne (index .Values.components "opencost") false) (not (empty .Values.global.curBucketName)) }}"
+          value: "{{ and (ne (index .Values.components "opencost" | toString) "false") (not (empty .Values.global.curBucketName)) }}"
         {{- /* When a GitHub App is configured, the platform module writes
               a cluster-wide repo-creds Secret that covers every repo
               under the org. The per-repo PAT ExternalSecrets in

--- a/bootstrap/platform-root/templates/vault-ingress.yaml
+++ b/bootstrap/platform-root/templates/vault-ingress.yaml
@@ -10,7 +10,7 @@
   live in `estabilis-platform-gitops`, this repo only carries the bootstrap
   Application template that references them.
 */ -}}
-{{- if and (or (eq .Values.global.provider "aws") (eq .Values.global.provider "azure")) (ne (index .Values.components "vault") false) }}
+{{- if and (or (eq .Values.global.provider "aws") (eq .Values.global.provider "azure")) (ne (index .Values.components "vault" | toString) "false") }}
 {{- /* Source of truth: terraform's `vault.exposuresJson` field on
       platform-infrastructure-sensitive Secret, surfaced into helm values
       as global.vaultExposures by the upstart parameter wiring. */ -}}
@@ -27,7 +27,7 @@
 {{- $hasEnabled := false -}}
 {{- $hasTraefikExposure := false -}}
 {{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
-{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik") false) }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik" | toString) "false") }}
 {{- if and $traefikGate $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/bootstrap/platform-root/templates/vault.yaml
+++ b/bootstrap/platform-root/templates/vault.yaml
@@ -22,7 +22,7 @@
   manually after this Application syncs, then proceeds with downstream
   / runbook procedures.
 */ -}}
-{{- if and (or (eq .Values.global.provider "aws") (eq .Values.global.provider "azure")) (ne (index .Values.components "vault") false) }}
+{{- if and (or (eq .Values.global.provider "aws") (eq .Values.global.provider "azure")) (ne (index .Values.components "vault" | toString) "false") }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:


### PR DESCRIPTION
## Summary

Completes the toString sweep started in v0.61.2/v0.61.3. Applies `| toString` to 6 remaining templates that still compared `index .Values.components` against Go bool/string without normalization:

- `opencost.yaml`
- `vault.yaml`
- `vault-ingress.yaml`
- `karpenter.yaml`
- `platform-secrets.yaml`
- `grafana-dashboards.yaml`

After this PR, zero templates use bare `(ne ... false)` or `(eq ... true)` on `index .Values.components`.

## Verification

```bash
grep -rn 'index .Values.components.*) false)\|index .Values.components.*) true)' \
  bootstrap/platform-root/templates/ | grep -v toString | grep -v '#'
# Expected: no output
```