### PR TITLE
feat(external-dns,cert-manager): read the Cloudflare token from the secret store

### DIFF
--- a/bootstrap/platform-root/templates/cert-manager.yaml
+++ b/bootstrap/platform-root/templates/cert-manager.yaml
@@ -132,8 +132,19 @@ spec:
           - name: identity.certManager.clientId
             value: "{{ .Values.identity.certManager.clientId }}"
           {{- else if eq $dnsProvider "cloudflare" }}
+          {{- if and (eq .Values.global.provider "aws") .Values.global.secretsPathPrefix }}
+          {{- /* AWS: pass the Secrets Manager path so cert-manager-config takes
+                its ExternalSecret branch instead of rendering the token in
+                cleartext onto this Application spec. Requires
+                estabilis-platform-gitops >= v0.42.11, where that branch reads
+                .Values.kvSecrets.cloudflareApiToken instead of a hardcoded flat
+                Key Vault name (which never resolves against AWS SM paths). */}}
+          - name: kvSecrets.cloudflareApiToken
+            value: "{{ .Values.global.secretsPathPrefix }}/platform-cloudflare-api-token"
+          {{- else }}
           - name: global.cloudflareApiToken
             value: "{{ .Values.global.cloudflareApiToken }}"
+          {{- end }}
           {{- end }}
     - repoURL: {{ .Values.platformGitopsRepoUrl }}
       targetRevision: {{ .Values.platformGitopsVersion }}

--- a/bootstrap/platform-root/templates/external-dns.yaml
+++ b/bootstrap/platform-root/templates/external-dns.yaml
@@ -37,8 +37,24 @@ spec:
           - name: identity.externalDns.clientId
             value: "{{ .Values.identity.externalDns.clientId }}"
           {{- else if eq $dnsProvider "cloudflare" }}
+          {{- if and (eq .Values.global.provider "aws") .Values.global.secretsPathPrefix }}
+          {{- /* AWS: hand the chart the Secrets Manager PATH, not the token.
+                Injecting the token as a helm parameter writes it in cleartext
+                onto this Application spec — and an Application is a CRD, so it
+                sits outside the EKS `resources: ["secrets"]` envelope
+                encryption, unlike the Secret it ends up producing.
+
+                Same prefixing convention as platform-secrets.yaml: secrets live
+                under estabilis/<deploymentId>/*, which is the IRSA scope of the
+                external-secrets role. */}}
+          - name: kvSecrets.cloudflareApiToken
+            value: "{{ .Values.global.secretsPathPrefix }}/platform-cloudflare-api-token"
+          {{- else }}
+          {{- /* Azure and any deployment without a secrets path prefix keep the
+                direct injection. */}}
           - name: global.cloudflareApiToken
             value: "{{ .Values.global.cloudflareApiToken }}"
+          {{- end }}
           {{- end }}
     - repoURL: {{ .Values.platformRepoUrl }}
       targetRevision: {{ .Values.platformVersion }}
@@ -46,6 +62,15 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: external-dns
+  ignoreDifferences:
+    {{- /* ESO writes these defaults server-side; undeclared they show up as
+          permanent OutOfSync drift. Same block as platform-secrets.yaml. */}}
+    - group: external-secrets.io
+      kind: ExternalSecret
+      jsonPointers:
+        - /spec/data/0/remoteRef/conversionStrategy
+        - /spec/data/0/remoteRef/decodingStrategy
+        - /spec/data/0/remoteRef/metadataPolicy
   syncPolicy:
     {{- include "platform-root.managedNamespaceMetadataExcluded" . | nindent 4 }}
     retry:
@@ -114,6 +139,15 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: external-dns
+  ignoreDifferences:
+    {{- /* ESO writes these defaults server-side; undeclared they show up as
+          permanent OutOfSync drift. Same block as platform-secrets.yaml. */}}
+    - group: external-secrets.io
+      kind: ExternalSecret
+      jsonPointers:
+        - /spec/data/0/remoteRef/conversionStrategy
+        - /spec/data/0/remoteRef/decodingStrategy
+        - /spec/data/0/remoteRef/metadataPolicy
   syncPolicy:
     {{- include "platform-root.managedNamespaceMetadataExcluded" . | nindent 4 }}
     retry:

--- a/core/components/external-dns-config/templates/cloudflare-config.yaml
+++ b/core/components/external-dns-config/templates/cloudflare-config.yaml
@@ -1,4 +1,17 @@
 {{- if eq .Values.global.dnsProvider "cloudflare" }}
