### PR TITLE
docs(release): correct the release-process pointers

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,9 +7,11 @@ name: release
 #
 # Operator workflow:
 #   - Merge feature PRs normally (squash or merge, doesn't matter)
-#   - When ready to release, create a dedicated commit on main with the
-#     subject `chore(release): vX.Y.Z` (via a small PR or direct push —
-#     the workflow handles both).
+#   - When ready to release, DIRECT-PUSH a dedicated commit to main with the
+#     subject `chore(release): vX.Y.Z` and nothing after the version. The
+#     regex below is anchored at both ends, so a squash merge — which
+#     appends ` (#NNN)` to the subject — produces no tag and no release,
+#     silently. A release cannot go through a PR.
 #   - This workflow tags + releases. No manual `git tag` / `git push --tags`
 #     required.
 
@@ -48,7 +50,17 @@ jobs:
             echo "Detected release: $version"
           else
             echo "should_release=false" >> "$GITHUB_OUTPUT"
+            # Every push to main lands here, so most runs are correctly doing
+            # nothing. The one that is NOT is a release attempt whose subject
+            # missed the pattern — usually ` (#NNN)` appended by a squash
+            # merge. Both look identical unless this says what was expected.
             echo "Not a release commit — skipping."
+            echo "A release commit's subject must be exactly: chore(release): vX.Y.Z"
+            case "$subject" in
+              "chore(release): "*)
+                echo "::warning::Subject starts like a release commit but does not match, so nothing was tagged. A squash merge appends ' (#NNN)' to the subject — direct-push the release commit instead."
+                ;;
+            esac
           fi
 
       - name: Guard against tag drift (idempotent)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,9 +100,9 @@ coexist permanently.
    written directly under the version they ship in).
 3. Commit with subject `chore(release): vX.Y.Z` and **direct-push** to
    `main`. Do NOT route through a PR — squash merge rewrites the subject
-   to `chore(release): vX.Y.Z (#NNN)`, which breaks the auto-tag
-   workflow's prefix regex.
-4. The `.github/workflows/auto-tag.yml` workflow tags the commit and
+   to `chore(release): vX.Y.Z (#NNN)`, and the release workflow's regex
+   is anchored at both ends, so the tag is silently not created.
+4. The `.github/workflows/release.yaml` workflow tags the commit and
    publishes the GitHub Release page automatically.
 5. Propagate to downstream template + clients per the version-propagation
    checklist in the consumer repo's `CLAUDE.md`.


### PR DESCRIPTION
Closes #214.

Both fixes are in the paragraph that decides whether a release tags.

### 1. `CONTRIBUTING.md` step 4 named a workflow that has never existed

`.github/workflows/auto-tag.yml` → `.github/workflows/release.yaml`. Nothing by the former name appears anywhere in the history; the workflow was added as `release.yaml` in `92414f7` on 2026-04-23.

### 2. `release.yaml`'s header said a PR works

It said the release commit could arrive "via a small PR or direct push — the workflow handles both". It cannot. The regex is anchored at both ends:

```bash
if [[ "$subject" =~ ^chore\(release\):\ v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
```

A squash merge rewrites the subject to `chore(release): vX.Y.Z (#NNN)`, `$` never matches, and nothing is tagged. `CONTRIBUTING.md` step 3 already said this correctly — the two documents contradicted each other, and the workflow's own comment was the more dangerous one, since it is what you read when you go to the implementation to check the rule.

### 3. The workflow now says when it declines

Every push to `main` reaches the detect step, so most runs are correctly doing nothing. A release attempt whose subject missed the pattern produced *identical* output. It now prints the expected subject, and raises a `::warning::` annotation when the subject starts like a release commit but does not match — which is exactly the squash-merge case.

Exercised offline against three subjects:

| subject | result |
|---|---|
| `chore(release): v0.69.0` | `Detected release: v0.69.0` |
| `chore(release): v0.69.0 (#215)` | no release, **warning annotation** naming the cause |
| `feat(aws): something else` | no release, quiet |

Docs and CI comments only — no Terraform, no `VERSION` bump, no `CHANGELOG` entry.

### One thing left out, deliberately

`CONTRIBUTING.md` steps 2–3 read as though `VERSION` and the `CHANGELOG` entry land *in* the `chore(release):` commit. That was true through `v0.62.0`; since `v0.64.0` every release commit has been **empty**, with the bump carried by the feature PR instead — `v0.68.0` included. That is a third drift in the same section, but fixing it means declaring which practice is canonical, which is a maintainer's call and not a typo. Left for you to decide; happy to follow up.