### PR TITLE
fix(ingress): traefikGate reads global.traefikInternal bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.61.5] - 2026-05-28
+
+### Fixed — ingress `$traefikGate` reads `global.traefikInternal` bridge
+
+All 6 ingress templates (argocd, grafana, loki, mimir, hubble-ui,
+vault) now include `global.traefikInternal == "true"` in their
+`$traefikGate` OR-chain. Previously, when `components.traefik = false`
+and `components.traefik-internal` defaulted to `false`, the gate
+evaluated to false even though the Terraform bridge correctly
+injected `global.traefikInternal = true`. Result: no ingress apps
+rendered.
+
+After this fix, an ILB-only cluster (traefik disabled, traefik-internal
+enabled via bridge) correctly renders all ingress apps without any
+`overrides/platform-root/values.yaml`.
+
 ## [0.61.4] - 2026-05-28
 
 ### Fixed — complete toString in remaining templates

--- a/bootstrap/platform-root/templates/argocd-ingress.yaml
+++ b/bootstrap/platform-root/templates/argocd-ingress.yaml
@@ -21,7 +21,7 @@
 {{- /* Require components.traefik only when at least one exposure
        actually targets a Traefik-style class. ALB-only exposures are
        allowed when components.traefik is false. */}}
-{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik" | toString) "false") (eq (index .Values.components "traefik-internal" | default false | toString) "true") }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik" | toString) "false") (eq (index .Values.components "traefik-internal" | default false | toString) "true") (eq (index .Values.global "traefikInternal" | default false | toString) "true") }}
 {{- if and $traefikGate $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/bootstrap/platform-root/templates/grafana-ingress.yaml
+++ b/bootstrap/platform-root/templates/grafana-ingress.yaml
@@ -20,7 +20,7 @@
 {{- $hasEnabled := false -}}
 {{- $hasTraefikExposure := false -}}
 {{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
-{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik" | toString) "false") (eq (index .Values.components "traefik-internal" | default false | toString) "true") }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik" | toString) "false") (eq (index .Values.components "traefik-internal" | default false | toString) "true") (eq (index .Values.global "traefikInternal" | default false | toString) "true") }}
 {{- if and $traefikGate $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/bootstrap/platform-root/templates/hubble-ui-ingress.yaml
+++ b/bootstrap/platform-root/templates/hubble-ui-ingress.yaml
@@ -18,7 +18,7 @@
 {{- $hasEnabled := false -}}
 {{- $hasTraefikExposure := false -}}
 {{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
-{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik" | toString) "false") (eq (index .Values.components "traefik-internal" | default false | toString) "true") }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik" | toString) "false") (eq (index .Values.components "traefik-internal" | default false | toString) "true") (eq (index .Values.global "traefikInternal" | default false | toString) "true") }}
 {{- $dataplane := index .Values.global "networkDataplane" | default "" -}}
 {{- if and
       $traefikGate

--- a/bootstrap/platform-root/templates/loki-ingress.yaml
+++ b/bootstrap/platform-root/templates/loki-ingress.yaml
@@ -17,7 +17,7 @@
 {{- $hasEnabled := false -}}
 {{- $hasTraefikExposure := false -}}
 {{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
-{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik" | toString) "false") (eq (index .Values.components "traefik-internal" | default false | toString) "true") }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik" | toString) "false") (eq (index .Values.components "traefik-internal" | default false | toString) "true") (eq (index .Values.global "traefikInternal" | default false | toString) "true") }}
 {{- if and $traefikGate $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/bootstrap/platform-root/templates/mimir-ingress.yaml
+++ b/bootstrap/platform-root/templates/mimir-ingress.yaml
@@ -17,7 +17,7 @@
 {{- $hasEnabled := false -}}
 {{- $hasTraefikExposure := false -}}
 {{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
-{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik" | toString) "false") (eq (index .Values.components "traefik-internal" | default false | toString) "true") }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik" | toString) "false") (eq (index .Values.components "traefik-internal" | default false | toString) "true") (eq (index .Values.global "traefikInternal" | default false | toString) "true") }}
 {{- if and $traefikGate $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/bootstrap/platform-root/templates/vault-ingress.yaml
+++ b/bootstrap/platform-root/templates/vault-ingress.yaml
@@ -27,7 +27,7 @@
 {{- $hasEnabled := false -}}
 {{- $hasTraefikExposure := false -}}
 {{- range $_, $exp := $exposures }}{{- if $exp.enabled }}{{- $hasEnabled = true }}{{- if ne $exp.ingress_class "alb" }}{{- $hasTraefikExposure = true }}{{- end }}{{- end }}{{- end }}
-{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik" | toString) "false") }}
+{{- $traefikGate := or (eq $hasTraefikExposure false) (ne (index .Values.components "traefik" | toString) "false") (eq (index .Values.components "traefik-internal" | default false | toString) "true") (eq (index .Values.global "traefikInternal" | default false | toString) "true") }}
 {{- if and $traefikGate $hasEnabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application


### PR DESCRIPTION
## Summary

All 6 ingress templates (argocd/grafana/loki/mimir/hubble-ui/vault) now include `global.traefikInternal` in the `$traefikGate` OR-chain.

**Root cause**: ILB-only clusters set `components.traefik = false` (via ingressController override) and rely on `global.traefikInternal = true` (Terraform bridge) to enable the second Traefik instance. But the ingress templates' `$traefikGate` only checked `components.traefik` and `components.traefik-internal` — neither of which is true in this setup. Result: gate evaluates to false → no ingress apps rendered.

## Validation

Local `helm template` with ILB-only values now renders all 6 ingress apps.

## Test plan

- [ ] Verify ILB-only deployment after bump → ingress apps appear
- [ ] Verify dual-traefik deployment → no behavior change