+{{- /* `default dict` keeps the chart standalone-renderable against a values
+       file predating kvSecrets — same three-level guard style as
+       estabilis.provenanceAnnotations in _helpers.tpl. */ -}}
+{{- $kvToken := (default dict .Values.kvSecrets).cloudflareApiToken | default "" -}}
+{{- if .Values.global.cloudflareApiToken }}
+{{- /* DIRECT path — the token arrives as a helm parameter, so it is stored in
+       cleartext on the Application spec: readable in etcd (Application is a
+       CRD, NOT covered by the EKS `resources: ["secrets"]` envelope
+       encryption), in the ArgoCD UI/API, and in the repo-server cache.
+
+       Kept for backward compatibility and for bootstrap flows that run before
+       External Secrets exists. Prefer kvSecrets.cloudflareApiToken below on
+       any cluster where the platform secret store is wired. */ -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,4 +21,29 @@ metadata:
 type: Opaque
 stringData:
   api-token: {{ .Values.global.cloudflareApiToken | quote }}
+{{- else if $kvToken }}
+{{- /* SECRET-STORE path — the token never leaves the store. ESO materialises
+       the same Secret name and key, so the external-dns Deployment's
+       secretKeyRef needs no change. Mirrors the shape already used by
+       components/cert-manager-config in estabilis-platform-gitops. */ -}}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: external-dns-cloudflare-config
+  namespace: external-dns
+  {{- include "estabilis.metadata" . | nindent 2 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: platform-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: external-dns-cloudflare-config
+    creationPolicy: Owner
+  data:
+    - secretKey: api-token
+      remoteRef:
+        key: {{ $kvToken | quote }}
+        nullBytePolicy: Ignore
+{{- end }}
 {{- end }}

--- a/core/components/external-dns-config/values.yaml
+++ b/core/components/external-dns-config/values.yaml
@@ -4,7 +4,15 @@ global:
   tenantId: ""              # used when dnsProvider=azure
   subscriptionId: ""        # used when dnsProvider=azure
   resourceGroup: ""         # used when dnsProvider=azure
-  cloudflareApiToken: ""    # used when dnsProvider=cloudflare
+  cloudflareApiToken: ""    # used when dnsProvider=cloudflare — DIRECT injection (cleartext)
+
+# Preferred alternative to global.cloudflareApiToken when the platform secret
+# store is available: the name (Azure Key Vault) or full path (AWS Secrets
+# Manager) of the secret holding the token. Set, the chart emits an
+# ExternalSecret instead of a cleartext Secret. platform-root prepends the
+# AWS path prefix — see bootstrap/platform-root/templates/external-dns.yaml.
+kvSecrets:
+  cloudflareApiToken: ""
 identity:
   externalDns:
     clientId: ""            # used when dnsProvider=azure (workload identity)


### PR DESCRIPTION
## Problem

`global.cloudflareApiToken` travels as a **helm parameter**, so the token sits in cleartext on the `platform-root`, `external-dns-config` and `cert-manager-config` Application specs.

An Application is a **CRD**, so it is *outside* the EKS `resources: ["secrets"]` envelope encryption — unlike the Secret it ultimately produces. It is also readable in the ArgoCD UI/API and in the repo-server cache.

The final consumption was already a `secretKeyRef`. **Only the transport was the problem.**

## Change

`core/components/external-dns-config` gains the ExternalSecret branch that `components/cert-manager-config` already had. Same Secret name and key, so the external-dns Deployment is untouched.

`platform-root` passes the Secrets Manager **path** instead of the token on AWS deployments that have `global.secretsPathPrefix`, reusing the prefixing convention from `platform-secrets.yaml`. Also adds the standard ESO `ignoreDifferences` block so the server-side defaults don't show up as permanent drift.

## Backward compatibility

Fully gated — nothing changes for an existing deployment unless it has both `provider=aws` and a `secretsPathPrefix`:

| Scenario | Behaviour |
|---|---|
| AWS + prefix | ExternalSecret; **token absent from the entire render (0 occurrences)** |
| Azure | direct injection preserved, no `kvSecrets` emitted |
| AWS without prefix | direct injection preserved |
| Direct token set | always wins — bootstrap flows that run before ESO exists still work |

## ⚠️ Dependency

The **cert-manager-config** half needs `estabilis-platform-gitops >= v0.42.11` (companion PR), where that chart's ExternalSecret reads `kvSecrets.cloudflareApiToken` instead of the hardcoded flat Key Vault name `cloudflare-api-token` — a bare name never resolves against an AWS SM path. The external-dns half is self-contained.

## Not included

`VERSION` / `CHANGELOG` are untouched — per CONTRIBUTING the release is a separate `chore(release): vX.Y.Z` direct-push to `main`, since a squash merge would rewrite the subject and break the auto-tag regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)